### PR TITLE
fix: inbox tab deep-links no longer fall back to Comments

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -997,3 +997,25 @@ class TestCommentCounter:
             ctx.close()
             # teardown: resolve the remaining open comment
             api("post", f"/comments/{c1['id']}/resolve", t, expect_status=[200, 204])
+
+
+# ── Inbox deep-links (regression for #33: tab deep-links fell back to Comments) ──
+
+class TestInboxDeepLinks:
+    @pytest.mark.parametrize("tab,label", [
+        ("incidents", "Incidents"),
+        ("corrective_actions", "CAs"),
+    ])
+    def test_deeplink_activates_tab(self, pw_browser, tokens, tab, label):
+        # Deep-linking to /inbox/<tab> must activate that tab, not fall back to
+        # Comments (validTabs was missing incidents/corrective_actions).
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/inbox/{tab}")
+            # The active tab button carries 'text-white'; assert it's the deep-linked one.
+            active = page.locator('div.flex.gap-1.bg-slate-900 button.text-white').first
+            expect(active).to_contain_text(label, timeout=8000)
+        finally:
+            ctx.close()

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1014,8 +1014,8 @@ class TestInboxDeepLinks:
         try:
             do_login(page, ADMIN[0], ADMIN[1])
             page.goto(f"{BASE}/{ORG}/inbox/{tab}")
-            # The active tab button carries 'text-white'; assert it's the deep-linked one.
-            active = page.locator('div.flex.gap-1.bg-slate-900 button.text-white').first
+            # The active tab carries data-testid="active-tab" (stable across styling).
+            active = page.locator('[data-testid="active-tab"]')
             expect(active).to_contain_text(label, timeout=8000)
         finally:
             ctx.close()

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -32,6 +32,7 @@
           v-for="tab in tabs"
           :key="tab.key"
           @click="activeTab = tab.key"
+          :data-testid="activeTab === tab.key ? 'active-tab' : undefined"
           class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors"
           :class="activeTab === tab.key
             ? 'bg-slate-800 text-white'

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -732,7 +732,7 @@ const reviews = ref([])
 const tasks = ref([])
 const changes = ref([])
 
-const validTabs = ['comments', 'reviews', 'tasks', 'changes', 'suggestions']
+const validTabs = ['comments', 'reviews', 'tasks', 'changes', 'suggestions', 'incidents', 'corrective_actions']
 const initialTab = validTabs.includes(route.params.tab) ? route.params.tab : 'comments'
 const activeTab = ref(initialTab)
 const highlightSuggestionId = ref(route.query.id ? parseInt(route.query.id) : null)


### PR DESCRIPTION
Closes #33.

`validTabs` (Inbox.vue) was missing `incidents` and `corrective_actions`, so deep-linking to `/inbox/incidents` or `/inbox/corrective_actions` failed the `validTabs.includes()` check and fell back to the Comments tab. Added both to the list (the tab content templates already existed).

## Test
- `test_e2e_browser.py::TestInboxDeepLinks` — deep-links to each tab and asserts the active tab button is the deep-linked one (not Comments). Verified against the local stack (2 passed). Old code → active tab 'Comments' → fails; fix → 'Incidents'/'CAs' → passes.