### PR TITLE
Release toolchain: goreleaser + PR-based release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+# Release on tag push (v*) — builds the frontend, embeds it + migrations,
+# then goreleaser publishes binaries, checksums and changelog to a GitHub
+# Release.
+#
+# Security: triggers only on tags, which only maintainers can push. No
+# secrets beyond the auto-provided GITHUB_TOKEN (scoped to contents:write
+# for creating the release).
+
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history: changelog + commit count
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend and sync embeds
+        run: |
+          cd web && npm ci && npm run build
+          cd ..
+          mkdir -p cmd/isms/web/dist && cp -r web/dist/* cmd/isms/web/dist/
+          cp -f migrations/*.sql cmd/isms/migrations/
+
+      - name: Commit count for version string
+        run: echo "COMMIT_COUNT=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
   push:
     tags: ["v*"]
 
+# Only one release run per tag; never cancel an in-flight publish.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -20,14 +25,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      # Actions are SHA-pinned (not tag-pinned): this job has contents: write,
+      # so a compromised/retagged action could publish arbitrary releases.
+      # Trailing comment is the human-readable version for each SHA.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # full history: changelog + commit count
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
           cache: npm
@@ -43,8 +51,9 @@ jobs:
       - name: Commit count for version string
         run: echo "COMMIT_COUNT=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
+          version: "~> v2" # pin the goreleaser binary to the v2 line
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ name: tests
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 permissions:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+# goreleaser config — runs in CI on tag push (see .github/workflows/release.yml).
+# The Vue frontend and migrations must be synced into cmd/isms/ BEFORE this
+# runs (go:embed) — the release workflow does that; the hook below just fails
+# fast if it didn't happen.
+version: 2
+
+before:
+  hooks:
+    - test -f cmd/isms/web/dist/index.html
+    - test -n "$(ls cmd/isms/migrations/*.sql)"
+
+builds:
+  - id: isms
+    main: ./cmd/isms
+    binary: isms
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - openbsd
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commitHash={{ .ShortCommit }}
+      - -X main.commitCount={{ .Env.COMMIT_COUNT }}
+
+# macOS: single universal binary (amd64+arm64 lipo-merged) instead of two
+# per-arch downloads. replace: true drops the per-arch darwin artifacts.
+universal_binaries:
+  - replace: true
+
+archives:
+  - formats: [tar.gz]
+    name_template: "isms_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github
+  filters:
+    exclude:
+      - "^Merge "
+
+release:
+  draft: false
+  prerelease: auto

--- a/Justfile
+++ b/Justfile
@@ -94,6 +94,8 @@ migrate:
 release-pr VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Bare X.Y.Z only — the recipe adds the `v`. Rejects "v0.6.0" (→ vv0.6.0).
+    [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "✗ version must be X.Y.Z (no leading v), got '{{VERSION}}'"; exit 1; }
     [ -z "$(git status --porcelain)" ] || { echo "✗ working tree not clean"; exit 1; }
     git fetch origin
     git checkout -b "release/v{{VERSION}}" origin/master
@@ -119,9 +121,11 @@ snapshot:
 release VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
+    [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "✗ version must be X.Y.Z (no leading v), got '{{VERSION}}'"; exit 1; }
     [ -z "$(git status --porcelain)" ] || { echo "✗ working tree not clean"; exit 1; }
     git checkout master
     git pull --ff-only
+    git fetch --tags origin  # catch remote-only tags the local repo hasn't seen
     [ "$(tr -d '[:space:]' < version.txt)" = "{{VERSION}}" ] || \
         { echo "✗ version.txt is '$(cat version.txt)' — merge the release PR first"; exit 1; }
     git rev-parse "v{{VERSION}}" >/dev/null 2>&1 && { echo "✗ tag v{{VERSION}} already exists"; exit 1; }

--- a/Justfile
+++ b/Justfile
@@ -81,6 +81,54 @@ serve:
 migrate:
     go run ./cmd/isms/ migrate --dir migrations
 
+# ── Release ──────────────────────────────────────────────────────────────────
+#
+# Two-step, PR-based release flow:
+#   1. just release-pr 0.6.0   → branch + version.txt bump + PR (review, CI)
+#   2. merge the PR
+#   3. just release 0.6.0      → verifies master carries 0.6.0, signs the tag,
+#                                pushes — CI (goreleaser) publishes binaries,
+#                                checksums and changelog to a GitHub Release.
+
+# Step 1: open the version-bump PR.
+release-pr VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    [ -z "$(git status --porcelain)" ] || { echo "✗ working tree not clean"; exit 1; }
+    git fetch origin
+    git checkout -b "release/v{{VERSION}}" origin/master
+    echo "{{VERSION}}" > version.txt
+    git add version.txt
+    git commit -m "Release v{{VERSION}}"
+    git push -u origin "release/v{{VERSION}}"
+    gh pr create --title "Release v{{VERSION}}" \
+        --body "Bumps version.txt to {{VERSION}}. After merge: \`just release {{VERSION}}\` tags master and CI publishes the release."
+    echo "✓ release PR opened — merge it, then run: just release {{VERSION}}"
+
+# Local test-build of the release pipeline — same artifacts as a real release
+# (dist/), nothing published. Requires built frontend (just build-web) first.
+snapshot:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p cmd/isms/web/dist && cp -r web/dist/* cmd/isms/web/dist/ 2>/dev/null || true
+    cp -f migrations/*.sql cmd/isms/migrations/
+    COMMIT_COUNT=$(git rev-list --count HEAD) goreleaser release --snapshot --clean --skip=validate
+    echo "✓ snapshot in dist/ — try: tar -xzf dist/*linux_amd64.tar.gz -C /tmp isms && /tmp/isms version"
+
+# Step 2 (after the PR is merged): tag master and push the tag.
+release VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    [ -z "$(git status --porcelain)" ] || { echo "✗ working tree not clean"; exit 1; }
+    git checkout master
+    git pull --ff-only
+    [ "$(tr -d '[:space:]' < version.txt)" = "{{VERSION}}" ] || \
+        { echo "✗ version.txt is '$(cat version.txt)' — merge the release PR first"; exit 1; }
+    git rev-parse "v{{VERSION}}" >/dev/null 2>&1 && { echo "✗ tag v{{VERSION}} already exists"; exit 1; }
+    git tag -s "v{{VERSION}}" -m "v{{VERSION}}"
+    git push origin "v{{VERSION}}"
+    echo "✓ v{{VERSION}} tagged — CI builds the release: gh run watch"
+
 # ── Maintenance ──────────────────────────────────────────────────────────────
 
 # Run go mod tidy

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -79,6 +79,11 @@ RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
 RUN printf 'export PATH=%s/bin:%s/bin:$HOME/.local/bin:$PATH\n' "${GOROOT}" "${GOPATH}" \
     > /etc/profile.d/golang.sh
 
+# goreleaser — local snapshot builds (`goreleaser release --snapshot`) for
+# testing the release pipeline without tagging.
+RUN GOBIN=${LOCAL_INSTALL}/bin GOPATH=/tmp/gobuild ${GOROOT}/bin/go install github.com/goreleaser/goreleaser/v2@latest \
+    && rm -rf /tmp/gobuild
+
 # ── Create non-root user (isms:isms 1000:1000) ───────────────────────────────
 RUN groupadd -g ${USER_GID} ${USER_NAME} \
     && useradd -m -u ${USER_UID} -g ${USER_GID} -s /bin/bash ${USER_NAME}

--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -118,6 +118,13 @@ test-reset:
 test-logs:
     {{compose}} logs -f isms-test
 
+# ── Release ──────────────────────────────────────────────────────────────────
+
+# Local snapshot build of the release pipeline (goreleaser lives in the image).
+# Artifacts land in dist/ in the repo — visible on the host via the bind mount.
+snapshot:
+    {{compose}} exec -u isms isms bash -lc "cd /home/isms/workspace/isms && just build-web && just snapshot"
+
 # ── Git ──────────────────────────────────────────────────────────────────────
 
 # Git status inside the dev container


### PR DESCRIPTION
Two-step release: `just release-pr X.Y.Z` (version-bump PR) →
  merge → `just release X.Y.Z` (signed tag → goreleaser in CI publishes binaries + checksums + changelog).

  - Targets: linux amd64/arm64 (static, alpine-ready), macOS universal, openbsd amd64/arm64
  - Release workflow triggers on v* tags only (tag ruleset restricts those to admins), no secrets beyond GITHUB_TOKEN
  - `just snapshot` builds identical artifacts locally without publishing — verified: static linking, version ldflags, all archives + checksums
  - Tests workflow now also triggers on push to master (was: main)