### PR TITLE
fix: markdown table inline code renders without breaking mid-token

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1003,24 +1003,27 @@ class TestCommentCounter:
 
 class TestTableInlineCodeCss:
     DOC = "e2e-table-code"
+    # A genuinely long token (55+ chars) so the overflow case is exercised.
+    LONG = "sts-USERNAME@a-very-long-contractor-domain-name.example.com"
+    CONTENT = (
+        "# Table\n\n"
+        "| Type | Example |\n"
+        "|------|---------|\n"
+        "| Employee | `sts-john` / `john@example.com` |\n"
+        f"| Long | `{LONG}` |\n"
+    )
+
+    def setup_doc(self, t):
+        api("post", "/documents", t, json={
+            "folder": "iso27001", "filename": "e2e-table-code.md",
+            "document_id": self.DOC, "title": "E2E Table Code", "content": self.CONTENT,
+        }, expect_status=[200, 201, 409])
+        # Unconditionally overwrite so the table (incl. the long token) is always present.
+        api("put", f"/documents/{self.DOC}/content", t, json={"content": self.CONTENT}, expect_status=200)
 
     def test_table_cell_code_is_nowrap(self, pw_browser, tokens):
         t = tokens["admin"]
-        content = (
-            "# Table\n\n"
-            "| Type | Example |\n"
-            "|------|---------|\n"
-            "| Employee | `sts-john` / `john@example.com` |\n"
-            "| Contractor | `sts-USERNAME@contractor.com` |\n"
-        )
-        api("post", "/documents", t, json={
-            "folder": "iso27001",
-            "filename": "e2e-table-code.md",
-            "document_id": self.DOC,
-            "title": "E2E Table Code",
-            "content": content,
-        }, expect_status=[200, 201, 409])
-
+        self.setup_doc(t)
         ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
         page = ctx.new_page()
         try:
@@ -1030,5 +1033,23 @@ class TestTableInlineCodeCss:
             code.wait_for(state="visible", timeout=10000)
             ws = code.evaluate("el => getComputedStyle(el).whiteSpace")
             assert ws == "nowrap", f"expected white-space:nowrap on table-cell code, got {ws!r}"
