### PR TITLE
fix: sync stays on main and never silently discards work

### DIFF
--- a/cmd/isms/clone.go
+++ b/cmd/isms/clone.go
@@ -7,6 +7,7 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/cobra"
 )
@@ -66,13 +67,9 @@ Directory defaults to {org-slug}-isms. All config comes from your env file:
 			remoteURL := baseURL + "/git/" + info.OrganizationUUID
 
 			fmt.Printf("Cloning %s (%s) into %s...\n", info.OrganizationName, info.OrganizationSlug, target)
-			repo, err := git.PlainClone(target, false, &git.CloneOptions{
-				URL: remoteURL,
-				Auth: &githttp.BasicAuth{
-					Username: "x-token-auth",
-					Password: token,
-				},
-				Progress: os.Stdout,
+			repo, err := clonePinnedToMain(target, remoteURL, &githttp.BasicAuth{
+				Username: "x-token-auth",
+				Password: token,
 			})
 			if err != nil {
 				return fmt.Errorf("git clone failed: %w", err)
@@ -109,4 +106,16 @@ Directory defaults to {org-slug}-isms. All config comes from your env file:
 
 	cmd.Flags().StringVar(&dir, "dir", "", "Target directory (default: {slug}-isms)")
 	return cmd
+}
+
+// clonePinnedToMain clones remoteURL into target, pinning the checkout to the
+// main branch so HEAD is never left detached — belt-and-suspenders independent
+// of the server's HEAD advertisement. ISMS has exactly one branch (main).
+func clonePinnedToMain(target, remoteURL string, auth *githttp.BasicAuth) (*git.Repository, error) {
+	return git.PlainClone(target, false, &git.CloneOptions{
+		URL:           remoteURL,
+		ReferenceName: plumbing.NewBranchReferenceName("main"),
+		Auth:          auth,
+		Progress:      os.Stdout,
+	})
 }

--- a/cmd/isms/sync.go
+++ b/cmd/isms/sync.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -18,6 +19,7 @@ import (
 const gitRemoteName = "origin"
 
 func syncCmd() *cobra.Command {
+	var force bool
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync local ISMS repository with the server",
@@ -29,7 +31,10 @@ All configuration comes from your env file:
   ISMS_ORGANIZATION   — organization UUID
 
 On first run, sync auto-configures the git remote.
-After that, sync does fetch + fast-forward then push.`,
+After that, sync does fetch + fast-forward then push.
+
+Sync must be run on the main branch. Use --force to discard local state
+and reset to main.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			baseURL, token, orgSlug, err := syncEnv()
 			if err != nil {
@@ -55,10 +60,11 @@ After that, sync does fetch + fast-forward then push.`,
 				}
 			}
 
-			return syncRun(repo, root, token)
+			return syncRun(repo, root, token, force)
 		},
 	}
 
+	cmd.Flags().BoolVar(&force, "force", false, "Discard local state and reset to main if HEAD is not on main")
 	return cmd
 }
 
@@ -150,7 +156,7 @@ func setupRemote(repo *git.Repository, baseURL, token, orgSlug string) error {
 }
 
 // syncRun does the actual sync: fetch, fast-forward, push.
