### PR TITLE
docs: release principles + scope clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ The test for any new capability: *does every deployment need it, generically?* �
 core. Standard-specific → template. External system → integration. Deployment or
 AI wiring → hosting.
 
+**Meeting a standard's requirements** is done through these generic primitives,
+not through per-clause features. For example, corrective-action *effectiveness*
+is expressed as an objective with a measurable target — incidents of a type
+trending down, as part of risk treatment — not a bespoke "verified" field.
+Built-in layers that *are* core, like the incident data-breach fields (breach
+flag, GDPR role, authority/subject notifications), are deliberate first-class
+capabilities, not standard-specific leakage.
+
 ## Architecture
 
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,20 +39,20 @@ Rule of thumb: **fix → patch, feature → minor.** You never have to ask
 "patch or minor" — the work decides. `1.0` is reached on substance (the core
 is feature-complete and stable), not as a marketing number.
 
+**Schema changes ship in feature releases.** Anything that needs a database
+migration goes in a **minor**, never a patch. Patches stay migration-free —
+trivially safe to ship and to roll back.
+
+The one exception: a **serious security issue** (or active data loss) whose fix
+requires a migration may ship in a patch — security comes first. Any such
+exception must be called out explicitly in that release.
+
 ## Release focus (themes)
 
-Every **minor** has a single headline focus, decided ahead of time, so
-contributors and users know what's coming. Patches don't need a theme — they
-are whatever fixes are ready that week.
-
-Current plan (adjustable as the backlog is triaged):
-
-| Release | Focus |
-|---------|-------|
-| 0.7.0 | Mobile & review polish |
-| 0.8.0 | Register lifecycle & integrity — suggestion-apply parity, supplier/evidence/contract review cycles, CA effectiveness |
-| 0.9.0 | White-label & core boundaries — per-org branding, standard/vendor logic out of core |
-| 1.0.0 | Trust center (cornerstone) + stabilization |
+Each minor has a single headline focus, decided ahead of time. The focus and
+the tickets behind it live in the **GitHub milestone description** — that is the
+single source of truth, not this document. Patches don't need a theme; they are
+whatever fixes are ready that week.
 
 ## Scope per release
 


### PR DESCRIPTION
Captures decisions we made:

- **Schema changes ship in feature releases**, never patches — patches stay migration-free and trivially safe. The one exception: a serious security issue (or active data loss) whose fix needs a migration may ship in a patch, called out explicitly.
- **Release focus lives in GitHub milestone descriptions**, not a table here — removed the table that would only go stale.
- **Scope clarification**: a standard's requirements are met through generic primitives (e.g. corrective-action effectiveness = an objective trending incidents down, not a 'verified' field). Built-in layers like the incident data-breach fields are deliberate core, not standard-specific leakage.