### PR TITLE
fix: top comment badge counts open comments only

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -962,3 +962,38 @@ class TestMobile:
             assert "login" not in page.url
         finally:
             ctx.close()
+
+
+# ── Comment counter (regression for #30: top badge counts OPEN only) ──
+
+class TestCommentCounter:
+    DOC = "iso27001-4-1"
+
+    def test_badge_counts_open_only(self, pw_browser, tokens):
+        t = tokens["admin"]
+
+        def _open_comments():
+            r = api("get", f"/documents/{self.DOC}/comments", t, expect_status=200).json()
+            items = r.get("data") if isinstance(r, dict) else r
+            return [c for c in (items or []) if c.get("status") != "resolved" and not c.get("parent_id")]
+
+        # Clean slate: resolve any currently-open top-level comments on the doc.
+        for c in _open_comments():
+            api("post", f"/comments/{c['id']}/resolve", t, expect_status=[200, 204])
+
+        # Two open comments, resolve one → exactly 1 open.
+        c1 = api("post", "/comments", t, json={"document_id": self.DOC, "body": "open one", "paragraph_index": 0}, expect_status=[200, 201]).json()
+        c2 = api("post", "/comments", t, json={"document_id": self.DOC, "body": "to resolve", "paragraph_index": 0}, expect_status=[200, 201]).json()
+        api("post", f"/comments/{c2['id']}/resolve", t, expect_status=[200, 204])
+
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{self.DOC}")
+            # Badge on the Comments toolbar button must show OPEN count (1), not total (2).
+            expect(page.locator('button[title="Comments"] span')).to_have_text("1", timeout=8000)
+        finally:
+            ctx.close()
+            # teardown: resolve the remaining open comment
+            api("post", f"/comments/{c1['id']}/resolve", t, expect_status=[200, 204])

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -429,7 +429,7 @@
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 011.037-.443 48.282 48.282 0 005.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
                 </svg>
-                <span v-if="comments.length > 0" class="absolute -top-1 -right-1 min-w-[16px] h-4 flex items-center justify-center px-1 text-[9px] font-bold text-white bg-blue-500 rounded-full">{{ comments.length }}</span>
+                <span v-if="openCommentCount > 0" class="absolute -top-1 -right-1 min-w-[16px] h-4 flex items-center justify-center px-1 text-[9px] font-bold text-white bg-blue-500 rounded-full">{{ openCommentCount }}</span>
               </button>
               <!-- Print (icon only) -->
               <button v-if="!editMode" @click="printDocument"

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -987,7 +987,7 @@
             </div>
           </div>
 
-          <template v-else-if="comments.length > 0">
+          <template v-else-if="openComments.length > 0 || resolvedComments.length > 0">
             <!-- Open comments -->
             <div
               v-for="comment in openComments"


### PR DESCRIPTION
Closes #30.

The top comment badge used `comments.length` (total, incl. resolved). It now uses `openCommentCount` (Documents.vue:2430 — filters `status !== 'resolved'` and top-level), so resolving a comment decrements it.

## AC
- Top badge counts open only, decrements on resolve — fixed (badge → `openCommentCount`).
- Resolved comments stay reachable via the panel toggle — unchanged.
- Per-paragraph badges count open only — already correct: `commentCountForBlock` (useDocumentComments.js:63) already filters resolved. No change needed.

## Test
- `test_e2e_browser.py::TestCommentCounter` — seeds 2 comments via API, resolves 1, opens the doc, asserts the badge shows '1' (open) not '2' (total). Old code (`comments.length`) would show '2' → fails; the fix shows '1' → passes. Verified against the local test stack (PASSED).