-func syncRun(repo *git.Repository, root, token string) error {
+func syncRun(repo *git.Repository, root, token string, force bool) error {
 	auth := &githttp.BasicAuth{
 		Username: "x-token-auth",
 		Password: token,
@@ -167,22 +173,24 @@ func syncRun(repo *git.Repository, root, token string) error {
 		return fmt.Errorf("git fetch failed: %w", err)
 	}
 
-	// Determine current branch. If HEAD is detached, attach to the remote's
-	// default branch — otherwise fast-forward and push both silently no-op on
-	// the "HEAD" pseudo-ref and the user sees no working-tree update.
 	headRef, err := repo.Head()
 	if err != nil {
 		return fmt.Errorf("could not determine current branch — do you have any commits?")
 	}
 
-	// ISMS workflow is always on main. If HEAD is detached, or on any other
-	// branch, snap back to main from the remote tip.
+	// ISMS workflow is always on main. You must be on main to sync — we do NOT
+	// silently rescue a detached HEAD or another branch, since that would risk
+	// discarding local work. Refuse and let the user sort out their own state,
+	// unless --force is given (discard local state and reset to main).
+	if err := requireMain(headRef.Name(), force); err != nil {
+		return err
+	}
 	if headRef.Name() != plumbing.NewBranchReferenceName("main") {
 		attached, attachErr := attachToMain(repo)
 		if attachErr != nil {
-			return fmt.Errorf("could not attach local HEAD to main: %w", attachErr)
+			return fmt.Errorf("could not reset to main: %w", attachErr)
 		}
-		fmt.Println("Attached local HEAD to main.")
+		fmt.Println("--force: discarded local state, reset to main.")
 		headRef = attached
 	}
 
@@ -216,22 +224,10 @@ func syncRun(repo *git.Repository, root, token string) error {
 			}
 
 			if isAncestor {
-				// Fast-forward: update worktree to remote HEAD
-				wt, err := repo.Worktree()
-				if err != nil {
-					return fmt.Errorf("could not get worktree: %w", err)
-				}
-				err = wt.Checkout(&git.CheckoutOptions{
-					Hash: remoteHash,
-				})
-				if err != nil {
-					return fmt.Errorf("fast-forward failed: %w", err)
-				}
-				// Update branch ref to point to new hash
-				ref := plumbing.NewHashReference(headRef.Name(), remoteHash)
-				err = repo.Storer.SetReference(ref)
-				if err != nil {
-					return fmt.Errorf("could not update branch ref: %w", err)
+				// Fast-forward to the remote tip, keeping HEAD attached to the
+				// branch (checking out the bare hash would detach HEAD).
+				if err := fastForwardToRemote(repo, remoteHash); err != nil {
+					return err
 				}
 				fmt.Println("Fast-forwarded to remote.")
 			} else {
@@ -348,6 +344,43 @@ func attachToMain(repo *git.Repository) (*plumbing.Reference, error) {
 		return nil, fmt.Errorf("could not re-read HEAD after attach: %w", err)
 	}
 	return newHead, nil
+}
+
+// requireMain enforces that sync runs on the main branch. ISMS has exactly one
+// branch (main); a detached HEAD or any other branch is refused so we never
+// silently discard local work. --force overrides (the caller then resets to
+// main, discarding local state).
+func requireMain(headName plumbing.ReferenceName, force bool) error {
+	if headName == plumbing.NewBranchReferenceName("main") || force {
+		return nil
+	}
+	current := headName.Short()
+	if headName == plumbing.HEAD {
+		current = "a detached HEAD"
+	}
+	return fmt.Errorf("HEAD is on %s, not main — ISMS sync only runs on main.\n"+
+		"Switch with 'git switch main', or re-run with --force to discard local state and reset to main.", current)
+}
+
+// fastForwardToRemote advances the local branch to remoteHash and updates the
+// working tree, keeping HEAD attached to the branch. It uses a MergeReset (not
+// Checkout{Force:true}, which is a HardReset): MergeReset advances the branch ref
+// via HEAD, updates the working tree, and keeps HEAD symbolic — but refuses with
+// ErrUnstagedChanges on a dirty tree instead of silently wiping uncommitted
+// local edits. The branch-ref advance is atomic with the working-tree update, so
+// a partial failure can't leave the ref and tree out of sync.
+func fastForwardToRemote(repo *git.Repository, remoteHash plumbing.Hash) error {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("could not get worktree: %w", err)
+	}
+	if err := wt.Reset(&git.ResetOptions{Commit: remoteHash, Mode: git.MergeReset}); err != nil {
+		if errors.Is(err, git.ErrUnstagedChanges) {
+			return fmt.Errorf("uncommitted local changes — commit or stash before syncing")
+		}
+		return fmt.Errorf("fast-forward failed: %w", err)
+	}
+	return nil
 }
 
 // validateLocalDocIDs scans all .md files in the local repo for duplicate document_ids.

--- a/cmd/isms/sync_test.go
+++ b/cmd/isms/sync_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// TestRequireMain verifies sync refuses to run off main unless --force is given,
+// so it never silently discards work on a detached HEAD or another branch.
+func TestRequireMain(t *testing.T) {
+	main := plumbing.NewBranchReferenceName("main")
+	other := plumbing.NewBranchReferenceName("feature")
+
+	if err := requireMain(main, false); err != nil {
+		t.Fatalf("on main should pass: %v", err)
+	}
+	if err := requireMain(plumbing.HEAD, false); err == nil {
+		t.Fatal("detached HEAD without --force should fail")
+	}
+	if err := requireMain(other, false); err == nil {
+		t.Fatal("other branch without --force should fail")
+	}
+	if err := requireMain(plumbing.HEAD, true); err != nil {
+		t.Fatalf("--force should allow a detached HEAD: %v", err)
+	}
+	if err := requireMain(other, true); err != nil {
+		t.Fatalf("--force should allow another branch: %v", err)
+	}
+}
+
+// TestFastForwardKeepsHeadAttached is a regression for the data-loss path where
+// a sync fast-forward checked out the bare remote hash, leaving HEAD detached.
+// A later sync would then "recover" by force-resetting to the remote tip,
+// silently discarding any commits made on the detached HEAD. HEAD must stay
+// attached to the branch after a fast-forward.
+func TestFastForwardKeepsHeadAttached(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	main := plumbing.NewBranchReferenceName("main")
+	// PlainInit points HEAD at master; ISMS content lives on main.
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, main)); err != nil {
+		t.Fatalf("set HEAD->main: %v", err)
+	}
+
+	commit := func(name string) plumbing.Hash {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if _, err := wt.Add(name); err != nil {
+			t.Fatalf("add %s: %v", name, err)
+		}
+		h, err := wt.Commit("add "+name, &git.CommitOptions{
+			Author: &object.Signature{Name: "t", Email: "t@example.test"},
+		})
+		if err != nil {
+			t.Fatalf("commit %s: %v", name, err)
+		}
+		return h
+	}
+
+	c1 := commit("a.txt") // main @ c1
+	c2 := commit("b.txt") // remote tip we will fast-forward to
+
+	// Simulate "local behind remote": rewind main to c1, HEAD still on main.
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(main, c1)); err != nil {
+		t.Fatalf("rewind main: %v", err)
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: main, Force: true}); err != nil {
+		t.Fatalf("checkout c1: %v", err)
+	}
+
+	// Fast-forward to the remote tip.
+	if err := fastForwardToRemote(repo, c2); err != nil {
+		t.Fatalf("fastForwardToRemote: %v", err)
+	}
+
+	// HEAD must be a symbolic ref to main — NOT detached.
+	headRaw, err := repo.Reference(plumbing.HEAD, false)
+	if err != nil {
+		t.Fatalf("read raw HEAD: %v", err)
+	}
+	if headRaw.Type() != plumbing.SymbolicReference || headRaw.Target() != main {
+		t.Fatalf("HEAD detached after fast-forward: type=%v target=%v", headRaw.Type(), headRaw.Target())
+	}
+
+	// Branch must have advanced to the remote tip, and the worktree with it.
+	mainRef, err := repo.Reference(main, false)
+	if err != nil {
+		t.Fatalf("read main: %v", err)
+	}
+	if mainRef.Hash() != c2 {
+		t.Fatalf("main not advanced: got %s want %s", mainRef.Hash(), c2)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "b.txt")); err != nil {
+		t.Fatalf("worktree not updated to remote tip: %v", err)
+	}
+}
+
+// TestFastForwardRefusesDirtyWorktree verifies a fast-forward refuses (and does
+// NOT silently discard) uncommitted edits to tracked files — a plain sync must
+// never wipe local working-tree changes.
+func TestFastForwardRefusesDirtyWorktree(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	main := plumbing.NewBranchReferenceName("main")
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, main)); err != nil {
+		t.Fatalf("set HEAD->main: %v", err)
+	}
+	commit := func(name string) plumbing.Hash {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if _, err := wt.Add(name); err != nil {
+			t.Fatalf("add %s: %v", name, err)
+		}
+		h, err := wt.Commit("add "+name, &git.CommitOptions{
+			Author: &object.Signature{Name: "t", Email: "t@example.test"},
+		})
+		if err != nil {
+			t.Fatalf("commit %s: %v", name, err)
+		}
+		return h
+	}
+	c1 := commit("a.txt")
+	c2 := commit("b.txt")
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(main, c1)); err != nil {
+		t.Fatalf("rewind main: %v", err)
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: main, Force: true}); err != nil {
+		t.Fatalf("checkout c1: %v", err)
+	}
+
+	// Uncommitted edit to a tracked file.
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("LOCAL EDIT"), 0o644); err != nil {
+		t.Fatalf("dirty edit: %v", err)
+	}
+
+	if err := fastForwardToRemote(repo, c2); err == nil {
+		t.Fatal("expected fast-forward to refuse a dirty working tree, got nil")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "a.txt"))
+	if err != nil {
+		t.Fatalf("read a.txt: %v", err)
+	}
+	if string(got) != "LOCAL EDIT" {
+		t.Fatalf("uncommitted edit was discarded: a.txt = %q", got)
+	}
+}
+
+// TestCloneLandsOnMain verifies clonePinnedToMain leaves HEAD attached to main,
+// independent of the server's HEAD advertisement.
+func TestCloneLandsOnMain(t *testing.T) {
+	src := t.TempDir()
+	srcRepo, err := git.PlainInit(src, false)
+	if err != nil {
+		t.Fatalf("init src: %v", err)
+	}
+	swt, err := srcRepo.Worktree()
+	if err != nil {
+		t.Fatalf("src worktree: %v", err)
+	}
+	main := plumbing.NewBranchReferenceName("main")
+	if err := srcRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, main)); err != nil {
+		t.Fatalf("src HEAD->main: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := swt.Add("README.md"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := swt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example.test"},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	target := filepath.Join(t.TempDir(), "clone")
+	repo, err := clonePinnedToMain(target, src, nil)
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	headRaw, err := repo.Reference(plumbing.HEAD, false)
+	if err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	if headRaw.Type() != plumbing.SymbolicReference || headRaw.Target() != main {
+		t.Fatalf("clone left HEAD detached/off-main: type=%v target=%v", headRaw.Type(), headRaw.Target())
+	}
+}


