### PR TITLE
fix: guard against silent data loss editing docs with embedded HTML/SVG

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -997,3 +997,33 @@ class TestCommentCounter:
             ctx.close()
             # teardown: resolve the remaining open comment
             api("post", f"/comments/{c1['id']}/resolve", t, expect_status=[200, 204])
+
+
+# ── Editor data-loss guard (regression for #61: editing drops embedded HTML/SVG) ──
+
+class TestEditorHtmlGuard:
+    DOC = "e2e-svg-doc"
+
+    def test_edit_guard_warns_on_embedded_svg(self, pw_browser, tokens):
+        t = tokens["admin"]
+        # A document with embedded raw SVG (the WYSIWYG editor can't preserve it).
+        api("post", "/documents", t, json={
+            "folder": "iso27001",
+            "filename": "e2e-svg-doc.md",
+            "document_id": self.DOC,
+            "title": "E2E SVG Doc",
+            "content": "# Heading\n\nBody text here.\n\n<svg width='12' height='12'><rect width='12' height='12'/></svg>\n",
+        }, expect_status=[200, 201, 409])
+
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{self.DOC}")
+            # Wait for the body to render (rawContent loaded) before triggering the guard.
+            expect(page.locator("text=Body text here.")).to_be_visible(timeout=10000)
+            page.get_by_role("button", name="Edit", exact=True).first.click()
+            # Guard: editing a doc with embedded SVG must warn first, not silently enter edit.
+            expect(page.locator("text=editing here will drop it")).to_be_visible(timeout=8000)
+        finally:
+            ctx.close()

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1003,27 +1003,71 @@ class TestCommentCounter:
 
 class TestEditorHtmlGuard:
     DOC = "e2e-svg-doc"
+    SVG_CONTENT = "# Heading\n\nBody text here.\n\n<svg width='12' height='12'><rect width='12' height='12'/></svg>\n"
+
+    def setup_svg_doc(self, t):
+        """Ensure the SVG doc exists WITH its embedded SVG, regardless of prior runs."""
+        api("post", "/documents", t, json={
+            "folder": "iso27001", "filename": "e2e-svg-doc.md",
+            "document_id": self.DOC, "title": "E2E SVG Doc",
+            "content": self.SVG_CONTENT,
+        }, expect_status=[200, 201, 409])
+        # Unconditionally overwrite — a 409 above could leave a stale, SVG-free doc
+        # (e.g. a prior run confirmed the warning and saved via the web editor).
+        api("put", f"/documents/{self.DOC}/content", t, json={"content": self.SVG_CONTENT}, expect_status=200)
 
     def test_edit_guard_warns_on_embedded_svg(self, pw_browser, tokens):
         t = tokens["admin"]
-        # A document with embedded raw SVG (the WYSIWYG editor can't preserve it).
-        api("post", "/documents", t, json={
-            "folder": "iso27001",
-            "filename": "e2e-svg-doc.md",
-            "document_id": self.DOC,
-            "title": "E2E SVG Doc",
-            "content": "# Heading\n\nBody text here.\n\n<svg width='12' height='12'><rect width='12' height='12'/></svg>\n",
-        }, expect_status=[200, 201, 409])
-
+        self.setup_svg_doc(t)
         ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
         page = ctx.new_page()
         try:
             do_login(page, ADMIN[0], ADMIN[1])
             page.goto(f"{BASE}/{ORG}/documents/{self.DOC}")
-            # Wait for the body to render (rawContent loaded) before triggering the guard.
             expect(page.locator("text=Body text here.")).to_be_visible(timeout=10000)
             page.get_by_role("button", name="Edit", exact=True).first.click()
             # Guard: editing a doc with embedded SVG must warn first, not silently enter edit.
             expect(page.locator("text=editing here will drop it")).to_be_visible(timeout=8000)
