### PR TITLE
Self-serve org creation, multi-tenant routing, status-rule parity

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,115 @@
+# CI test suite — Go unit tests + full API/E2E integration suite.
+#
+# Security model (public repo, fork PRs welcome):
+#   - `pull_request` trigger only — NEVER `pull_request_target`. Fork PRs run
+#     in an isolated ephemeral VM with a read-only GITHUB_TOKEN and no access
+#     to repository secrets.
+#   - This workflow uses no secrets at all; there is nothing to exfiltrate.
+#   - `permissions: contents: read` pins the token to read-only even on push.
+#   - Repo setting "Require approval for all outside collaborators"
+#     (Settings → Actions → General) gates fork-PR runs behind a maintainer
+#     click as defense-in-depth.
+
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: CGO_ENABLED=0 go build ./...
+      - name: Unit tests
+        run: CGO_ENABLED=0 go test ./internal/... -count=1 -timeout 120s
+
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: isms
+          POSTGRES_PASSWORD: isms
+          POSTGRES_DB: isms_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U isms"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://isms:isms@localhost:5432/isms_test?sslmode=disable
+      ISMS_SECRET: ci-secret-must-be-at-least-32-characters-long-tests-only
+      ISMS_STORAGE_BACKEND: file
+      ISMS_DATA_DIR: /tmp/isms-ci-data
+      ISMS_TEMPLATE_PATH: ${{ github.workspace }}/isms-templates
+      ISMS_USER_SIGNUP: "1"
+      ISMS_SKIP_EMAIL_VERIFY: "1"
+      ISMS_RATE_LIMIT: "0"
+      ISMS_DOMAIN: localhost
+      ISMS_SUBDOMAIN_ROUTING: "1"
+      ISMS_DEV_MODE: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      # Templates are a separate repo — the suite scaffolds orgs from them.
+      - name: Checkout templates
+        uses: actions/checkout@v4
+        with:
+          repository: unidoc/isms-templates
+          path: isms-templates
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend
+        run: |
+          cd web && npm ci && npm run build
+          cd .. && mkdir -p cmd/isms/web/dist && cp -r web/dist/* cmd/isms/web/dist/
+
+      - name: Install test dependencies
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install --quiet pytest requests playwright
+          .venv/bin/playwright install --with-deps chromium
+
+      - name: Start server
+        run: |
+          go run ./cmd/isms server migrate
+          nohup go run ./cmd/isms server serve --addr :9090 > server.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:9090/healthz && break
+            sleep 2
+          done
+          curl -sf http://localhost:9090/healthz || { cat server.log; exit 1; }
+
+      - name: Run test suite
+        run: ISMS_TEST_URL=http://localhost:9090 .venv/bin/pytest tests/ --tb=short
+
+      - name: Server log on failure
+        if: failure()
+        run: cat server.log

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Placeholder web dist
+        # cmd/isms embeds web/dist (go:embed fails on an empty pattern); the
+        # unit job doesn't exercise the SPA, so a placeholder satisfies it
+        # without paying for a frontend build here.
+        run: mkdir -p cmd/isms/web/dist && touch cmd/isms/web/dist/index.html
       - name: Build
         run: CGO_ENABLED=0 go build ./...
       - name: Unit tests

--- a/devenv/.env
+++ b/devenv/.env
@@ -1,3 +1,4 @@
 ISMS_SRC_ROOT=/home/ahall/Projects
 CLAUDE_HOME=/home/ahall/.claude
 CLAUDE_JSON=/home/ahall/.claude.json
+COMPOSE_CMD="podman compose"

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -6,9 +6,8 @@
 FROM debian:trixie-slim
 
 # ── Build args ───────────────────────────────────────────────────────────────
-ARG CRONTAB_URL_DEPS
-ARG GO_DL=go1.25.3.linux-amd64.tar.gz
-ARG USER_NAME=tower
+ARG GO_VERSION=1.25.3
+ARG USER_NAME=isms
 ARG USER_UID=1000
 ARG USER_GID=1000
 
@@ -17,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LOCAL_INSTALL=/usr/local
 ENV GOROOT=${LOCAL_INSTALL}/go
 ENV GOPATH=/home/${USER_NAME}/.gopath
-ENV PATH=${GOROOT}/bin:${GOPATH}/bin:${PATH}
+ENV PATH=${GOROOT}/bin:${GOPATH}/bin:/home/${USER_NAME}/.local/bin:${PATH}
 ENV COLORTERM=truecolor
 ENV TERM=xterm-256color
 ENV LANG=C.UTF-8
@@ -62,19 +61,27 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
 RUN npm i -g @openai/codex
 RUN npm i -g @google/gemini-cli
 RUN npm i -g @playwright/test
-RUN npx playwright install --with-deps chromium
+# Fixed, world-readable browser path. This RUN executes as root, so the
+# default ($HOME/.cache/ms-playwright) would land in /root — invisible to
+# the isms user and to the Python playwright in the test venv. The ENV makes
+# every playwright (npm and pip, any user) resolve the same location.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN npx playwright install --with-deps chromium \
+    && chmod -R a+rX ${PLAYWRIGHT_BROWSERS_PATH}
 
 # ── Go ───────────────────────────────────────────────────────────────────────
-RUN mkdir -p ${LOCAL_INSTALL} && cd ${LOCAL_INSTALL} \
-    && wget -q ${CRONTAB_URL_DEPS}/${GO_DL} \
-    && tar -zxf ${GO_DL} \
-    && rm -f ${GO_DL}
+RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
+    | tar -C ${LOCAL_INSTALL} -xz
 
-# ── Create non-root user (tower:tower 1000:1000) ────────────────────────
+# Debian's /etc/profile hard-resets PATH in login shells (bash -l), dropping
+# the ENV PATH above. profile.d is sourced after that reset, so this wins —
+# keeps `go` resolvable in compose commands, Justfile recipes, and attach.
+RUN printf 'export PATH=%s/bin:%s/bin:$HOME/.local/bin:$PATH\n' "${GOROOT}" "${GOPATH}" \
+    > /etc/profile.d/golang.sh
+
+# ── Create non-root user (isms:isms 1000:1000) ───────────────────────────────
 RUN groupadd -g ${USER_GID} ${USER_NAME} \
     && useradd -m -u ${USER_UID} -g ${USER_GID} -s /bin/bash ${USER_NAME}
-
-ENV PATH=/home/tower/.local/bin:${PATH}
 
 # ── Project directory ────────────────────────────────────────────────────────
 RUN mkdir -p ${WORKSPACE_HOME} \
@@ -85,11 +92,10 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # ── Claude Code ──────────────────────────────────────────────────────────────
-USER tower 
+USER ${USER_NAME}
 RUN curl -fsSL https://claude.ai/install.sh | bash
 USER root
 
 WORKDIR ${WORKSPACE_HOME}
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]
-

--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -1,108 +1,152 @@
 # =============================================================================
-# Tower Dev Environment
+# ISMS Dev Environment
 # =============================================================================
-# just build       → Build the container
-# just up          → Start in background
-# just attach      → Attach to shell
-# just claude      → Start Claude Code
-# just down        → Stop
+# Dev server (manual, persistent):  port 9090, container isms-dev
+# Test server (auto, ephemeral):    port 9091, container isms-test
+#
+# just build         → Build the shared image
+# just up            → Start dev + test stacks
+# just attach        → Shell into dev container
+# just claude        → Start Claude Code in dev container
+# just test          → Run pytest against the test server
+# just test-restart  → Reload test server with current code (keeps DB)
+# just test-reset    → Wipe test DB + data and rebuild test server
+# just down          → Stop everything
+#
+# Container engine defaults to `docker compose`. Override with COMPOSE_CMD
+# in devenv/.env, e.g.  COMPOSE_CMD=podman compose  or  podman-compose.
 # =============================================================================
 
 set dotenv-load
 
-container := "isms-dev"
+compose := env_var_or_default('COMPOSE_CMD', 'docker compose')
 
 # ── Lifecycle ────────────────────────────────────────────────────────────────
 
-# Build Docker image
-build:
-    docker compose build
+# Ensure optional bind-mount sources exist (compose errors if they don't).
+# isms-demo is private prospect content — contributors without it get an
+# empty dir so the mount resolves and the container can still boot.
+_ensure-paths:
+    @mkdir -p "$ISMS_SRC_ROOT/isms-demo"
+
+# Build the shared image
+build: _ensure-paths
+    {{compose}} build
 
 # Build without cache (full rebuild)
-rebuild:
-    docker compose build --no-cache
+rebuild: _ensure-paths
+    {{compose}} build --no-cache
 
-# Start container in background
-up:
-    PODMAN_USERNS=keep-id PUID=$(id -u) PGID=$(id -g) docker compose up -d
+# Start dev + test stacks in background
+up: _ensure-paths
+    PODMAN_USERNS=keep-id PUID=$(id -u) PGID=$(id -g) {{compose}} up -d
 
 # Build and start
 boot: build up
-    @echo "✓ isms-dev running — just attach to connect"
+    @echo "✓ isms-dev (manual) on :9090 — just attach to connect"
+    @echo "✓ isms-test (auto)   on :9091 — just test to run pytest"
 
-# Stop container
+# Stop everything
 down:
-    docker compose down
+    {{compose}} down
 
-# Stop and remove volumes (clean slate)
+# Stop and remove all volumes (clean slate, including dev DB)
 nuke:
-    docker compose down -v
-    @echo "✓ Volumes removed — next boot will rebuild venv and caches"
+    {{compose}} down -v
+    @echo "✓ All volumes removed — next boot rebuilds from scratch"
 
-# Restart
+# Restart everything
 restart:
-    docker compose restart
+    {{compose}} restart
 
 # ── Connect ──────────────────────────────────────────────────────────────────
 
-# Attach to shell in container (primary workflow)
+# Attach to the dev container as user `isms` (primary workflow)
 attach:
-    docker compose exec -u tower isms bash
+    {{compose}} exec -u isms isms bash
 
 attach-root:
-    docker compose exec isms bash
+    {{compose}} exec isms bash
 
 # ── Run commands ─────────────────────────────────────────────────────────────
 
-# Flask dev server (streamed output)
-flask:
-    docker compose exec isms bash -lc "rundev"
+# Dev server (foreground, streamed output)
+serve:
+    {{compose}} exec -u isms isms bash -lc "cd /home/isms/workspace/isms && go run ./cmd/isms server serve --addr :9090"
 
 # Start Claude Code
 claude:
-    docker compose exec -u tower isms bash -lc "claude"
+    {{compose}} exec -u isms isms bash -lc "claude"
 
 # Continue last Claude session
 claude-continue:
-    docker compose exec -u tower isms bash -lc "claude --continue"
+    {{compose}} exec -u isms isms bash -lc "claude --continue"
 
 # Pick a Claude session to resume
 claude-resume:
-    docker compose exec -u tower isms bash -lc "claude --resume"
+    {{compose}} exec -u isms isms bash -lc "claude --resume"
 
-# Run an arbitrary command in the container
+# Run an arbitrary command in the dev container
 run +CMD:
-    docker compose exec isms bash -lc "{{ CMD }}"
+    {{compose}} exec isms bash -lc "{{ CMD }}"
+
+# ── Test environment ─────────────────────────────────────────────────────────
+
+# Run pytest from inside the dev container against the test server
+test +ARGS="tests/":
+    {{compose}} exec -u isms isms bash -lc \
+        "cd /home/isms/workspace/isms && ISMS_TEST_URL=http://isms-test:9090 .venv/bin/pytest {{ ARGS }}"
+
+# Run the Playwright e2e suite against the test server
+test-e2e +ARGS="tests/test_e2e_browser.py tests/test_e2e_routing.py":
+    {{compose}} exec -u isms isms bash -lc \
+        "cd /home/isms/workspace/isms && ISMS_TEST_URL=http://isms-test:9090 .venv/bin/pytest {{ ARGS }} -v"
+
+# Restart the test server only — reloads current code, keeps the test DB.
+# Incremental `go run` rebuild, so this is the fast path after code changes.
+test-restart:
+    {{compose}} restart isms-test
+    @echo "✓ Test server restarting with current code on :9091 (~2s)"
+
+# Reset the test stack — wipe DB + data dir, restart the server fresh
+test-reset:
+    {{compose}} rm -fsv isms-test postgres-test
+    PODMAN_USERNS=keep-id PUID=$(id -u) PGID=$(id -g) {{compose}} up -d isms-test postgres-test
+    @echo "✓ Test stack reset; server starting on :9091 (give it ~10s to boot)"
+
+# Tail test server logs (useful while debugging boot failures)
+test-logs:
+    {{compose}} logs -f isms-test
 
 # ── Git ──────────────────────────────────────────────────────────────────────
 
-# Git status
+# Git status inside the dev container
 gs:
-    docker compose exec isms bash -lc "git status"
+    {{compose}} exec isms bash -lc "git status"
 
-# Git log
+# Git log inside the dev container
 gl:
-    docker compose exec isms bash -lc "git log --oneline -20"
+    {{compose}} exec isms bash -lc "git log --oneline -20"
 
 # ── Go ───────────────────────────────────────────────────────────────────────
 
-# Go build
+# Go build of the ISMS binary
 go-build:
-    docker compose exec isms bash -lc "cd /home/tower/workspace/isms-web && go build ./..."
+    {{compose}} exec isms bash -lc "cd /home/isms/workspace/isms && go build ./..."
 
-# Go test
+# Go test (unit tests in internal/)
 go-test:
-    docker compose exec isms bash -lc "cd /home/tower/workspace/isms-web && go test ./..."
+    {{compose}} exec isms bash -lc "cd /home/isms/workspace/isms && go test ./internal/..."
 
 # ── Info ─────────────────────────────────────────────────────────────────────
 
 # Show container status
 status:
-    @docker compose ps
+    @{{compose}} ps
 
-# Logs
+# Tail dev server logs
 logs:
-    docker compose logs -f isms
+    {{compose}} logs -f isms
 
 # Show all available commands
 help:

--- a/devenv/README.md
+++ b/devenv/README.md
@@ -1,0 +1,91 @@
+# ISMS Dev Environment
+
+Four containers, two stacks, one shared image (`isms-dev:latest`):
+
+| Container | Role | Port (host) | Data |
+|---|---|---|---|
+| `isms-dev` | Utility/work container — Claude, shells, pytest run here. **Runs no server by itself.** | 9090 (when you `just serve`) | persistent (`isms-pgdata`, `isms-data`) |
+| `isms-postgres` | Dev database | — (compose network only) | persistent volume |
+| `isms-test` | Test server — auto-starts, always-on pytest target | 9091 | ephemeral |
+| `isms-postgres-test` | Test database | — (compose network only) | tmpfs, wiped on reset |
+
+Go build/module caches live on named volumes (`go-build-cache`, `go-mod-cache`)
+shared by both ISMS containers — server restarts recompile incrementally (~2s),
+and `just test-reset` does not throw the cache away.
+
+## Daily workflow
+
+```bash
+just up          # start everything (idempotent)
+just claude      # Claude Code in the work container
+just test        # run the pytest suite against the test server (:9091)
+```
+
+**The key mental model: code changes never require touching `isms-dev`.**
+The repo is bind-mounted, so every container always sees the current source.
+What needs a nudge is any *running server process*, because Go servers run
+compiled code from the moment they started:
+
+| You changed… | Do this | Cost |
+|---|---|---|
+| Test assertions / pytest code | nothing — just `just test` | 0s |
+| Go code, want tests to see it | `just test-restart` | ~2s (incremental rebuild, test DB kept) |
+| Go code, dev server on :9090 | Ctrl-C the `just serve` terminal, run it again | ~2s |
+| Test state is corrupted / weird failures | `just test-reset` | ~10s (DB + data wiped, server fresh) |
+| Dockerfile / entrypoint.sh | `just build && just up` | minutes (image rebuild) |
+| compose.yml | `just up` — and if `isms-test` was recreated, follow with `just test-reset` (see Troubleshooting: repo/DB desync) | seconds (recreates affected containers) |
+
+## Claude and container restarts
+
+Claude Code runs as an exec session *inside* `isms-dev`. Nothing in the
+code-change workflow above touches that container, so Claude survives:
+server restarts, test resets, test runs — all of it.
+
+The only things that recreate `isms-dev` (and therefore end the session):
+
+- `just up` after a change to `isms-dev`'s own compose config
+- `just build && just up` after an image change
+- `just down` / `just restart`
+
+Recovery is one command — the session is on disk, not in the container:
+
+```bash
+just claude-continue    # resume the most recent session
+just claude-resume      # pick an older session
+```
+
+Tip: when Claude edits devenv files (compose.yml, Dockerfile), expect the
+next `just up`/`just build` to end the session — ask Claude to summarize
+state first, or just continue and let it pick up from the transcript.
+
+## Running tests
+
+```bash
+just test                      # whole suite
+just test tests/test_risks.py # one file
+just test tests/ -k review    # filter by keyword
+just test tests/ -x -v        # stop at first failure, verbose
+just test-e2e                  # Playwright browser + routing suites
+just test-logs                 # tail the test server (boot problems live here)
+```
+
+- Tests only run when invoked — nothing runs them automatically.
+- The suite is idempotent against accumulated state (fixed `test-org`),
+  but state does accumulate; `just test-reset` gives a clean slate.
+- Don't run two suites against the same test server at once — they share
+  `test-org` and will trample each other. Sequential runs are fine.
+- E2E routing tests reach the test server at `acme-logistics.localhost`
+  via a compose network alias on `isms-test` (subdomain routing is resolved
+  from the Host header).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Mass failures: `opening bare repo … repository does not exist` | test DB and test data dir out of sync — `just up` recreated `isms-test` (wiping `/tmp/isms-test-data`) but not `postgres-test`, so the DB claims orgs whose git repos are gone | `just test-reset` — recreates both halves together |
+| `connection refused` on :9091 right after `up`/reset | server still compiling/booting | wait ~10s; `just test-logs` |
+| Server boots very slowly | cold Go cache (first boot after `nuke` or volume removal) | one-time cost; subsequent boots are fast |
+| `go: command not found` in container | login-shell PATH (Debian resets it) | rebuilt image has `/etc/profile.d/golang.sh`; rebuild if missing |
+| `.venv/bin/pytest: required file not found` | venv created in an older image (stale interpreter path) | `cd ~/workspace/isms && rm -rf .venv && python3 -m venv .venv && .venv/bin/pip install pytest requests playwright && .venv/bin/playwright install chromium` |
+| Playwright `Executable doesn't exist` | browsers missing for the Python playwright | `.venv/bin/playwright install chromium` (image sets `PLAYWRIGHT_BROWSERS_PATH` after next rebuild) |
+| Orphan-container warnings from other projects | shared compose project namespace | fixed via `name: isms-devenv`; never use `--remove-orphans` here |

--- a/devenv/compose.yml
+++ b/devenv/compose.yml
@@ -1,50 +1,81 @@
+# Two stacks sharing one image, isolated on a private compose network:
+#   isms-dev  + postgres        — manual dev server (port 9090), persistent data
+#   isms-test + postgres-test   — isolated test server (port 9091), ephemeral DB
+#
+# Postgres is reachable ONLY on the compose network (no host port published) —
+# host-side Postgres instances on :5432 are untouched. ISMS server ports are
+# bound to 127.0.0.1 only, not 0.0.0.0, so they aren't exposed to the LAN.
+#
+# The test server auto-starts on container boot. Reset its state any time with
+#   just test-reset
+# without touching the dev DB.
+
+# Explicit project name — the default is the directory name ("devenv"), which
+# collides with other projects that also keep their compose file in a devenv/
+# dir. Without this, their containers show up as "orphans" of this project and
+# a stray --remove-orphans would delete them.
+name: isms-devenv
+
+x-isms-base: &isms-base
+  build:
+    context: .
+  image: isms-dev:latest
+  userns_mode: "keep-id"
+  stdin_open: true
+  tty: true
+  networks: [isms-net]
+
 services:
+  # ── Dev stack ──────────────────────────────────────────────────────────────
   isms:
-    userns_mode: "keep-id"
-    build:
-      context: .
-      args:
-        CRONTAB_URL_DEPS: ${CRONTAB_URL_DEPS:-https://go.dev/dl}
-        GO_DL: ${GO_DL:-go1.25.3.linux-amd64.tar.gz}
+    <<: *isms-base
     container_name: isms-dev
     hostname: isms-dev
-    stdin_open: true
-    tty: true
+    depends_on: [postgres]
+    ports:
+      - "127.0.0.1:9090:9090"
     volumes:
-      # Project source (edit on host, run in container)
-      - ${ISMS_SRC_ROOT}/isms:/home/tower/workspace/isms
-      - ${ISMS_SRC_ROOT}/isms-templates:/home/tower/workspace/isms-templates
-      # Optional: only mounted if the demo content repo is cloned alongside.
-      # Contributors who don't work on demo content can skip it; required:false
-      # tells Compose not to fail when the source path is missing.
-      - type: bind
-        source: ${ISMS_SRC_ROOT}/isms-demo
-        target: /home/tower/workspace/isms-demo
-        bind:
-          create_host_path: false
-        required: false
-      # Persistent data (survives container rebuilds)
-      - isms-data:/home/tower/workspace/isms-data
-      # Claude/AI config (optional, ignored if missing)
-      - ${HOME}/Projects/unidoc-isms-localhost:/home/tower/workspace/unidoc-isms-localhost
-      - ${HOME}/Projects/unidoc-isms-production:/home/tower/workspace/unidoc-isms-production
-      - ${HOME}/.claude:/home/tower/.claude
-      - ${HOME}/.claude.json:/home/tower/.claude.json
+      - ${ISMS_SRC_ROOT}/isms:/home/isms/workspace/isms
+      - ${ISMS_SRC_ROOT}/isms-templates:/home/isms/workspace/isms-templates
+      # isms-demo is private prospect content. Contributors without it cloned
+      # get an empty directory (created by `just up`/`just build`) so the mount
+      # resolves and the container can still boot.
+      - ${ISMS_SRC_ROOT}/isms-demo:/home/isms/workspace/isms-demo
+      - isms-data:/home/isms/workspace/isms-data
+      - ${HOME}/Projects/unidoc-isms-localhost:/home/isms/workspace/unidoc-isms-localhost
+      - ${HOME}/Projects/unidoc-isms-production:/home/isms/workspace/unidoc-isms-production
+      - ${HOME}/.claude:/home/isms/.claude
+      - ${HOME}/.claude.json:/home/isms/.claude.json
+      # Shared Go caches (with isms-test) — survive container removal so
+      # rebuilds stay incremental.
+      - go-build-cache:/home/isms/.cache/go-build
+      - go-mod-cache:/home/isms/.gopath/pkg/mod
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - DATABASE_URL=postgres://isms:isms@postgres:5432/isms?sslmode=disable
       - ISMS_SECRET=${ISMS_SECRET:-dev-secret-must-be-at-least-32-characters-long-change-me}
       - ISMS_STORAGE_BACKEND=file
-      - ISMS_DATA_DIR=/home/tower/workspace/isms-data
-      - ISMS_TEMPLATE_PATH=/home/tower/workspace/isms-templates
+      - ISMS_DATA_DIR=/home/isms/workspace/isms-data
+      - ISMS_TEMPLATE_PATH=/home/isms/workspace/isms-templates
       - ISMS_USER_SIGNUP=1
       - ISMS_SKIP_EMAIL_VERIFY=1
       - ISMS_RATE_LIMIT=0
+      - ISMS_DOMAIN=localhost
+      - ISMS_SUBDOMAIN_ROUTING=1
+      # Dev opt-in: without it the server refuses to start when no
+      # ISMS_BASE_URL/ISMS_CORS_ORIGIN is set (production CORS guard).
+      - ISMS_DEV_MODE=1
+    # NOTE: no extra_hosts for acme-logistics.localhost here — /etc/hosts wins
+    # over DNS, and the e2e routing tests need the name to resolve to the
+    # isms-test container (network alias above), not to 127.0.0.1.
     restart: unless-stopped
 
   postgres:
     image: postgres:17
     container_name: isms-postgres
+    networks: [isms-net]
+    # No `ports:` on purpose — postgres is reachable only on the isms-net
+    # bridge as `postgres:5432`. Keeps host's own :5432 untouched.
     environment:
       POSTGRES_USER: isms
       POSTGRES_PASSWORD: isms
@@ -53,6 +84,77 @@ services:
       - isms-pgdata:/var/lib/postgresql/data
     restart: unless-stopped
 
+  # ── Test stack — isolated, ephemeral ───────────────────────────────────────
+  # Auto-starts the ISMS server on boot so the test suite always has a target.
+  # State is wiped on container removal (`just test-reset`) — no manual DB
+  # flushing required.
+  isms-test:
+    <<: *isms-base
+    container_name: isms-test
+    hostname: isms-test
+    # Network alias so the e2e routing tests (running in isms-dev) can reach
+    # this server at the tenant subdomain host — the server routes the org
+    # from the Host header (ISMS_SUBDOMAIN_ROUTING).
+    networks:
+      isms-net:
+        aliases: [acme-logistics.localhost]
+    depends_on: [postgres-test]
+    ports:
+      - "127.0.0.1:9091:9090"
+    volumes:
+      - ${ISMS_SRC_ROOT}/isms:/home/isms/workspace/isms
+      - ${ISMS_SRC_ROOT}/isms-templates:/home/isms/workspace/isms-templates
+      # Shared Go caches (with isms-dev) — `just test-reset` removes this
+      # container; without these volumes every reset is a cold recompile.
+      - go-build-cache:/home/isms/.cache/go-build
+      - go-mod-cache:/home/isms/.gopath/pkg/mod
+    environment:
+      - DATABASE_URL=postgres://isms:isms@postgres-test:5432/isms_test?sslmode=disable
+      - ISMS_SECRET=test-secret-must-be-at-least-32-characters-long-tests-only
+      - ISMS_STORAGE_BACKEND=file
+      - ISMS_DATA_DIR=/tmp/isms-test-data
+      - ISMS_TEMPLATE_PATH=/home/isms/workspace/isms-templates
+      - ISMS_USER_SIGNUP=1
+      - ISMS_SKIP_EMAIL_VERIFY=1
+      - ISMS_RATE_LIMIT=0
+      - ISMS_DOMAIN=localhost
+      - ISMS_SUBDOMAIN_ROUTING=1
+      # Dev opt-in: without it the server refuses to start when no
+      # ISMS_BASE_URL/ISMS_CORS_ORIGIN is set (production CORS guard).
+      - ISMS_DEV_MODE=1
+    extra_hosts:
+      - "acme-logistics.localhost:127.0.0.1"
+    # Run migrations then serve. `go run` rebuilds from the mounted source
+    # on each container start, so a fresh `just test-reset` always reflects
+    # the current code.
+    command:
+      - bash
+      - -lc
+      - |
+        cd /home/isms/workspace/isms && \
+        go run ./cmd/isms server migrate && \
+        exec go run ./cmd/isms server serve --addr :9090
+    restart: unless-stopped
+
+  postgres-test:
+    image: postgres:17
+    container_name: isms-postgres-test
+    networks: [isms-net]
+    # No `ports:` — same isolation as the dev postgres.
+    environment:
+      POSTGRES_USER: isms
+      POSTGRES_PASSWORD: isms
+      POSTGRES_DB: isms_test
+    tmpfs:
+      - /var/lib/postgresql/data
+    restart: unless-stopped
+
+networks:
+  isms-net:
+    driver: bridge
+
 volumes:
   isms-pgdata:
   isms-data:
+  go-build-cache:
+  go-mod-cache:

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -4,8 +4,15 @@ set -e
 PUID="${PUID:-1000}"
 PGID="${PGID:-1000}"
 
-# Map container user to host UID/GID
-sed -i "s/^tower\:x\:1000\:1000/tower\:x\:$PUID\:$PGID/" /etc/passwd
-sed -i "s/^tower\:x\:1000/tower\:x\:$PGID/" /etc/group
+# Map container user to host UID/GID so bind-mounted files keep their owner.
+sed -i "s/^isms\:x\:1000\:1000/isms\:x\:$PUID\:$PGID/" /etc/passwd
+sed -i "s/^isms\:x\:1000/isms\:x\:$PGID/" /etc/group
 
-exec gosu tower "$@"
+# Named volumes (Go caches) are created root-owned on first use — hand the
+# mountpoints to isms so `go run` can write to them. Not -R: contents written
+# by isms already have the right owner, and -R on a warm cache is slow.
+for d in /home/isms/.cache/go-build /home/isms/.gopath/pkg/mod; do
+    [ -d "$d" ] && chown isms:isms "$d"
+done
+
+exec gosu isms "$@"

--- a/docs/multi-tenant-routing.md
+++ b/docs/multi-tenant-routing.md
@@ -99,8 +99,10 @@ header binds it); on path/apex the user first enters their org slug.
 
 ### Verification — `/verify-email?token=...`
 
-Sets password from the email link, returns a JWT, and redirects to
-`/organizations` (picker) so a brand-new user can create their first org.
+Sets password from the email link and returns a JWT. If the user has no org
+yet, redirects to `/organizations` (picker) to create their first org; users
+joining via an invite already belong to an org — the response carries their
+`organization_slug` and they land on `/overview` directly.
 
 ## Server-served paths and the global anchor interceptor
 

--- a/docs/multi-tenant-routing.md
+++ b/docs/multi-tenant-routing.md
@@ -1,0 +1,145 @@
+# Multi-tenant routing
+
+ISMS serves multiple organizations from a single deployment. Each request is
+mapped to exactly one org context (or none — the "landing" / apex context).
+This document describes the rules the platform enforces end-to-end.
+
+## Two routing modes
+
+A deployment can serve orgs in either or both of two modes:
+
+### Subdomain mode — `<slug>.<apex>`
+
+Each tenant gets its own host: `acme.isms.sh`, `unidoc.isms.sh`,
+`acme-logistics.localhost`. **The subdomain IS the org boundary.** Users on
+a tenant subdomain are bound to that one org:
+
+- The `/organizations` picker is unreachable (router guard redirects to
+  `/overview` or `/login`).
+- The header org-switcher does not show "Switch to other orgs" or
+  "Switch organization".
+- `api.getMyOrgs()` is not called — the SPA never loads the user's other
+  memberships. Even if a future code path tried to render them, there's
+  nothing to render.
+- Stale-token refresh re-auths into THIS subdomain's org, never into the
+  picker (would otherwise leak other org memberships into the tenant UI).
+
+Enabled with `ISMS_SUBDOMAIN_ROUTING=1` plus `ISMS_DOMAIN=<apex>`.
+
+### Path mode — `<apex>/<slug>/...`
+
+Org is part of the URL path: `isms.sh/acme/risks`,
+`commandvector.net/verkis/documents`. **The path tells you which org is
+active, but the user can switch.**
+
+- The `/organizations` picker is reachable.
+- The header org-switcher shows other org memberships.
+- The `:org` path param is the single source of truth for the active org —
+  no `localStorage` fallback, no JWT-only context.
+- If the user lands on `/acme/...` with a JWT scoped to `unidoc`, the SPA
+  calls `auth/switch-org` to swap the token before loading any org data.
+
+Path mode works on every host — apex (`isms.sh`), localhost, container
+hosts. It is the only mode on deployments without wildcard DNS / TLS.
+
+## Resolution order (server)
+
+`OrgResolverMiddleware` runs BEFORE auth and sets the org context on the
+request:
+
+1. **Skip** `/git/...` — git wire protocol resolves by UUID in the handler.
+2. **Subdomain** — `hostname` ends with `.<apex>` and `ISMS_SUBDOMAIN_ROUTING=1`
+   → look up the slug as the first label.
+3. **Custom domain** — `hostname` matches an `organizations.domain` column.
+4. **Path-based** — for non-API, non-static paths only: the first path
+   segment is treated as the slug, the path is rewritten (`/acme/dashboard`
+   becomes `/dashboard` with `org_id` set on context).
+5. **No match** — apex context, `landing: true` flag set.
+
+API requests (`/api/v1/...`) bypass path-based resolution. API consumers
+must either be on a subdomain Host header or attach a JWT scoped to an org.
+
+## UI rules (frontend)
+
+The SPA mirrors the server-side model. See `web/src/composables/useCurrentOrg.js`
+for the canonical helpers.
+
+| Concern | Subdomain mode | Path mode |
+|---|---|---|
+| `route.params.org` | not used | source of truth |
+| `orgFromSubdomain()` | returns the slug | returns `''` |
+| `/organizations` reachable | NO (router guard) | YES |
+| Header switcher dropdown | current org + settings only | full switcher |
+| `api.getMyOrgs()` called | NO | YES |
+| `orgEntryURL(slug)` returns | `https://<slug>.<apex>/...` | `/<slug>/...` |
+
+The router guard in `web/src/router.js` intercepts navigation to
+`/organizations` on a subdomain unconditionally — defense in depth in case
+some future code path tries to push there.
+
+## Authentication
+
+### Signup — `/signup`
+
+Local password account only. **Never OIDC.**
+
+The first owner of an org must be a local password account so that if Entra
+ID / Google access is later removed, contracts end, MFA devices are lost, or
+the IT admin revokes the user, there is still a break-glass account that
+can sign in and recover. OIDC is configured AFTER the org exists, by the
+local owner.
+
+The signup form is never combined with the login form. They are separate
+pages — never tabs, never toggles, never a shared form.
+
+### Login — `/login`
+
+Password, OIDC, passkey, OTP. On a subdomain the org is implicit (Host
+header binds it); on path/apex the user first enters their org slug.
+
+### Verification — `/verify-email?token=...`
+
+Sets password from the email link, returns a JWT, and redirects to
+`/organizations` (picker) so a brand-new user can create their first org.
+
+## Server-served paths and the global anchor interceptor
+
+`App.vue` installs a `document.addEventListener('click', ...)` that
+intercepts internal anchor clicks and routes them through Vue Router with
+the correct org prefix. This makes markdown-rendered links like
+`/documents/foo` or `/risks/RISK-1` work as SPA navigations regardless of
+which view rendered them.
+
+**The interceptor must not capture clicks for server-served paths** like
+`/docs` (Scalar API reference), `/api/openapi.yaml`, `/healthz`,
+`/branding/...`. The Vue Router has no route for these; if the interceptor
+pushes them, the auth guard rejects them and the user lands on `/login`.
+
+The current implementation calls `router.resolve(candidate)` first and
+only calls `preventDefault()` when `resolved.matched.length > 0`. Anything
+else falls through to native browser navigation, which hits the server
+handler directly. Test coverage: `tests/test_e2e_routing.py::TestDocsLinkServedNatively`.
+
+## Configuration
+
+| Env var | Required when | Effect |
+|---|---|---|
+| `ISMS_DOMAIN` | subdomain mode | Apex hostname — `acme.<ISMS_DOMAIN>` resolves to org `acme`. |
+| `ISMS_SUBDOMAIN_ROUTING` | subdomain mode | Set to `1` to enable. Default off. |
+| `organizations.domain` | custom domain mode | Per-org column; an exact hostname match resolves to that org. |
+
+The `/api/v1/config` endpoint surfaces `subdomain_routing` and `apex_host`
+to the SPA so `orgEntryURL()` can construct the right URL when switching
+between orgs.
+
+## Test coverage
+
+| File | Layer | What it covers |
+|---|---|---|
+| `tests/test_routing.py` | Backend (HTTP) | `OrgResolverMiddleware` resolves Host headers; apex and unknown subdomains fall through cleanly; `/docs` is public Scalar HTML |
+| `tests/test_e2e_routing.py` | Playwright | Subdomain hides the picker and the switcher's other-orgs section; stale token redirects to `/login` not `/organizations`; `/docs` link navigates natively |
+| `tests/test_multi_tenant.py` | Backend (data) | Org A cannot read org B's data — RLS + application-layer enforcement |
+
+The devenv container sets the routing env vars and adds
+`acme-logistics.localhost` to `/etc/hosts` so Playwright can drive the
+browser against a real subdomain URL.

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2453,6 +2453,12 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 		Detail: fmt.Sprintf("%s updated", updated.Identifier),
 	})
 
+	// Same side effect as the dedicated status endpoint — approving via the
+	// edit form must also create the implementation task.
+	if req.Status != nil && *req.Status == "approved" && old.Status != "approved" {
+		s.createChangeFollowupTask(ctx, orgID, updated, actor)
+	}
+
 	return c.JSON(http.StatusOK, updated)
 }
 
@@ -2515,42 +2521,50 @@ func (s *Server) handleUpdateChangeStatus(c echo.Context) error {
 
 	// Auto-create implementation task on approval, assigned to the change requester
 	if req.Status == "approved" && oldStatus != "approved" {
-		assignee := updated.AssignedTo
-		if assignee == "" {
-			assignee = updated.RequestedBy
-		}
-		due := db.NewEpoch(time.Now().AddDate(0, 0, 14))
-		t := &db.Task{
-			Title:       fmt.Sprintf("Implement %s: %s", updated.Identifier, updated.Title),
-			Description: fmt.Sprintf("Auto-created from approved change %s. Verify implementation and mark this task done.", updated.Identifier),
-			TaskType:    "change_followup",
-			Assignee:    assignee,
-			CreatedBy:   actor,
-			Status:      "open",
-			Priority:    "medium",
-			DueDate:     &due,
-		}
-		if err := s.db.CreateTask(ctx, orgID, t); err == nil {
-			_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
-				EntityType: "task",
-				EntityID:   int64(t.ID),
-				Action:     "create",
-				ChangedBy:  actor,
-			})
-			s.searchUpsert(orgID, "task", t.Identifier, t.Title, t.Identifier+" "+t.Title+" "+t.Description)
-			s.logAndNotify(ctx, orgID, &db.Activity{
-				Actor:  actor,
-				Action: "task_created",
-				Detail: fmt.Sprintf("Auto-task %s for approved change %s", t.Identifier, updated.Identifier),
-			})
-			if assignee != "" && s.mailer != nil && s.mailer.Enabled() {
-				baseURL := os.Getenv("ISMS_BASE_URL")
-				_ = s.mailer.SendTaskAssigned(assignee, assignee, actor, t.Title, t.Priority, baseURL)
-			}
-		}
+		s.createChangeFollowupTask(ctx, orgID, updated, actor)
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"status": req.Status})
+}
+
+// createChangeFollowupTask auto-creates the "Implement <CR>" task when a
+// change transitions into approved, assigned to the change requester. Shared
+// by handleUpdateChange (edit-form saves) and handleUpdateChangeStatus so
+// both status-change paths behave identically.
+func (s *Server) createChangeFollowupTask(ctx context.Context, orgID int, updated *db.ChangeRequest, actor string) {
+	assignee := updated.AssignedTo
+	if assignee == "" {
+		assignee = updated.RequestedBy
+	}
+	due := db.NewEpoch(time.Now().AddDate(0, 0, 14))
+	t := &db.Task{
+		Title:       fmt.Sprintf("Implement %s: %s", updated.Identifier, updated.Title),
+		Description: fmt.Sprintf("Auto-created from approved change %s. Verify implementation and mark this task done.", updated.Identifier),
+		TaskType:    "change_followup",
+		Assignee:    assignee,
+		CreatedBy:   actor,
+		Status:      "open",
+		Priority:    "medium",
+		DueDate:     &due,
+	}
+	if err := s.db.CreateTask(ctx, orgID, t); err == nil {
+		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+			EntityType: "task",
+			EntityID:   int64(t.ID),
+			Action:     "create",
+			ChangedBy:  actor,
+		})
+		s.searchUpsert(orgID, "task", t.Identifier, t.Title, t.Identifier+" "+t.Title+" "+t.Description)
+		s.logAndNotify(ctx, orgID, &db.Activity{
+			Actor:  actor,
+			Action: "task_created",
+			Detail: fmt.Sprintf("Auto-task %s for approved change %s", t.Identifier, updated.Identifier),
+		})
+		if assignee != "" && s.mailer != nil && s.mailer.Enabled() {
+			baseURL := os.Getenv("ISMS_BASE_URL")
+			_ = s.mailer.SendTaskAssigned(assignee, assignee, actor, t.Title, t.Priority, baseURL)
+		}
+	}
 }
 
 func (s *Server) handleDeleteChange(c echo.Context) error {

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2561,8 +2561,12 @@ func (s *Server) createChangeFollowupTask(ctx context.Context, orgID int, update
 			Detail: fmt.Sprintf("Auto-task %s for approved change %s", t.Identifier, updated.Identifier),
 		})
 		if assignee != "" && s.mailer != nil && s.mailer.Enabled() {
+			displayName := assignee
+			if u, err := s.db.GetUserByEmail(ctx, assignee); err == nil && u != nil && u.Name != "" {
+				displayName = u.Name
+			}
 			baseURL := os.Getenv("ISMS_BASE_URL")
-			_ = s.mailer.SendTaskAssigned(assignee, assignee, actor, t.Title, t.Priority, baseURL)
+			_ = s.mailer.SendTaskAssigned(assignee, displayName, actor, t.Title, t.Priority, baseURL)
 		}
 	}
 }

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -235,7 +235,12 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 	if req.Status != nil && *req.Status != existing.Status {
 		// Same rule as the dedicated status endpoint: cannot resolve a CA
 		// with open implementation tasks still linked.
-		if *req.Status == "resolved" && existing.Identifier != "" {
+		if *req.Status == "resolved" {
+			// An empty identifier is corrupt data — the open-task query can't
+			// match anything, so skipping would silently disable enforcement.
+			if existing.Identifier == "" {
+				return echo.NewHTTPError(http.StatusInternalServerError, "corrective action has no identifier")
+			}
 			if n, err := s.db.CountOpenTasksByCA(ctx, orgID, existing.Identifier); err == nil && n > 0 {
 				return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot resolve %s: %d open implementation task(s) still linked", existing.Identifier, n))
 			}
@@ -331,10 +336,17 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 
 	// Block resolving if there are still-open implementation tasks linked to this CA.
 	if req.Status == "resolved" {
-		if existing, err := s.db.GetCorrectiveAction(ctx, orgID, id); err == nil && existing != nil && existing.Identifier != "" {
-			if n, err := s.db.CountOpenTasksByCA(ctx, orgID, existing.Identifier); err == nil && n > 0 {
-				return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot resolve %s: %d open implementation task(s) still linked", existing.Identifier, n))
-			}
+		existing, err := s.db.GetCorrectiveAction(ctx, orgID, id)
+		if err != nil || existing == nil {
+			return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		}
+		// An empty identifier is corrupt data — the open-task query can't
+		// match anything, so skipping would silently disable enforcement.
+		if existing.Identifier == "" {
+			return echo.NewHTTPError(http.StatusInternalServerError, "corrective action has no identifier")
+		}
+		if n, err := s.db.CountOpenTasksByCA(ctx, orgID, existing.Identifier); err == nil && n > 0 {
+			return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot resolve %s: %d open implementation task(s) still linked", existing.Identifier, n))
 		}
 	}
 

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -233,6 +233,13 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 	// Route status changes through the dedicated transition function so that
 	// resolved_at / resolved_by_id closure metadata is set correctly.
 	if req.Status != nil && *req.Status != existing.Status {
+		// Same rule as the dedicated status endpoint: cannot resolve a CA
+		// with open implementation tasks still linked.
+		if *req.Status == "resolved" && existing.Identifier != "" {
+			if n, err := s.db.CountOpenTasksByCA(ctx, orgID, existing.Identifier); err == nil && n > 0 {
+				return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot resolve %s: %d open implementation task(s) still linked", existing.Identifier, n))
+			}
+		}
 		if err := s.db.UpdateCorrectiveActionStatus(ctx, orgID, id, *req.Status, getUserEmail(c)); err != nil {
 			return pgxHTTPError(err)
 		}

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -428,7 +428,9 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 }
 
 // statusVerb maps a target status to the verb for "cannot <verb> …" error
-// messages ("resolved" → "resolve").
+// messages. Intentionally scoped to the terminal statuses guarded by the
+// open-CA rule ("resolved", "closed") — extend the switch before adding
+// callers with other statuses.
 func statusVerb(status string) string {
 	switch status {
 	case "resolved":
@@ -436,7 +438,7 @@ func statusVerb(status string) string {
 	case "closed":
 		return "close"
 	default:
-		return "set " + status + " on"
+		return status
 	}
 }
 

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -324,6 +324,13 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	// Route status changes through the dedicated transition function so that
 	// contained_at / resolved_at / closed_at are cleared correctly on reverse transitions.
 	if req.Status != nil && *req.Status != existing.Status {
+		// Same rule as the dedicated status endpoint: cannot resolve/close an
+		// incident with open corrective actions still linked.
+		if *req.Status == "closed" || *req.Status == "resolved" {
+			if n, err := s.db.CountOpenCAsByIncident(ctx, orgID, existing.Identifier); err == nil && n > 0 {
+				return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", statusVerb(*req.Status), n))
+			}
+		}
 		if err := s.db.UpdateIncidentStatus(ctx, orgID, id, *req.Status); err != nil {
 			return pgxHTTPError(err)
 		}
@@ -420,6 +427,19 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	return c.JSON(http.StatusOK, existing)
 }
 
+// statusVerb maps a target status to the verb for "cannot <verb> …" error
+// messages ("resolved" → "resolve").
+func statusVerb(status string) string {
+	switch status {
+	case "resolved":
+		return "resolve"
+	case "closed":
+		return "close"
+	default:
+		return "set " + status + " on"
+	}
+}
+
 func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
@@ -447,8 +467,12 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 
 	// Block closing/resolving if there are still-open corrective actions linked to this incident.
 	if req.Status == "closed" || req.Status == "resolved" {
-		if n, err := s.db.CountOpenCAsByIncident(ctx, orgID, id); err == nil && n > 0 {
-			return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", req.Status, n))
+		existing, err := s.db.GetIncident(ctx, orgID, id)
+		if err != nil || existing == nil {
+			return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		}
+		if n, err := s.db.CountOpenCAsByIncident(ctx, orgID, existing.Identifier); err == nil && n > 0 {
+			return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", statusVerb(req.Status), n))
 		}
 	}
 

--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -180,79 +180,55 @@ func (s *Server) resolveDocumentSubtype(ctx context.Context, orgID int, docID st
 
 // resolveEntityTitle looks up the display name for an entity by type and ID.
 func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, entityType, entityID string) string {
+	// References store per-org identifiers (e.g. "RISK-12", "INC-3") — both
+	// the UI and createReferencesForEntity write that format. Resolve by
+	// identifier, never by numeric row id: the numeric part of an identifier
+	// and the row id are different sequences and diverge in multi-org DBs.
 	switch entityType {
 	case "risk":
-		id, err := parseEntityNumericID(entityID, "RISK-")
-		if err != nil {
-			return entityID
-		}
-		r, err := s.db.GetRisk(ctx, orgID, id)
+		r, err := s.db.GetRiskByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
 		return r.Title
 
 	case "legal_requirement":
-		id, err := parseEntityNumericID(entityID, "LEGAL-")
-		if err != nil {
-			return entityID
-		}
-		l, err := s.db.GetLegalRequirement(ctx, orgID, int(id))
+		l, err := s.db.GetLegalRequirementByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
 		return l.Title
 
 	case "asset":
-		id, err := parseEntityNumericID(entityID, "ASSET-")
-		if err != nil {
-			return entityID
-		}
-		a, err := s.db.GetAsset(ctx, orgID, id)
+		a, err := s.db.GetAssetByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
 		return a.Name
 
 	case "supplier":
-		id, err := parseEntityNumericID(entityID, "SUPPLIER-")
-		if err != nil {
-			return entityID
-		}
-		sup, err := s.db.GetSupplier(ctx, orgID, id)
+		sup, err := s.db.GetSupplierByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
 		return sup.Name
 
 	case "system":
-		id, err := parseEntityNumericID(entityID, "SYSTEM-")
-		if err != nil {
-			return entityID
-		}
-		sys, err := s.db.GetSystem(ctx, orgID, id)
+		sys, err := s.db.GetSystemByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
 		return sys.Name
 
 	case "incident":
-		id, err := strconv.Atoi(stripPrefix(entityID, "INC-"))
-		if err != nil {
-			return entityID
-		}
-		inc, err := s.db.GetIncident(ctx, orgID, id)
+		inc, err := s.db.GetIncidentByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
 		return inc.Title
 
 	case "corrective_action":
-		id, err := strconv.Atoi(stripPrefix(entityID, "CA-"))
-		if err != nil {
-			return entityID
-		}
-		ca, err := s.db.GetCorrectiveAction(ctx, orgID, id)
+		ca, err := s.db.GetCorrectiveActionByIdentifier(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -193,9 +194,11 @@ func NewWithFS(addr, webDir string, database *db.DB, embeddedFS fs.FS) *Server {
 			return strings.TrimSpace(xff)
 		}
 		if req.RemoteAddr != "" {
-			// Strip port.
-			if i := strings.LastIndexByte(req.RemoteAddr, ':'); i >= 0 {
-				return req.RemoteAddr[:i]
+			// Strip port. net.SplitHostPort handles bracketed IPv6
+			// ("[::1]:54321" → "::1") — a naive LastIndex(':') cut would
+			// return "[::1]", which downstream inet casts reject.
+			if host, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+				return host
 			}
 			return req.RemoteAddr
 		}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -2070,9 +2070,9 @@ func (s *Server) handleRiskAdvisories(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "risk not found")
 	}
 
-	// Find linked assets via entity_references (both directions).
-	riskRef := fmt.Sprintf("%d", risk.ID)
-	refs, err := s.db.ListAllReferencesForEntity(ctx, orgID, "risk", riskRef)
+	// Find linked assets via entity_references (both directions). References
+	// store per-org identifiers ("RISK-12"), not numeric row ids.
+	refs, err := s.db.ListAllReferencesForEntity(ctx, orgID, "risk", risk.Identifier)
 	if err != nil {
 		refs = nil
 	}
@@ -2096,12 +2096,7 @@ func (s *Server) handleRiskAdvisories(c echo.Context) error {
 			continue
 		}
 
-		assetID, err := strconv.ParseInt(assetIDStr, 10, 64)
-		if err != nil {
-			continue
-		}
-
-		asset, err := s.db.GetAsset(ctx, orgID, assetID)
+		asset, err := s.db.GetAssetByIdentifier(ctx, orgID, assetIDStr)
 		if err != nil {
 			continue
 		}

--- a/internal/isms/db/corrective_actions.go
+++ b/internal/isms/db/corrective_actions.go
@@ -105,6 +105,18 @@ func (d *DB) GetCorrectiveAction(ctx context.Context, orgID int, id int) (*Corre
 	return &ca, nil
 }
 
+// GetCorrectiveActionByIdentifier resolves a CA by its per-org identifier
+// (e.g. "CA-7") — the canonical ID format used in entity_references.
+func (d *DB) GetCorrectiveActionByIdentifier(ctx context.Context, orgID int, identifier string) (*CorrectiveAction, error) {
+	var id int
+	if err := d.pool.QueryRow(ctx,
+		`SELECT id FROM corrective_actions WHERE identifier = $1 AND organization_id = $2 AND deleted_at IS NULL`,
+		identifier, orgID).Scan(&id); err != nil {
+		return nil, err
+	}
+	return d.GetCorrectiveAction(ctx, orgID, id)
+}
+
 func (d *DB) ListCorrectiveActions(ctx context.Context, orgID int, status, severity, assignee string, limit int) ([]CorrectiveAction, error) {
 	query := `SELECT ` + correctiveActionSelectCols + `
 		FROM corrective_actions WHERE organization_id = $1 AND deleted_at IS NULL`
@@ -184,10 +196,13 @@ func (d *DB) UpdateCorrectiveActionStatus(ctx context.Context, orgID int, id int
 
 // CountOpenCAsByIncident returns the number of corrective actions linked to an incident
 // (via entity_references) that are not yet resolved.
-func (d *DB) CountOpenCAsByIncident(ctx context.Context, orgID int, incidentID int) (int, error) {
+// CountOpenCAsByIncident counts unresolved corrective actions linked to the
+// incident via entity_references. incidentIdentifier is the per-org
+// identifier (e.g. "INC-12") — the canonical format references are stored in.
+func (d *DB) CountOpenCAsByIncident(ctx context.Context, orgID int, incidentIdentifier string) (int, error) {
 	var n int
 	err := d.pool.QueryRow(ctx, `
-		SELECT count(*) FROM corrective_actions ca
+		SELECT count(DISTINCT ca.id) FROM corrective_actions ca
 		JOIN entity_references r ON r.organization_id = ca.organization_id
 		WHERE ca.organization_id = $1
 		  AND ca.status != 'resolved'
@@ -199,7 +214,7 @@ func (d *DB) CountOpenCAsByIncident(ctx context.Context, orgID int, incidentID i
 		    (r.target_type = 'corrective_action' AND r.target_id = ca.identifier
 		      AND r.source_type = 'incident' AND r.source_id = $2)
 		  )
-	`, orgID, fmt.Sprintf("INC-%d", incidentID)).Scan(&n)
+	`, orgID, incidentIdentifier).Scan(&n)
 	return n, err
 }
 

--- a/internal/isms/db/corrective_actions.go
+++ b/internal/isms/db/corrective_actions.go
@@ -108,13 +108,21 @@ func (d *DB) GetCorrectiveAction(ctx context.Context, orgID int, id int) (*Corre
 // GetCorrectiveActionByIdentifier resolves a CA by its per-org identifier
 // (e.g. "CA-7") — the canonical ID format used in entity_references.
 func (d *DB) GetCorrectiveActionByIdentifier(ctx context.Context, orgID int, identifier string) (*CorrectiveAction, error) {
-	var id int
-	if err := d.pool.QueryRow(ctx,
-		`SELECT id FROM corrective_actions WHERE identifier = $1 AND organization_id = $2 AND deleted_at IS NULL`,
-		identifier, orgID).Scan(&id); err != nil {
+	var ca CorrectiveAction
+	err := d.pool.QueryRow(ctx, `
+		SELECT `+correctiveActionSelectCols+`
+		FROM corrective_actions WHERE identifier = $1 AND organization_id = $2 AND deleted_at IS NULL
+	`, identifier, orgID).Scan(&ca.ID, &ca.OrganizationID, &ca.Identifier, &ca.Title, &ca.Description,
+		&ca.Source, &ca.Severity, &ca.Status,
+		&ca.Assignee, &ca.CreatedBy, &ca.DueDate,
+		&ca.RootCause,
+		&ca.Notes,
+		&ca.ResolvedAt, &ca.ResolvedBy,
+		&ca.CreatedAt, &ca.UpdatedAt)
+	if err != nil {
 		return nil, err
 	}
-	return d.GetCorrectiveAction(ctx, orgID, id)
+	return &ca, nil
 }
 
 func (d *DB) ListCorrectiveActions(ctx context.Context, orgID int, status, severity, assignee string, limit int) ([]CorrectiveAction, error) {

--- a/internal/isms/db/incidents.go
+++ b/internal/isms/db/incidents.go
@@ -110,7 +110,10 @@ func (d *DB) CreateIncident(ctx context.Context, orgID int, inc *Incident) error
 	).Scan(&inc.ID, &inc.CreatedAt, &inc.UpdatedAt)
 }
 
-func (d *DB) GetIncident(ctx context.Context, orgID int, id int) (*Incident, error) {
+// getIncidentWhere runs the canonical single-incident query with the given
+// match column ("id" or "identifier") — shared by GetIncident and
+// GetIncidentByIdentifier so the column/scan lists live in one place.
+func (d *DB) getIncidentWhere(ctx context.Context, orgID int, matchCol string, matchVal any) (*Incident, error) {
 	var inc Incident
 	err := d.pool.QueryRow(ctx, `
 		SELECT id, organization_id, identifier, title, description, severity, status,
@@ -124,8 +127,8 @@ func (d *DB) GetIncident(ctx context.Context, orgID int, id int) (*Incident, err
 			detected_at, contained_at, resolved_at, closed_at,
 			COALESCE(root_cause, ''), COALESCE(lessons_learned, ''),
 			created_at, updated_at
-		FROM incidents WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
-	`, id, orgID).Scan(&inc.ID, &inc.OrganizationID, &inc.Identifier, &inc.Title, &inc.Description,
+		FROM incidents WHERE `+matchCol+` = $1 AND organization_id = $2 AND deleted_at IS NULL
+	`, matchVal, orgID).Scan(&inc.ID, &inc.OrganizationID, &inc.Identifier, &inc.Title, &inc.Description,
 		&inc.Severity, &inc.Status,
 		&inc.AffectsC, &inc.AffectsI, &inc.AffectsA,
 		&inc.IncidentType, &inc.Source,
@@ -142,16 +145,14 @@ func (d *DB) GetIncident(ctx context.Context, orgID int, id int) (*Incident, err
 	return &inc, nil
 }
 
+func (d *DB) GetIncident(ctx context.Context, orgID int, id int) (*Incident, error) {
+	return d.getIncidentWhere(ctx, orgID, "id", id)
+}
+
 // GetIncidentByIdentifier resolves an incident by its per-org identifier
 // (e.g. "INC-12") — the canonical ID format used in entity_references.
 func (d *DB) GetIncidentByIdentifier(ctx context.Context, orgID int, identifier string) (*Incident, error) {
-	var id int
-	if err := d.pool.QueryRow(ctx,
-		`SELECT id FROM incidents WHERE identifier = $1 AND organization_id = $2 AND deleted_at IS NULL`,
-		identifier, orgID).Scan(&id); err != nil {
-		return nil, err
-	}
-	return d.GetIncident(ctx, orgID, id)
+	return d.getIncidentWhere(ctx, orgID, "identifier", identifier)
 }
 
 func (d *DB) ListIncidents(ctx context.Context, orgID int, status, severity string, limit int) ([]Incident, error) {

--- a/internal/isms/db/incidents.go
+++ b/internal/isms/db/incidents.go
@@ -142,6 +142,18 @@ func (d *DB) GetIncident(ctx context.Context, orgID int, id int) (*Incident, err
 	return &inc, nil
 }
 
+// GetIncidentByIdentifier resolves an incident by its per-org identifier
+// (e.g. "INC-12") — the canonical ID format used in entity_references.
+func (d *DB) GetIncidentByIdentifier(ctx context.Context, orgID int, identifier string) (*Incident, error) {
+	var id int
+	if err := d.pool.QueryRow(ctx,
+		`SELECT id FROM incidents WHERE identifier = $1 AND organization_id = $2 AND deleted_at IS NULL`,
+		identifier, orgID).Scan(&id); err != nil {
+		return nil, err
+	}
+	return d.GetIncident(ctx, orgID, id)
+}
+
 func (d *DB) ListIncidents(ctx context.Context, orgID int, status, severity string, limit int) ([]Incident, error) {
 	query := `SELECT ` + incidentSelectCols + `
 		FROM incidents WHERE organization_id = $1 AND deleted_at IS NULL`

--- a/internal/isms/db/tokens.go
+++ b/internal/isms/db/tokens.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 )
 
@@ -190,7 +192,17 @@ func (d *DB) CleanExpiredBlockedJWTs(ctx context.Context) error {
 // --- Login Attempts (DB-backed brute-force protection) ---
 
 // RecordLoginAttempt records a failed login attempt and returns the count in the last 15 minutes.
+//
+// ipAddress is normalized to a bare IP before insert: IPv6 loopback arrives
+// from echo's RealIP as "[::1]" (bracketed), which the inet column rejects —
+// and since callers ignore this error, a failing insert silently disables
+// brute-force protection for IPv6 clients. Unparseable values become NULL.
 func (d *DB) RecordLoginAttempt(ctx context.Context, email, ipAddress string) (int, error) {
+	if ip := net.ParseIP(strings.Trim(ipAddress, "[]")); ip != nil {
+		ipAddress = ip.String()
+	} else {
+		ipAddress = ""
+	}
 	_, err := d.pool.Exec(ctx, `INSERT INTO login_attempts (email, ip_address) VALUES ($1, $2)`, email, nilIfEmpty(ipAddress))
 	if err != nil {
 		return 0, err
@@ -218,6 +230,13 @@ func (d *DB) CountRecentLoginAttempts(ctx context.Context, email string) (int, e
 // auth endpoints — complements the per-email check by catching one attacker
 // trying many accounts from one source.
 func (d *DB) CountRecentLoginAttemptsByIP(ctx context.Context, ip string) (int, error) {
+	// Same normalization as RecordLoginAttempt — "[::1]" would fail the
+	// ::inet cast and error out the rate-limit check entirely.
+	if parsed := net.ParseIP(strings.Trim(ip, "[]")); parsed != nil {
+		ip = parsed.String()
+	} else {
+		ip = ""
+	}
 	if ip == "" {
 		return 0, nil
 	}

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -4,6 +4,7 @@ Requires: pip install playwright && playwright install chromium
 Run:      pytest tests/test_e2e_browser.py -v
 """
 import os, pytest, importlib
+import uuid
 import requests
 
 # Fail loudly if Playwright is missing — never silently skip 41 tests.
@@ -783,20 +784,18 @@ class TestQuickActionRiskToTask:
 
 
 class TestOrphanValidationIncidentInUI:
-    """P3: Cannot close incident with open CA — UI shows server's 409 error.
-
-    NOTE: skipped pending rewrite. The incident detail UI now drives state
-    transitions through an edit-mode `<select>` instead of dedicated
-    `Investigate/Contain/Resolve` buttons; the validation behaviour (server
-    returning 409) is still covered by the API integration tests in
-    `test_workflow_integration.py`.
+    """P3: Cannot resolve/close incident with open CA — the edit-form save
+    surfaces the server's 409 as an error toast and the status does not
+    advance. The server rule itself is also covered by the API integration
+    tests in `test_workflow_integration.py`; this verifies the UI feedback.
     """
 
-    @pytest.mark.skip(reason="UI redesigned to edit-mode status select; needs rewrite to test through edit form")
     def test_close_with_open_ca_blocked(self, pw_browser, tokens):
         t = tokens["admin"]
+        marker = uuid.uuid4().hex[:6]
+        title = f"E2E Orphan incident {marker}"
         r = api("post", "/incidents", t, json={
-            "title": "E2E Orphan incident",
+            "title": title,
             "description": "for orphan UI test",
             "severity": "medium",
             "affects_a": True,
@@ -805,55 +804,64 @@ class TestOrphanValidationIncidentInUI:
             "reporter": ADMIN[0],
         }, expect_status=[200, 201])
         inc_id = r.json()["id"]
-        api("post", "/corrective-actions", t, json={
-            "title": "E2E Orphan CA",
+        inc_identifier = r.json()["identifier"]
+        ca = api("post", "/corrective-actions", t, json={
+            "title": f"E2E Orphan CA {marker}",
             "description": "linked",
             "source": "security_incident",
             "severity": "observation",
-            "incident_id": inc_id,
+        }, expect_status=[200, 201]).json()
+        # Link CA → incident via entity_references — there is no incident_id
+        # field on the CA itself; the orphan check counts these references.
+        # References use per-org identifiers (INC-N), not numeric row ids.
+        api("post", "/references", t, json={
+            "source_type": "corrective_action",
+            "source_id": ca["identifier"],
+            "target_type": "incident",
+            "target_id": inc_identifier,
         }, expect_status=[200, 201])
 
-        # Direct API check — we already verified 409 in test_workflow_integration.
-        # Browser-level: load incident detail and observe the close button is the way to trigger this.
-        # Server validation will return 409; we verify the button click does not advance to "closed".
         ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
         page = ctx.new_page()
         try:
-            do_login(page, ADMIN[0], ADMIN[1], then_goto=f"incidents/{inc_id}")
-            wait_for(page, "E2E Orphan incident", timeout=8000)
-            # Walk through valid transitions: open → investigating → contained
-            page.locator('button:has-text("Investigate")').first.click()
-            page.wait_for_load_state("networkidle")
-            page.locator('button:has-text("Contain")').first.click()
-            page.wait_for_load_state("networkidle")
-            # Now Resolve should be blocked by server with a visible error toast
-            resolve_btn = page.locator('button:has-text("Resolve")').first
-            assert resolve_btn.is_visible(timeout=2000)
-            resolve_btn.click()
-            # User should see an error toast explaining the block
-            page.locator('text=/open corrective action/i').first.wait_for(state="visible", timeout=4000)
-            # API state should still be "contained" — not advanced to resolved
+            do_login(page, ADMIN[0], ADMIN[1])
+            click_sidebar(page, "Incidents")
+            wait_for(page, title, timeout=8000)
+            page.locator(f'text={title}').first.click()
+            # Detail modal → edit the overview section
+            page.locator('button:has-text("Edit")').first.click()
+            # The edit-form status select sits right after a "Status" label —
+            # the list-filter select has the same options but no label, so
+            # this is the only locator that can't grab the wrong one.
+            status_select = page.locator(
+                'xpath=//label[normalize-space()="Status"]/following-sibling::select'
+            ).first
+            status_select.wait_for(state="visible", timeout=5000)
+            status_select.select_option("resolved")
+            page.locator('button:has-text("Save")').first.click()
+            # Server rejects with 409 — UI must surface it as an error toast
+            page.locator('text=/open corrective action/i').first.wait_for(state="visible", timeout=5000)
+            # And the incident must not have advanced
             inc_after = api("get", f"/incidents/{inc_id}", t).json()
-            assert inc_after["status"] == "contained", \
-                f"Expected status=contained after blocked resolve, got {inc_after['status']}"
+            assert inc_after["status"] != "resolved", \
+                f"Status advanced to resolved despite open CA"
         finally:
             ctx.close()
 
 
 class TestAutoTaskOnChangeApprovalUI:
-    """P2: Approving a change auto-creates an implementation task — visible in Tasks list.
-
-    NOTE: skipped pending rewrite. The change detail UI no longer has a
-    dedicated `Approve` action button; approvals go through the edit-mode
-    status select. The auto-task behaviour itself is exercised by the API
-    integration tests; the E2E version needs reworking to drive the new UI.
+    """P2: Approving a change via the edit-form status select auto-creates an
+    implementation task, visible in the Tasks list. Guards the edit-form path
+    specifically — it goes through PUT /changes/:id, not the dedicated status
+    endpoint, and both must produce the follow-up task.
     """
 
-    @pytest.mark.skip(reason="UI redesigned to edit-mode status select; needs rewrite to test through edit form")
     def test_approval_creates_task_visible(self, pw_browser, tokens):
         t = tokens["admin"]
+        marker = uuid.uuid4().hex[:6]
+        title = f"E2E AutoTask change {marker}"
         r = api("post", "/changes", t, json={
-            "title": "E2E AutoTask change",
+            "title": title,
             "description": "for auto-task test",
             "priority": "medium",
             "category": "process",
@@ -865,22 +873,28 @@ class TestAutoTaskOnChangeApprovalUI:
         ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
         page = ctx.new_page()
         try:
-            do_login(page, ADMIN[0], ADMIN[1], then_goto=f"changes/{cr['id']}")
-            page.locator('nav button:has-text("Overview")').first.wait_for(state="visible", timeout=8000)
-            # Click Approve in header
-            page.locator('button:has-text("Approve")').first.click()
-            page.wait_for_load_state("networkidle")
-            page.wait_for_timeout(500)
-            # Close the modal first so sidebar is clickable
+            do_login(page, ADMIN[0], ADMIN[1])
+            click_sidebar(page, "Change Management")
+            wait_for(page, title, timeout=8000)
+            page.locator(f'text={title}').first.click()
+            # Detail → edit the overview section, approve via status select
+            # (label-scoped for the same reason as the incident test).
+            page.locator('button:has-text("Edit")').first.click()
+            status_select = page.locator(
+                'xpath=//label[normalize-space()="Status"]/following-sibling::select'
+            ).first
+            status_select.wait_for(state="visible", timeout=5000)
+            status_select.select_option("approved")
+            page.locator('button:has-text("Save")').first.click()
+            wait_for(page, "Saved", timeout=5000)
+            # Auto-task must exist and be visible in the Tasks list
             page.keyboard.press("Escape")
             page.wait_for_timeout(300)
-            # Navigate to Tasks via SPA router (avoids modal-overlay click issue)
-            page.evaluate(f"() => document.querySelector('#app').__vue_app__.config.globalProperties.$router.push('/{ORG}/tasks')")
-            page.wait_for_load_state("networkidle")
-            # Search for the change identifier
-            page.locator('input[placeholder="Search..."]').first.fill(change_ident)
+            click_sidebar(page, "Tasks")
+            search = page.locator('input[placeholder="Search..."]').first
+            search.wait_for(state="visible", timeout=5000)
+            search.fill(change_ident)
             page.wait_for_timeout(400)  # debounce
-            # Title should contain "Implement <CR-N>"
             wait_for(page, f"Implement {change_ident}", timeout=5000)
         finally:
             ctx.close()

--- a/tests/test_e2e_routing.py
+++ b/tests/test_e2e_routing.py
@@ -1,0 +1,174 @@
+"""E2E routing tests — Playwright against a tenant subdomain host.
+
+Verifies the subdomain-bound routing model in a real browser:
+
+  - /organizations picker is never reachable from a tenant subdomain
+  - Org switcher dropdown hides "Switch organization" + otherOrgs
+  - Stale-token refresh on a subdomain goes to /login, not the picker
+  - "Read the docs" link on Landing navigates natively to /docs (Scalar),
+    not into the SPA org-discovery flow
+
+The devenv container is configured for these tests:
+  - ISMS_DOMAIN=localhost
+  - ISMS_SUBDOMAIN_ROUTING=1
+  - extra_hosts: acme-logistics.localhost → 127.0.0.1
+
+Run from inside the devenv container:
+    pytest tests/test_e2e_routing.py -v
+"""
+import os
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+try:
+    from playwright.sync_api import sync_playwright, expect
+except ImportError:
+    pytest.fail(
+        "Playwright is required for E2E routing tests. Install with: "
+        "pip install playwright && playwright install chromium",
+        pytrace=False,
+    )
+
+APEX = os.environ.get("ISMS_TEST_URL", "http://localhost:9090")
+ORG_SLUG = "acme-logistics"
+# Subdomain host: swap the apex hostname for <slug>.localhost, keeping the
+# port. Works from the host (browsers resolve *.localhost to 127.0.0.1) and
+# from the dev container (compose network alias on the isms-test service).
+_apex = urlparse(APEX)
+SUBDOMAIN = f"{_apex.scheme}://{ORG_SLUG}.localhost" + (f":{_apex.port}" if _apex.port else "")
+
+ADMIN_EMAIL = "routing-admin@test.local"
+ADMIN_PASSWORD = "RoutingTest2026!"
+ADMIN_NAME = "Routing Admin"
+
+
+def _api(method, base, path, token=None, **kw):
+    h = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"} if token else {}
+    return getattr(requests, method)(f"{base}/api/v1{path}", headers=h, timeout=15, **kw)
+
+
+@pytest.fixture(scope="module")
+def setup_org():
+    """Create the routing test org + admin user with membership."""
+    _api("post", APEX, "/auth/signup",
+         json={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD, "name": ADMIN_NAME})
+    token = _api("post", APEX, "/auth/login",
+                 json={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD}).json().get("token")
+    assert token, "Could not signup or login routing admin"
+    # Create the org (409 if exists — both fine for our purposes)
+    _api("post", APEX, "/organizations", token,
+         json={"name": "Acme Logistics", "slug": ORG_SLUG, "template": "iso27001"})
+    # Re-login scoped to the org so subsequent /me returns the right slug
+    scoped = _api("post", APEX, "/auth/login",
+                  json={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD,
+                        "organization": ORG_SLUG}).json().get("token")
+    return {"token": scoped or token}
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as p:
+        # Chromium hard-maps *.localhost to 127.0.0.1 (RFC 6761), bypassing
+        # DNS and /etc/hosts. Remap the tenant subdomain to the apex host so
+        # the browser reaches the actual test server (e.g. the isms-test
+        # container when run from the devenv work container).
+        b = p.chromium.launch(args=[
+            f"--host-resolver-rules=MAP {ORG_SLUG}.localhost {_apex.hostname}",
+        ])
+        yield b
+        b.close()
+
+
+def _login_on_subdomain(page, email, password):
+    """Login at <slug>.localhost. The org is implicit (Host header) so the
+    org-discovery step is skipped — straight to email + password."""
+    page.set_default_timeout(8000)
+    page.goto(f"{SUBDOMAIN}/login")
+    page.get_by_placeholder("you@company.com").wait_for(state="visible", timeout=8000)
+    page.get_by_placeholder("you@company.com").fill(email)
+    page.get_by_placeholder("Password", exact=True).fill(password)
+    page.get_by_role("button", name="Sign in").click()
+    page.locator("aside").first.wait_for(state="visible", timeout=10000)
+
+
+class TestSubdomainBound:
+    """On a tenant subdomain, the org is bound — no picker, no switcher targets."""
+
+    def test_organizations_route_redirects(self, browser, setup_org):
+        """Direct navigation to /organizations on subdomain → bounces to /overview."""
+        ctx = browser.new_context()
+        page = ctx.new_page()
+        try:
+            _login_on_subdomain(page, ADMIN_EMAIL, ADMIN_PASSWORD)
+            page.goto(f"{SUBDOMAIN}/organizations")
+            # Router guard should redirect immediately.
+            page.wait_for_url(f"{SUBDOMAIN}/overview", timeout=5000)
+            assert "/organizations" not in page.url
+        finally:
+            ctx.close()
+
+    def test_switcher_hides_switch_organization_link(self, browser, setup_org):
+        """Header org switcher must not surface a "Switch organization" link."""
+        ctx = browser.new_context()
+        page = ctx.new_page()
+        try:
+            _login_on_subdomain(page, ADMIN_EMAIL, ADMIN_PASSWORD)
+            # Open the header org-switcher dropdown.
+            page.locator("button:has-text('" + ORG_SLUG + "')").first.click()
+            # The dropdown shows current org + (admin-only) Settings, but the
+            # "Switch organization" link must be absent on subdomain.
+            expect(page.locator("a:has-text('Switch organization')")).to_have_count(0)
+            expect(page.locator("text=Create new organization")).to_have_count(0)
+        finally:
+            ctx.close()
+
+    def test_stale_token_lands_on_login_not_picker(self, browser, setup_org):
+        """Stale-token refresh on subdomain → /login (not /organizations)."""
+        ctx = browser.new_context()
+        page = ctx.new_page()
+        try:
+            # Plant a deliberately invalid token so /me returns 401 on first call.
+            page.goto(SUBDOMAIN)
+            page.evaluate("localStorage.setItem('isms_api_token', 'invalid-jwt-for-test')")
+            # Navigate to an org-scoped route — the auth guard should redirect.
+            page.goto(f"{SUBDOMAIN}/overview")
+            page.wait_for_url(f"{SUBDOMAIN}/login**", timeout=5000)
+            # Must NOT have landed on the picker — that would leak other orgs.
+            assert "/organizations" not in page.url
+        finally:
+            ctx.close()
+
+
+class TestDocsLinkServedNatively:
+    """Regression for the global anchor interceptor fix.
+
+    Clicking "Read the docs" on Landing.vue must trigger a real browser
+    navigation to the server-served /docs Scalar UI — not a Vue Router push
+    that gets caught by the auth guard.
+    """
+
+    def test_docs_link_navigates_to_scalar(self, browser):
+        """Click → full nav → Scalar HTML loads (no SPA shell, no login redirect)."""
+        ctx = browser.new_context()
+        page = ctx.new_page()
+        try:
+            page.goto(APEX)  # Landing on apex (path-based mode)
+            # Wait for the Landing CTAs to render.
+            page.locator("a[href='/docs']").first.wait_for(state="visible", timeout=5000)
+            with page.expect_navigation(timeout=8000) as nav_info:
+                page.locator("a[href='/docs']").first.click()
+            response = nav_info.value
+            # Scalar UI loads its bundle from CDN. The response body must
+            # include "scalar" — otherwise the SPA shell came through and the
+            # interceptor bug is back.
+            content = page.content().lower()
+            assert "scalar" in content, (
+                "Expected Scalar API reference HTML at /docs; the SPA shell "
+                "appears to have intercepted the click (regression)."
+            )
+            # And the URL stays on /docs — not bounced to /login.
+            assert page.url.rstrip("/").endswith("/docs"), f"unexpected URL: {page.url}"
+        finally:
+            ctx.close()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,134 @@
+"""Multi-tenant routing tests — backend OrgResolverMiddleware.
+
+Verifies that the org context is resolved from the request host (or path)
+before auth, and that the routing model documented in
+docs/multi-tenant-routing.md holds at the wire level:
+
+  - Subdomain `<slug>.<apex>` → org bound to that slug
+  - Apex (no subdomain) → no org context (landing)
+  - Unknown subdomain → no org context (fall through, no leak)
+
+Requires the devenv server to be running with:
+    ISMS_DOMAIN=localhost
+    ISMS_SUBDOMAIN_ROUTING=1
+    extra_hosts: acme-logistics.localhost → 127.0.0.1
+"""
+import os
+import requests
+import pytest
+
+from conftest import BASE_URL, API, ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_NAME, _signup, _login
+
+ROUTING_ORG_SLUG = "acme-logistics"
+ROUTING_ORG_NAME = "Acme Logistics"
+
+
+def _ensure_routing_org():
+    """Create the routing test org if it doesn't already exist."""
+    token = _signup(ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_NAME)
+    if token is None:
+        token = _login(ADMIN_EMAIL, ADMIN_PASSWORD, "")
+    assert token is not None, "Could not auth admin"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    # 409 if already exists — idempotent
+    requests.post(f"{API}/organizations", headers=headers, json={
+        "name": ROUTING_ORG_NAME, "slug": ROUTING_ORG_SLUG,
+    })
+
+
+def _server_config():
+    """Fetch /api/v1/config to learn what the server thinks its apex and
+    subdomain-routing settings are. Tests adapt to whatever the server
+    reports rather than hard-coding `localhost` — that way they work in
+    any deployment (devenv, staging, production-clone) as long as
+    subdomain routing is enabled.
+    """
+    return requests.get(f"{BASE_URL}/api/v1/config").json()
+
+
+def _require_subdomain_routing(cfg):
+    if not cfg.get("subdomain_routing"):
+        pytest.skip(
+            "server has ISMS_SUBDOMAIN_ROUTING off — subdomain resolution "
+            "tests need it on (set in devenv/compose.yml)"
+        )
+    if not cfg.get("apex_host"):
+        pytest.skip("server has no apex_host configured (ISMS_DOMAIN unset)")
+
+
+class TestSubdomainResolution:
+    """OrgResolverMiddleware resolves the org from the Host header."""
+
+    @classmethod
+    def setup_class(cls):
+        _ensure_routing_org()
+        cls.cfg = _server_config()
+
+    def test_subdomain_sets_org_context(self):
+        """Host header `<slug>.<apex>` → org context for that slug."""
+        _require_subdomain_routing(self.cfg)
+        host = f"{ROUTING_ORG_SLUG}.{self.cfg['apex_host']}"
+        r = requests.get(f"{BASE_URL}/api/v1/config", headers={"Host": host})
+        assert r.status_code == 200, f"got {r.status_code}: {r.text[:200]}"
+        cfg = r.json()
+        assert cfg.get("organization_slug") == ROUTING_ORG_SLUG, (
+            f"expected org_slug={ROUTING_ORG_SLUG!r} from Host: {host}, "
+            f"got {cfg.get('organization_slug')!r}"
+        )
+
+    def test_apex_has_no_org_context(self):
+        """Plain apex Host → no org bound, neutral config."""
+        _require_subdomain_routing(self.cfg)
+        r = requests.get(
+            f"{BASE_URL}/api/v1/config",
+            headers={"Host": self.cfg["apex_host"]},
+        )
+        assert r.status_code == 200
+        cfg = r.json()
+        assert not cfg.get("organization_slug"), (
+            f"apex must not surface an org_slug; got {cfg.get('organization_slug')!r}"
+        )
+
+    def test_unknown_subdomain_falls_through(self):
+        """Subdomain pointing at a non-existent org → no org context (no 5xx, no leak)."""
+        _require_subdomain_routing(self.cfg)
+        host = f"definitely-not-an-org-12345.{self.cfg['apex_host']}"
+        r = requests.get(f"{BASE_URL}/api/v1/config", headers={"Host": host})
+        assert r.status_code == 200
+        cfg = r.json()
+        assert not cfg.get("organization_slug")
+
+    def test_subdomain_routing_advertised_in_config(self):
+        """The SPA needs `subdomain_routing` + `apex_host` to build entry URLs.
+        Skipped (not failed) when the deployment runs path-only — the test
+        verifies the wire format when subdomain routing IS enabled.
+        """
+        _require_subdomain_routing(self.cfg)
+        assert self.cfg.get("subdomain_routing") is True
+        assert self.cfg.get("apex_host"), "apex_host must be set when subdomain routing is on"
+
+
+class TestDocsServedNatively:
+    """Regression guard: /docs is a server-served public path, not an SPA route.
+
+    The Vue SPA's global anchor-click interceptor used to capture <a href="/docs">
+    and push it through Vue Router, which has no /docs route, so the auth guard
+    redirected users to /login. The fix is to only intercept when
+    router.resolve(href).matched.length > 0 — but at the HTTP layer, /docs must
+    always return the Scalar API reference HTML.
+    """
+
+    def test_docs_returns_scalar_html_unauthenticated(self):
+        r = requests.get(f"{BASE_URL}/docs")
+        assert r.status_code == 200
+        assert "text/html" in r.headers.get("Content-Type", "")
+        # Scalar UI loads its bundle from a known CDN path.
+        assert "scalar" in r.text.lower(), (
+            "/docs should serve the Scalar API reference HTML, not the SPA index"
+        )
+
+    def test_openapi_spec_served_unauthenticated(self):
+        r = requests.get(f"{BASE_URL}/api/openapi.yaml")
+        assert r.status_code == 200
+        assert "yaml" in r.headers.get("Content-Type", "").lower()
+        assert "openapi:" in r.text.lower()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -26,16 +26,20 @@ class TestSearchIndex:
             "asset_type": "software", "status": "open",
         })
 
-    def test_02_search_empty_returns_all(self, api_url, admin_headers):
-        """Empty query returns a variety of entities (up to 50)."""
+    def test_02_search_empty_returns_results(self, api_url, admin_headers):
+        """Empty query returns indexed entries, capped at 50.
+
+        No assertion on type variety: the endpoint returns the first 50
+        entries in index-build order (goroutine completion order), so once
+        any single type accumulates 50+ contiguous entries the first page is
+        homogeneous. Type reachability is covered by the targeted-query tests
+        below (title, identifier, documents).
+        """
         r = requests.get(f"{api_url}/search?q=", headers=admin_headers)
         assert r.status_code == 200
         data = r.json().get("data") or []
         assert len(data) > 0, "Expected at least some results"
-        # Should return multiple entity types — exact selection is non-deterministic
-        # (depends on goroutine completion order during index build)
-        types = set(d["type"] for d in data)
-        assert len(types) >= 2, f"Expected multiple entity types, got: {types}"
+        assert len(data) <= 50, f"Expected the 50-entry cap, got {len(data)}"
 
     def test_03_search_by_title(self, api_url, admin_headers):
         """Search by entity title."""

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,6 @@
 """Security-specific tests."""
+import uuid
+
 import requests
 
 
@@ -58,16 +60,20 @@ def test_path_traversal_in_document(api_url, admin_headers):
 
 def test_xss_in_risk_title(api_url, admin_headers):
     """XSS in risk title should be stored safely (not executed)."""
+    # Unique marker so the search can't collide with other records — "script"
+    # is a substring of "Description", which appears in every risk created
+    # from the markdown scaffold, so q=script overflows the page size.
+    marker = uuid.uuid4().hex[:12]
     r = requests.post(f"{api_url}/risks", headers=admin_headers, json={
-        "title": '<script>alert("xss")</script>',
+        "title": f'<script>alert("{marker}")</script>',
         "current_likelihood": 1, "current_impact": 1,
         "risk_type": "threat", "origin": "internal", "status": "open",
     })
     if r.status_code in [200, 201]:
-        # Verify it's stored as text, not rendered. Search by query to bypass pagination.
-        risks = requests.get(f"{api_url}/risks?q=script", headers=admin_headers).json()["data"]
-        found = [r for r in risks if "script" in (r.get("title") or "")]
-        assert len(found) > 0  # stored safely
+        # Verify it's stored as text, not rendered.
+        risks = requests.get(f"{api_url}/risks?q={marker}", headers=admin_headers).json()["data"]
+        found = [r for r in risks if marker in (r.get("title") or "") and "<script>" in (r.get("title") or "")]
+        assert len(found) > 0  # stored safely, tags intact as text
 
 
 def test_brute_force_protection(api_url):

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -26,6 +26,7 @@ class TestIncidentOrphanValidation:
         })
         assert r.status_code in [200, 201], f"Create failed: {r.text}"
         TestIncidentOrphanValidation.incident_id = r.json()["id"]
+        TestIncidentOrphanValidation.incident_identifier = r.json()["identifier"]
 
     def test_02_link_ca_to_incident(self, api_url, admin_headers):
         r = requests.post(f"{api_url}/corrective-actions", headers=admin_headers, json={
@@ -37,12 +38,13 @@ class TestIncidentOrphanValidation:
         assert r.status_code in [200, 201], f"Create CA failed: {r.text}"
         ca = r.json()
         TestIncidentOrphanValidation.ca_id = ca["id"]
-        # Register the CA → Incident link via entity_references
+        # Register the CA → Incident link via entity_references — references
+        # use per-org identifiers (INC-N), not numeric row ids.
         ref = requests.post(f"{api_url}/references", headers=admin_headers, json={
             "source_type": "corrective_action",
             "source_id": ca["identifier"],
             "target_type": "incident",
-            "target_id": f"INC-{TestIncidentOrphanValidation.incident_id}",
+            "target_id": TestIncidentOrphanValidation.incident_identifier,
         })
         assert ref.status_code in [200, 201], f"Create reference failed: {ref.text}"
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -396,7 +396,7 @@
                     <span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="org.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : 'bg-slate-500/20 text-slate-400'">{{ org.role }}</span>
                   </button>
                 </div>
-                <div class="border-t border-slate-800 py-1">
+                <div v-if="!subdomainBound" class="border-t border-slate-800 py-1">
                   <router-link to="/organizations" @click="showOrgMenu = false" class="flex items-center gap-2 px-4 py-2 text-sm text-slate-400 hover:text-white hover:bg-slate-800/50 transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
                     Switch organization
@@ -503,7 +503,7 @@ const confirmDialog = useConfirm()
 import GlobalSearch from './components/GlobalSearch.vue'
 import { useSession } from './composables/useSession'
 import { useNotifications } from './composables/useNotifications'
-import { useCurrentOrg, currentOrgPath, registerRouter } from './composables/useCurrentOrg'
+import { useCurrentOrg, currentOrgPath, registerRouter, isSubdomainMode } from './composables/useCurrentOrg'
 
 const { toasts, dismiss: dismissToast } = useToast()
 
@@ -527,6 +527,10 @@ const {
   loadNotifications, loadUnreadCount, markRead: notifMarkRead, markAllRead: notifMarkAllRead,
   formatNotifDate,
 } = useNotifications()
+
+// On a tenant subdomain the org is bound — no switcher, no picker, no
+// "create new org" link. Used to hide multi-org UI surfaces below.
+const subdomainBound = isSubdomainMode()
 
 // Local UI state (not worth extracting — template-only concerns)
 const globalSearchRef = ref(null)
@@ -685,8 +689,16 @@ onMounted(() => {
     // Only SPA-internal absolute paths. Skip external, protocol-relative,
     // hash anchors, mailto:, tel:, etc.
     if (!href.startsWith('/') || href.startsWith('//')) return
+    // Only intercept if Vue Router actually has a route for this path.
+    // Server-served paths (e.g. /docs Scalar UI, /api/openapi.yaml,
+    // /healthz, /branding/...) must navigate natively — otherwise the SPA
+    // captures the click, no route matches, and the auth guard kicks the
+    // user to /login.
+    const candidate = currentOrgPath(href)
+    const resolved = router.resolve(candidate)
+    if (!resolved.matched.length) return
     e.preventDefault()
-    router.push(currentOrgPath(href))
+    router.push(resolved.fullPath)
   })
   // Handle 401 from any API call — redirect to login. Skip when the user is
   // already on a public auth page (signup / forgot-password / verify-email /

--- a/web/src/composables/useCurrentOrg.js
+++ b/web/src/composables/useCurrentOrg.js
@@ -53,6 +53,11 @@ export function isSubdomainHost(hostname) {
   if (_apexHosts.has(hostNoPort)) return false
 
   const parts = hostNoPort.split('.')
+  // Dev convention: a direct child of .localhost (acme.localhost) is a tenant
+  // subdomain — mirrors the backend, which resolves subdomains against
+  // ISMS_DOMAIN=localhost in dev/test. Bare `localhost` stays path-based via
+  // LOCAL_HOSTS above.
+  if (parts.length === 2 && parts[1] === 'localhost') return parts[0] !== 'www'
   if (parts.length < 3) return false
   if (parts[0] === 'www') return false
   // Last two labels must look like a public domain (e.g. "isms.sh"). We accept

--- a/web/src/composables/useSession.js
+++ b/web/src/composables/useSession.js
@@ -83,11 +83,14 @@ export function useSession() {
         orgName.value = currentUserData.value.organization_name
       }
 
-      // If on an org-scoped route but no org_id from server, redirect to org picker.
-      // Org context can come from either the :org path param OR the host subdomain.
-      const onOrgScopedRoute = !!route.params.org || !!orgFromSubdomain()
+      // If on an org-scoped route but no org_id from server, redirect.
+      // Subdomain hosts go to /login (subdomain IS the org — never expose
+      // the picker which would leak other org memberships). Path-based
+      // hosts go to /organizations where the user picks one.
+      const onSubdomain = !!orgFromSubdomain()
+      const onOrgScopedRoute = !!route.params.org || onSubdomain
       if (onOrgScopedRoute && (!currentUserData.value?.organization_id || currentUserData.value.organization_id === 0)) {
-        router.push('/organizations')
+        router.push(onSubdomain ? '/login' : '/organizations')
         return false
       }
       // If we're on `/<slug>/...` but the resolved org slug doesn't match
@@ -97,11 +100,17 @@ export function useSession() {
         return false
       }
 
-      // Load all user orgs for switcher
-      try {
-        const orgs = await api.getMyOrgs()
-        userOrgs.value = Array.isArray(orgs) ? orgs : []
-      } catch { /* ignore */ }
+      // Load all user orgs for the switcher — skipped on tenant subdomain
+      // where switching is not allowed. Loading would leak other org
+      // memberships into the tenant UI even if no link surfaced them.
+      if (!orgFromSubdomain()) {
+        try {
+          const orgs = await api.getMyOrgs()
+          userOrgs.value = Array.isArray(orgs) ? orgs : []
+        } catch { /* ignore */ }
+      } else {
+        userOrgs.value = []
+      }
 
       return true
     } catch (e) {

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -104,6 +104,13 @@ const router = createRouter({
 let sessionValidated = false
 
 router.beforeEach(async (to, from) => {
+  // A tenant subdomain (e.g. verkis.commandvector.net) IS the org context —
+  // the org picker should never be reachable from there. Stale-token refreshes
+  // would otherwise leak the user's other org memberships into the verkis UI.
+  if (to.path === '/organizations' && orgFromSubdomain()) {
+    return getApiToken() ? { path: '/overview' } : { path: '/login' }
+  }
+
   if (to.meta.public) {
     if (to.path === '/' && getApiToken()) {
       // Already logged in landing on the root — go straight into the org

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -38,7 +38,7 @@
         Living documents, tracked reviews, and operational cadence in one auditable platform. Pick a framework or bring your own. AI helps with the work. Humans stay in control.
       </p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
-        <router-link to="/login"
+        <router-link to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
           Start in cloud
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"/></svg>
@@ -123,7 +123,7 @@
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
           <h3 class="text-lg font-semibold mb-2">Managed cloud</h3>
           <p class="text-sm text-slate-400 leading-relaxed mb-4">Sign up, pick your framework, start working. We handle infrastructure, backups, and updates. Multi-tenant with row-level data isolation.</p>
-          <router-link to="/login" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Start free &rarr;</router-link>
+          <router-link to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Start free &rarr;</router-link>
         </div>
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
           <h3 class="text-lg font-semibold mb-2">Self-hosted</h3>
@@ -138,7 +138,7 @@
       <h2 class="text-4xl font-bold mb-4">Your auditor will thank you</h2>
       <p class="text-slate-400 mb-8">Full version history. Immutable approval records. Cryptographically verifiable decisions. Complete audit trail from day one.</p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
-        <router-link to="/login"
+        <router-link to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
           Start in cloud
         </router-link>

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -31,6 +31,10 @@
             Continue
           </button>
         </form>
+        <div class="text-sm text-slate-500 mt-6">
+          Don't have an organization yet?
+          <router-link to="/signup" class="brand-text hover:brightness-125 transition-colors">Create one</router-link>
+        </div>
       </div>
 
       <!-- Normal login form: when org is known -->

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -32,8 +32,8 @@
           </button>
         </form>
         <div class="text-sm text-slate-500 mt-6">
-          Don't have an organization yet?
-          <router-link to="/signup" class="brand-text hover:brightness-125 transition-colors">Create one</router-link>
+          Don't have an account?
+          <router-link to="/signup" class="brand-text hover:brightness-125 transition-colors">Get started</router-link>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #7 — self-serve org creation for new cloud users: signup → create
  org → scaffold template, with org bound on tenant subdomains.

  - Subdomain routing: org bound on tenant subdomains; <slug>.localhost behaves like production domains
  - Status-rule parity: edit-form path now enforces the same rules as the status endpoints (change approval auto-task + email, 409 on closing incidents/CAs with open linked
  work)
  - entity_references canonicalized on per-org identifiers — orphan check, title resolution and CIA advisories matched nothing for UI-created links before
  - Devenv: persistent Go caches, just test-restart, playwright/PATH/CORS fixes, workflow docs

  Test plan: full suite 617 passed (API + Playwright e2e) against devenv test stack.