### PR DESCRIPTION
Fixes #13 (clone/sync detached-HEAD data-loss).

  ## Analysis
  - **Clone is already fine:** the git server advertises refs via system `git upload-pack --advertise-refs` (api_git.go), emitting `symref=HEAD:refs/heads/main` (the bare
  repo's HEAD is set to main on bootstrap, store/git.go), so go-git attaches HEAD to main on clone. The original 'clone leaves HEAD detached' symptom no longer reproduces.
  - **The risk was in sync:** the old code silently `attachToMain`'d a detached/other-branch HEAD by force-resetting to the remote tip — discarding any commits made there.
  And the fast-forward path checked out the bare hash, detaching HEAD on every fast-forward.

  ## Behavior
  We don't try to rescue or preserve work made off main — that isn't sync's job, and silent magic is how the data-loss happened.
  - **sync requires main.** If HEAD is detached or on another branch, sync fails with a clear message ('switch to main, or --force'). The user sorts out their own state.
  - **--force** discards local state and resets to main, then syncs.
  - **Fast-forward stays on main** — checks out the branch, not the bare hash, so a normal sync never detaches you.

  Net: after sync you are always on main; HEAD is never silently detached or reset.

  ## Tests
  - `TestRequireMain` — refuses off-main without --force, allows with --force.
  - `TestFastForwardKeepsHeadAttached` — HEAD stays a symbolic ref to main after a fast-forward.

  Closes #13