+        finally:
+            ctx.close()
+
+    def test_long_code_does_not_break_grid(self, pw_browser, tokens):
+        """A long code token at a narrow viewport must clip inside its cell, not
+        overflow the grid into the adjacent column (#14 AC: degrade gracefully)."""
+        t = tokens["admin"]
+        self.setup_doc(t)
+        ctx = pw_browser.new_context(viewport={"width": 760, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{self.DOC}")
+            # The grid row holding the long token must not overflow horizontally.
+            row = page.locator(f'.doc-prose .tbl-grid:has(code:has-text("{self.LONG}"))').first
+            row.wait_for(state="visible", timeout=10000)
+            overflow = row.evaluate("el => el.scrollWidth - el.clientWidth")
+            assert overflow <= 1, f"grid row overflows by {overflow}px — long code broke the grid"
         finally:
             ctx.close()

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -997,3 +997,38 @@ class TestCommentCounter:
             ctx.close()
             # teardown: resolve the remaining open comment
             api("post", f"/comments/{c1['id']}/resolve", t, expect_status=[200, 204])
+
+
+# ── Table inline-code CSS (regression for #14: code chips wrapped mid-token) ──
+
+class TestTableInlineCodeCss:
+    DOC = "e2e-table-code"
+
+    def test_table_cell_code_is_nowrap(self, pw_browser, tokens):
+        t = tokens["admin"]
+        content = (
+            "# Table\n\n"
+            "| Type | Example |\n"
+            "|------|---------|\n"
+            "| Employee | `sts-john` / `john@example.com` |\n"
+            "| Contractor | `sts-USERNAME@contractor.com` |\n"
+        )
+        api("post", "/documents", t, json={
+            "folder": "iso27001",
+            "filename": "e2e-table-code.md",
+            "document_id": self.DOC,
+            "title": "E2E Table Code",
+            "content": content,
+        }, expect_status=[200, 201, 409])
+
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{self.DOC}")
+            code = page.locator(".doc-prose .tbl-cell code").first
+            code.wait_for(state="visible", timeout=10000)
+            ws = code.evaluate("el => getComputedStyle(el).whiteSpace")
+            assert ws == "nowrap", f"expected white-space:nowrap on table-cell code, got {ws!r}"
+        finally:
+            ctx.close()

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -85,12 +85,17 @@
   border-radius: 0.25rem;
   font-size: 0.875em;
 }
-/* Inline code in table cells must not break mid-token — otherwise code chips
-   wrap and stack, rows go uneven, and columns stop lining up (#14). Cells still
-   wrap between separate code spans. */
+/* Inline code in real <table> cells (TrackChanges path) stays whole — no
+   mid-token wrap — and clips with an ellipsis if longer than the cell, so one
+   long token can't distort the table-layout:auto column proportions (#14). */
 .doc-prose td code,
 .doc-prose th code {
   white-space: nowrap;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
 }
 .doc-prose pre {
   background: rgb(15 23 42);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -85,6 +85,13 @@
   border-radius: 0.25rem;
   font-size: 0.875em;
 }
+/* Inline code in table cells must not break mid-token — otherwise code chips
+   wrap and stack, rows go uneven, and columns stop lining up (#14). Cells still
+   wrap between separate code spans. */
+.doc-prose td code,
+.doc-prose th code {
+  white-space: nowrap;
+}
 .doc-prose pre {
   background: rgb(15 23 42);
   border: 1px solid rgb(30 41 59);

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -2926,15 +2926,22 @@ onBeforeUnmount(() => {
   line-height: 1.6;
   font-size: 0.875rem;
   border-right: 1px solid rgba(51 65 85 / 0.3);
+  min-width: 0; /* allow 1fr grid tracks to shrink below content width (#14) */
 }
 .doc-prose :deep(.tbl-cell:last-child) {
   border-right: none;
 }
-/* Keep inline code chips whole inside grid cells (#14) — no mid-token wrap,
-   so rows line up. Cells still wrap between separate code spans. */
+/* Inline code chips stay whole (#14) — no mid-token wrap — and clip with an
+   ellipsis if longer than the cell, so a long token degrades gracefully instead
+   of overflowing into the next grid column. */
 .doc-prose :deep(.tbl-cell) code,
 .doc-prose :deep(.tbl-hdr-cell) code {
   white-space: nowrap;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
 }
 .doc-prose :deep(.tbl-cell strong) {
   color: rgb(241 245 249);

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -2930,6 +2930,12 @@ onBeforeUnmount(() => {
 .doc-prose :deep(.tbl-cell:last-child) {
   border-right: none;
 }
+/* Keep inline code chips whole inside grid cells (#14) — no mid-token wrap,
+   so rows line up. Cells still wrap between separate code spans. */
+.doc-prose :deep(.tbl-cell) code,
+.doc-prose :deep(.tbl-hdr-cell) code {
+  white-space: nowrap;
+}
 .doc-prose :deep(.tbl-cell strong) {
   color: rgb(241 245 249);
   font-weight: 600;


### PR DESCRIPTION
Closes #14.

Markdown tables with inline code rendered distorted in the document view: code chips (e.g. `sts-USERNAME@commandvector.com`) wrapped mid-token and stacked, so rows went uneven and columns didn't line up.

Fix: keep inline code chips whole in table cells (`white-space: nowrap`), so cells wrap only between separate code spans. Both rendering paths:
- Document-view grid cells (`.tbl-cell`/`.tbl-hdr-cell code`, Documents.vue) — the doc view renders tables as a grid, not <table>.
- Real-table renderers (`.doc-prose td code/th code`, style.css) — DocumentViewer / TrackChanges.

Scoped; broader table/markdown polish (syntax highlighting) is #56.

## Test
- `test_e2e_browser.py::TestTableInlineCodeCss` — renders a doc with a table of inline code, asserts cell code computes `white-space: nowrap`. Verified on the local stack (PASSED).