### PR TITLE
ci: move GitHub Actions to Node 24 runtimes (latest stable)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,14 @@ jobs:
       # Actions are SHA-pinned (not tag-pinned): this job has contents: write,
       # so a compromised/retagged action could publish arbitrary releases.
       # Trailing comment is the human-readable version for each SHA.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # full history: changelog + commit count
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
           cache: npm
@@ -51,7 +51,7 @@ jobs:
       - name: Commit count for version string
         run: echo "COMMIT_COUNT=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
 
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: "~> v2" # pin the goreleaser binary to the v2 line
           args: release --clean

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Placeholder web dist
@@ -73,19 +73,19 @@ jobs:
       ISMS_SUBDOMAIN_ROUTING: "1"
       ISMS_DEV_MODE: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Templates are a separate repo — the suite scaffolds orgs from them.
       - name: Checkout templates
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: unidoc/isms-templates
           path: isms-templates
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm


### PR DESCRIPTION
Bumps all GitHub Actions to their latest stable releases so they run on the Node 24 runtime, ahead of the June 16
  2026 node20 removal.

  - actions/checkout v4 → v6.0.3
  - actions/setup-go v5 → v6.4.0
  - actions/setup-node v4 → v6.4.0
  - goreleaser/goreleaser-action v6.4.0 → v7.2.2

  tests.yml uses floating major tags; release.yml keeps its SHA-pinned style (pinned to each release's commit, version in the
  trailing comment). Our usage relies only on stable core inputs, so no config changes were needed.

  Note: release.yml only runs on a v* tag push, so these bumps are not exercised by PR CI — we will verify goreleaser-action
  v7 when cutting 0.6.1.

  Closes #12