+        finally:
+            ctx.close()
+
+    def test_edit_guard_cancel_stays_readonly(self, pw_browser, tokens):
+        """Cancelling the warning must NOT enter edit mode."""
+        t = tokens["admin"]
+        self.setup_svg_doc(t)
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{self.DOC}")
+            expect(page.locator("text=Body text here.")).to_be_visible(timeout=10000)
+            page.get_by_role("button", name="Edit", exact=True).first.click()
+            expect(page.locator("text=editing here will drop it")).to_be_visible(timeout=8000)
+            page.get_by_role("button", name="Cancel").click()
+            # Editor must NOT open — no Save button in read-only mode.
+            expect(page.get_by_role("button", name="Save")).not_to_be_visible(timeout=3000)
+        finally:
+            ctx.close()
+
+    def test_edit_guard_clean_doc_no_warning(self, pw_browser, tokens):
+        """A document with no embedded HTML must open the editor without a warning."""
+        t = tokens["admin"]
+        clean = self.DOC + "-clean"
+        content = "# Heading\n\nJust plain markdown. No HTML here.\n"
+        api("post", "/documents", t, json={
+            "folder": "iso27001", "filename": clean + ".md",
+            "document_id": clean, "title": "E2E Clean Doc", "content": content,
+        }, expect_status=[200, 201, 409])
+        api("put", f"/documents/{clean}/content", t, json={"content": content}, expect_status=200)
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{clean}")
+            expect(page.locator("text=Just plain markdown.")).to_be_visible(timeout=10000)
+            page.get_by_role("button", name="Edit", exact=True).first.click()
+            # No guard — editor opens directly.
+            expect(page.locator("text=editing here will drop it")).not_to_be_visible(timeout=2000)
+            expect(page.get_by_role("button", name="Save")).to_be_visible(timeout=5000)
         finally:
             ctx.close()

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -1732,6 +1732,9 @@ function resolveUserName(email) {
 // silently dropped on save. Tables are excluded (they round-trip as HTML).
 function hasEditorUnsafeHtml(md) {
   if (!md) return false
+  // <div> is intentionally excluded: ProseMirror extracts its text content, so
+  // only the wrapper is lost (structural) — not the complete data loss of
+  // svg/canvas/iframe etc., which have no node type and vanish entirely.
   return /<\s*(svg|iframe|object|embed|canvas|video|audio|form|style|script|figure|details|section|article|aside|nav)\b/i.test(md)
 }
 

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -392,7 +392,7 @@
             </nav>
             <div class="flex items-center gap-1.5 flex-shrink-0">
               <!-- Edit (primary CTA with label) -->
-              <button v-if="canEditMetadata && !editMode" @click="startEdit"
+              <button v-if="canEditMetadata && !editMode" @click="startEditGuarded"
                 class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors text-slate-400 hover:text-slate-200 hover:bg-slate-800">
                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
@@ -1726,6 +1726,28 @@ function resolveUserName(email) {
   if (!email) return null
   const user = allUsers.value.find(u => u.email === email)
   return user?.name || email
+}
+
+// Block-level raw HTML / SVG the WYSIWYG editor can't represent — it would be
+// silently dropped on save. Tables are excluded (they round-trip as HTML).
+function hasEditorUnsafeHtml(md) {
+  if (!md) return false
+  return /<\s*(svg|iframe|object|embed|canvas|video|audio|form|style|script|figure|details|section|article|aside|nav)\b/i.test(md)
+}
+
+// Guard the editor against silent data loss: if the document has embedded
+// HTML/SVG the WYSIWYG editor can't preserve, confirm before entering edit mode
+// (one save would drop it). The user must explicitly opt in — never silent.
+async function startEditGuarded() {
+  if (hasEditorUnsafeHtml(rawContent.value)) {
+    const { ask } = useConfirm()
+    const ok = await ask(
+      "This document contains embedded HTML/SVG the editor can't preserve — editing here will drop it on save. Edit the source via the CLI to keep it. Edit anyway?",
+      'Embedded HTML will be lost',
+    )
+    if (!ok) return
+  }
+  startEdit()
 }
 
 // View approved version — show diff between current and approved commit


### PR DESCRIPTION
Closes #61.

  The WYSIWYG editor (TipTap/ProseMirror) silently drops embedded raw HTML/SVG on save. This adds a guard: editing a document that
  contains embedded HTML/SVG now asks for explicit confirmation first (`startEditGuarded` in Documents.vue) — never a silent drop.
  Tables are excluded (they round-trip). Full editability of embedded HTML is out of scope (future).

  ## Test
  - `test_e2e_browser.py::TestEditorHtmlGuard` — creates a doc with embedded <svg>, clicks Edit, asserts the warning appears.
  Verified on the local stack (PASSED).