### PR TITLE
fix: browser tab title reflects org display name

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -126,6 +126,20 @@ class TestSmoke:
         finally:
             ctx.close()
 
+# ── Tab title reflects org (regression for hardcoded "ISMS") ──
+
+class TestTabTitle:
+    def test_title_reflects_org_name(self, pw_browser, tokens):
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            # The browser tab title must reflect the org, not the hardcoded "ISMS".
+            page.wait_for_function("document.title === 'E2E Org'", timeout=8000)
+            assert page.title() == "E2E Org", f"expected 'E2E Org', got {page.title()!r}"
+        finally:
+            ctx.close()
+
 # ── Documents (shared page, sequential) ──
 
 class TestDocuments:

--- a/web/src/composables/useSession.js
+++ b/web/src/composables/useSession.js
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { api, getCurrentUser, clearApiToken, setApiToken } from '../api'
 import { orgFromSubdomain, isSubdomainMode, orgEntryURL, setSubdomainRouting, setApexHost, ensureConfigLoaded } from './useCurrentOrg'
 
@@ -6,6 +6,14 @@ const user = ref(getCurrentUser())
 const currentUserData = ref(null)
 const userOrgs = ref([])
 const orgName = ref('')
+
+// Keep the browser tab title in sync with the org display name, falling back to
+// "ISMS" before an org is loaded (index.html ships that static fallback). Updates
+// automatically when branding loads or the user switches orgs.
+watch(orgName, (name) => {
+  document.title = name || 'ISMS'
+}, { immediate: true })
+
 const logoUrl = ref(null)
 const logoError = ref(false)
 const termsUrl = ref('')

--- a/web/src/composables/useSession.js
+++ b/web/src/composables/useSession.js
@@ -192,6 +192,7 @@ export function useSession() {
       await api.postJSON('/api/v1/auth/logout', {})
     } catch { /* ignore — still clear locally */ }
     clearApiToken()
+    orgName.value = '' // reset so the tab title falls back to "ISMS" on /login
     return router.push('/login')
   }
 


### PR DESCRIPTION
Closes #15.

The browser tab title was hardcoded to 'ISMS' in index.html. Now it reflects the org's display name and updates when branding loads or the user switches orgs.

## Change
- `useSession.js`: a watch on `orgName` sets `document.title` (falls back to 'ISMS' before an org loads). `orgName` already resolves branding_name then organization_name.
- `index.html` keeps `<title>ISMS</title>` as the pre-load static fallback.
- Product identity in the tab comes from the favicon (the shield by default, brandable per org), so the title stays org-only — correct for white-label too.

## Test
- `test_e2e_browser.py::TestTabTitle` — logs in, asserts the tab title becomes the org name ('E2E Org'), not 'ISMS'. Verified against the local test stack (PASSED).