### PR TITLE
docs: release guidelines and how we ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ The core is a **generic versioned document engine** — it knows nothing about s
 
 ![Overview](docs/screenshots/overview.png)
 
+## Try the live demo
+
+A hosted demo runs at **[demo.isms.sh](https://demo.isms.sh)** with a sample
+organization — **ACME Logistics** — pre-populated so you can explore every role.
+Every demo account uses the password `demo`:
+
+| Role | Email | Password |
+|------|-------|----------|
+| Admin | `sarah.chen@acme-logistics.demo` | `demo` |
+| Manager | `maria.rodriguez@acme-logistics.demo` | `demo` |
+| Contributor | `david.walsh@acme-logistics.demo` | `demo` |
+
+> The demo is a sandbox: data resets periodically and holds nothing real.
+> Please don't store anything sensitive there.
+
 ## Round-Based Document Review
 
 ![Review workflow](docs/screenshots/review.png)
@@ -281,10 +296,16 @@ Slack and Matrix notifications are configured per-organization in **Admin → Se
 - [AI-First Strategy](docs/ai-first.md) — AI architecture, MCP tools, agent identity
 - [Suggestions](docs/suggestions.md) — Entity suggestion system specification
 - [AI Review Loop](docs/ai-review-loop.md) — Multi-agent document review design
+- [Releasing](docs/releasing.md) — Cadence, versioning discipline, and house style
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Please open an issue first to discuss what you'd like to change.
+
+How we ship — a weekly release train, honest semver, and a deliberate release
+discipline — is documented in [docs/releasing.md](docs/releasing.md). The short
+version: rigor lives in the process (CI, signed gates), so the people can stay
+welcoming.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,41 @@ isms server api-key create --email ai@company.com --name "mcp"
 }
 ```
 
+## Scope — what ISMS is, and isn't
+
+ISMS is a generic, versioned engine for management systems. The core is
+deliberately small: it does a few things well and pushes everything else to its
+edges. That smallness is the point — it keeps the engine clean, and the value of
+a managed deployment lives at the edges.
+
+**Core** (in the binary) — generic primitives every deployment needs: git-backed
+documents (markdown + frontmatter), the review/approval workflow, and structured
+registers (risks, assets, suppliers, systems, incidents, legal requirements,
+corrective actions, audits, objectives). Multi-tenant, white-label,
+authentication. The core knows nothing about any specific standard.
+
+**Templates** — standard-specific content is documents, not core. ISO 27001
+clauses, controls, a Statement of Applicability, management-review minutes,
+competence records are markdown documents scaffolded from
+[isms-templates](https://github.com/unidoc/isms-templates) and owned per
+organization. Templates get you started fast and make the core/content
+separation concrete. Once scaffolded, documents and operational entities (risks,
+incidents, …) cross-link freely.
+
+**Integrations** — external tools are sources; ISMS is the system of record.
+Evidence and objectives flow in through the integration layer, with objective
+check-ins capturing evidence against the objectives they support. The direction
+is first-party connectors for major systems alongside private, customer-specific
+integrations.
+
+**Hosting** — AI/agent wiring, deployment, and operations are hosting concerns,
+not the engine. A managed, hosted ISMS is operated by UniDoc at
+[isms.sh](https://isms.sh); self-hosting is fully supported.
+
+The test for any new capability: *does every deployment need it, generically?* →
+core. Standard-specific → template. External system → integration. Deployment or
+AI wiring → hosting.
+
 ## Architecture
 
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,137 @@
+# Releasing ISMS
+
+How we ship. The goal is discipline and an honest trail: small changes,
+reviewed, shipped on a steady cadence — not speed without rigor.
+
+## Principles
+
+- **The version number tells the truth.** It is derived from what shipped,
+  never chosen for effect.
+- **Discipline over churn.** A little every week, reviewed and green, beats
+  big irregular drops.
+- **Everything is a ticket on a milestone.** The roadmap rolls up from issues;
+  anyone can pick up a well-specified ticket and ship it into the next release.
+
+## Cadence — the weekly train
+
+We ship on a weekly cadence (a release train): whatever is merged, reviewed,
+and green goes out that week.
+
+- The **train is time-based**; the **version is content-based**.
+- A week with only bug fixes ships a **patch**. A week that lands a feature
+  ships a **minor**.
+- Do not force "a minor every week" — that makes the number lie. Ship weekly;
+  let the content name the release.
+- **The cadence is a rhythm, not a quota.** Aim for roughly weekly while
+  actively working; skip quiet weeks and vacations without guilt. Forcing out
+  an empty release to hit a date is the real failure — it ships churn and makes
+  the version lie. The quality bar never flexes; the calendar does.
+
+## Versioning (semver, honestly applied)
+
+| Bump | When | Examples |
+|------|------|----------|
+| **patch** `0.6.1` | bug fixes only | print fix, table render, owner-change |
+| **minor** `0.7.0` | new features | per-event review diff, mobile polish |
+| **major** `1.0.0` | cornerstone capability / architectural milestone | Trust center; 1.0 = core feature-complete and stable |
+
+Rule of thumb: **fix → patch, feature → minor.** You never have to ask
+"patch or minor" — the work decides. `1.0` is reached on substance (the core
+is feature-complete and stable), not as a marketing number.
+
+## Release focus (themes)
+
+Every **minor** has a single headline focus, decided ahead of time, so
+contributors and users know what's coming. Patches don't need a theme — they
+are whatever fixes are ready that week.
+
+Current plan (adjustable as the backlog is triaged):
+
+| Release | Focus |
+|---------|-------|
+| 0.7.0 | Mobile & review polish |
+| 0.8.0 | Register lifecycle & integrity — suggestion-apply parity, supplier/evidence/contract review cycles, CA effectiveness |
+| 0.9.0 | White-label & core boundaries — per-org branding, standard/vendor logic out of core |
+| 1.0.0 | Trust center (cornerstone) + stabilization |
+
+## Scope per release
+
+Keep each release small, coherent, and shippable.
+
+- Solo / small-team guardrail: **~2 tickets per patch.** This is a guardrail,
+  not a law — the real test is "small, coherent, shippable."
+- With more contributors, throughput rises and the **train schedule** — not a
+  ticket count — becomes the structure; releases naturally carry more.
+
+## Milestones and backlog
+
+A milestone is a **commitment for the next 1–2 releases**, not a wish list.
+
+- Assign only the next patch/minor's tickets to a milestone.
+- Everything else stays in the **backlog** (no milestone) and is pulled in
+  two-at-a-time as a release is started.
+- bug → patch milestone · feature → minor milestone · cornerstone → major.
+
+## Mechanics
+
+A two-step, PR-based flow (recipes in the root `Justfile`):
+
+```
+just release-pr X.Y.Z   # version-bump PR (reviewed, CI runs)
+# … merge the PR …
+just release X.Y.Z      # verifies master carries the version, signs the tag,
+                        # pushes — CI (goreleaser) publishes the GitHub Release
+```
+
+- `just snapshot` builds the release artifacts locally (dry run, nothing
+  published) — use it to test the pipeline before tagging.
+- Binaries: static `linux/amd64`, `linux/arm64`, macOS universal,
+  `openbsd/amd64`, `openbsd/arm64`, with `checksums.txt` and a changelog.
+- **Tag from a human, build from GitHub.** Releases are built and published in
+  CI, never from a laptop — reproducible, traceable, no local secrets.
+
+## Gates (non-negotiable)
+
+- **`master`**: PR + 1 approval + green CI (`go-unit`, `integration`) + signed
+  commits. Stale approvals are dismissed on new pushes, and the most recent
+  push must be approved by someone other than its author. No force-push, no
+  deletion.
+- **`v*` tags**: creation / update / deletion restricted to admins (ruleset),
+  and signed.
+
+## Branching — master is sacred
+
+`master` is always releasable. Every merge keeps it stable and shippable —
+that is exactly what the gates protect. A release tag is simply a snapshot of
+`master` at release time; `master` is the always-ready next release, never a
+place where work-in-progress lands.
+
+- Never push anything to `master` you wouldn't ship.
+- All work happens on branches and lands via reviewed, green PRs.
+- The weekly patch is cut from `master` with `just release`.
+
+When we later need to patch an older line while a newer one moves on (security
+errata on 0.6.x while 0.7 develops), we will cut a `X.Y-stable` branch. Until
+then it is trunk-based: one sacred `master`.
+
+## House style
+
+- **Secure and correct by default.** Safety is the default state, not a flag.
+- **A small core, and we remove code.** Deleting a path — a dead vendor
+  integration, an unused field — is a win, not a loss.
+- **A gentle rhythm, not a forced march.** Ship roughly weekly when active;
+  skip quiet weeks without guilt. The quality bar never relaxes; the calendar
+  does.
+- **Reliable errata.** Security and reliability fixes land as clean patch
+  releases, promptly.
+- **Rigor lives in the process, warmth lives in the people.** CI, rulesets and
+  signed gates are the uncompromising gatekeeper — so reviewers can be exacting
+  about the code and generous with the contributor. New contributors are
+  welcome; every release is worth celebrating.
+
+## Why this way
+
+Every change is a reviewed ticket on a milestone; the roadmap is just the issue
+state rolled up; the build is reproducible in CI. That transparency is
+deliberate — a steady, honest trail anyone can read and contribute to, rather
+than undisciplined shipping. Steadiness compounds.


### PR DESCRIPTION
Adds docs/releasing.md — cadence (weekly train), honest semver, release themes, milestones, the just release mechanics, gates, master-is-sacred, and house style. Plus a 'Try the live demo' section in the README.