### PR TITLE
fix: nested empty folders render + no header glitch on horizontal scroll

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1359,12 +1359,18 @@ class TestNestedFolderCreation:
         try:
             do_login(page, ADMIN[0], ADMIN[1])
             click_sidebar(page, "Documents")
-            # Expand the parent folder, then the empty sub-folder must be visible.
             page.locator('aside, nav').first.wait_for(state="visible", timeout=8000)
-            parent = page.locator('text=E2E Handbook').first
+            parent = page.get_by_role("button", name="E2E Handbook").first
             parent.wait_for(state="visible", timeout=10000)
-            parent.click()
-            expect(page.locator('text=E2E Alpine').first).to_be_visible(timeout=8000)
+            child = page.locator('text=E2E Alpine').first
+            # Ensure the parent is expanded (a freshly-created folder may already
+            # be auto-expanded — clicking blindly would collapse it). Only toggle
+            # if the child isn't already showing.
+            if not child.is_visible():
+                parent.click()
+            # The empty sub-folder must render — it has a .title but no documents,
+            # which is exactly the case that used to be dropped from the tree.
+            expect(child).to_be_visible(timeout=8000)
         finally:
             ctx.close()
 

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1344,3 +1344,56 @@ class TestCodeWrap:
             expect(block.locator(".code-wrap-btn.active")).to_be_visible(timeout=5000)
         finally:
             ctx.close()
+
+
+# ── Nested empty folder renders in the tree (regression for the folder bug) ──
+
+class TestNestedFolderCreation:
+    def test_empty_nested_folder_renders(self, pw_browser, tokens):
+        t = tokens["admin"]
+        # Create a root folder and an EMPTY sub-folder (no documents) via the API.
+        api("post", "/documents/folders", t, json={"path": "e2e-handbook", "title": "E2E Handbook"}, expect_status=[200, 201])
+        api("post", "/documents/folders", t, json={"path": "e2e-handbook/alpine", "title": "E2E Alpine"}, expect_status=[200, 201])
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            click_sidebar(page, "Documents")
+            # Expand the parent folder, then the empty sub-folder must be visible.
+            page.locator('aside, nav').first.wait_for(state="visible", timeout=8000)
+            parent = page.locator('text=E2E Handbook').first
+            parent.wait_for(state="visible", timeout=10000)
+            parent.click()
+            expect(page.locator('text=E2E Alpine').first).to_be_visible(timeout=8000)
+        finally:
+            ctx.close()
+
+
+# ── No horizontal page scroll on wide content (regression for the header glitch) ──
+
+class TestNoHorizontalPageScroll:
+    def test_long_code_line_does_not_scroll_page(self, pw_browser, tokens):
+        t = tokens["admin"]
+        doc = "e2e-wide-code"
+        longline = "x = '" + ("a" * 400) + "'"
+        content = "# Wide\n\n```python\n" + longline + "\n```\n"
+        api("post", "/documents", t, json={
+            "folder": "iso27001", "filename": doc + ".md",
+            "document_id": doc, "title": "E2E Wide", "content": content,
+        }, expect_status=[200, 201, 409])
+        api("put", f"/documents/{doc}/content", t, json={"content": content}, expect_status=200)
+        ctx = pw_browser.new_context(viewport={"width": 1280, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            page.goto(f"{BASE}/{ORG}/documents/{doc}")
+            page.locator(".doc-prose .code-block").first.wait_for(state="visible", timeout=10000)
+            page.wait_for_timeout(400)
+            # The page itself must not scroll horizontally — the wide code block
+            # scrolls inside its own container instead.
+            overflow = page.evaluate(
+                "() => document.documentElement.scrollWidth - document.documentElement.clientWidth"
+            )
+            assert overflow <= 1, f"page scrolls horizontally by {overflow}px (sticky header would glitch)"
+        finally:
+            ctx.close()

--- a/tests/test_e2e_routing.py
+++ b/tests/test_e2e_routing.py
@@ -173,7 +173,10 @@ class TestDocsLinkServedNatively:
                 "Expected Scalar API reference HTML at /docs; the SPA shell "
                 "appears to have intercepted the click (regression)."
             )
-            # And the URL stays on /docs — not bounced to /login.
-            assert page.url.rstrip("/").endswith("/docs"), f"unexpected URL: {page.url}"
+            # And the URL stays on /docs — not bounced to /login. Strip any hash
+            # fragment first: Scalar adds one (e.g. #description/authentication)
+            # once its JS runs, and whether it's present by now is timing-dependent.
+            path = page.url.split("#")[0].split("?")[0].rstrip("/")
+            assert path.endswith("/docs"), f"unexpected URL: {page.url}"
         finally:
             ctx.close()

--- a/tests/test_e2e_routing.py
+++ b/tests/test_e2e_routing.py
@@ -160,6 +160,11 @@ class TestDocsLinkServedNatively:
             with page.expect_navigation(timeout=8000) as nav_info:
                 page.locator("a[href='/docs']").first.click()
             response = nav_info.value
+            # Wait for the document to finish loading before reading content —
+            # expect_navigation returns as soon as navigation commits, but Scalar
+            # keeps mutating the DOM (loads its bundle), so page.content() can
+            # race with an in-flight navigation ("page is navigating" error).
+            page.wait_for_load_state("load")
             # Scalar UI loads its bundle from CDN. The response body must
             # include "scalar" — otherwise the SPA shell came through and the
             # interceptor bug is back.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -347,7 +347,7 @@
       />
 
       <!-- Right side: header + content -->
-      <div class="flex-1 min-h-screen flex flex-col transition-all duration-200" :class="isMobile ? 'ml-0' : (sidebarCollapsed ? 'ml-14' : 'ml-60')">
+      <div class="flex-1 min-w-0 min-h-screen flex flex-col transition-all duration-200" :class="isMobile ? 'ml-0' : (sidebarCollapsed ? 'ml-14' : 'ml-60')">
         <!-- Top header bar -->
         <header class="h-14 bg-slate-900/50 border-b border-slate-800 flex items-center px-4 sm:px-6 sticky top-0 z-40 backdrop-blur-sm">
           <!-- Mobile menu button -->

--- a/web/src/composables/useDocumentTree.js
+++ b/web/src/composables/useDocumentTree.js
@@ -42,76 +42,49 @@ export function useDocumentTree(api) {
 
   // Build nested tree from flat folder data
   const fileTree = computed(() => {
-    const tree = []
-    // Build folder title lookup from API subfolders (recursive)
-    const folderTitles = {}
-    function collectTitles(f, pathPrefix) {
-      const p = pathPrefix ? pathPrefix + '/' + f.name : f.name
-      if (f.title) folderTitles[p] = f.title
-      for (const sub of (f.subfolders || [])) collectTitles(sub, p)
-    }
-    for (const folder of folders.value) {
-      collectTitles(folder, '')
-    }
-
-    for (const folder of folders.value) {
-      const folderNode = { name: folder.name, title: folder.title || '', type: 'folder', path: folder.name, depth: 0, children: [], fileCount: 0 }
-
-      // Collect files from nested subfolders too
-      const allFiles = [...(folder.files || [])]
-      function collectFiles(f) {
-        for (const sub of (f.subfolders || [])) {
-          allFiles.push(...(sub.files || []))
-          collectFiles(sub)
-        }
+    // Build the tree directly from the API folder hierarchy (folders +
+    // subfolders + files). Deriving folders from file paths alone would drop
+    // empty folders — including freshly-created nested ones that have a .title
+    // but no documents yet — so they'd never render. The API already returns
+    // the full hierarchy, including empty folders, so mirror it.
+    function buildNode(apiFolder, parentPath, depth, topFolder) {
+      const path = parentPath ? parentPath + '/' + apiFolder.name : apiFolder.name
+      const node = { name: apiFolder.name, title: apiFolder.title || '', type: 'folder', path, depth, children: [], fileCount: 0 }
+      for (const sub of (apiFolder.subfolders || [])) {
+        node.children.push(buildNode(sub, path, depth + 1, topFolder))
       }
-      collectFiles(folder)
-
-      for (const file of allFiles) {
-        const parts = file.path.split('/')
-        let current = folderNode
-        for (let i = 1; i < parts.length - 1; i++) {
-          const segName = parts[i]
-          const segPath = parts.slice(0, i + 1).join('/')
-          let existing = current.children.find(c => c.type === 'folder' && c.name === segName)
-          if (!existing) {
-            existing = { name: segName, title: folderTitles[segPath] || '', type: 'folder', path: segPath, depth: i, children: [], fileCount: 0 }
-            current.children.push(existing)
-          }
-          current = existing
-        }
-        // Add file node
-        current.children.push({
+      for (const file of (apiFolder.files || [])) {
+        node.children.push({
           name: formatFileTitle(file),
           type: 'file',
           file: file,
-          folder: folder.name,
-          depth: parts.length - 1,
+          folder: file.folder || topFolder,
+          depth: depth + 1,
           path: file.path,
         })
       }
-
-      // Sort children recursively and compute file counts
-      function sortAndCount(node) {
-        if (node.type !== 'folder') return 0
-        let count = 0
-        for (const child of node.children) {
-          if (child.type === 'folder') {
-            count += sortAndCount(child)
-          } else {
-            count++
-          }
-        }
-        node.fileCount = count
-        // Sort: folders first (sorted naturally), then files (sorted naturally)
-        const folderChildren = node.children.filter(c => c.type === 'folder').sort((a, b) => naturalCompare(a.name, b.name))
-        const fileChildren = node.children.filter(c => c.type === 'file').sort((a, b) => naturalCompare(a.file.document_id || a.file.path, b.file.document_id || b.file.path))
-        node.children = [...folderChildren, ...fileChildren]
-        return count
-      }
-      sortAndCount(folderNode)
-      tree.push(folderNode)
+      return node
     }
+
+    // Sort children recursively and compute file counts (folders first).
+    function sortAndCount(node) {
+      if (node.type !== 'folder') return 0
+      let count = 0
+      for (const child of node.children) {
+        count += child.type === 'folder' ? sortAndCount(child) : 1
+      }
+      node.fileCount = count
+      const folderChildren = node.children.filter(c => c.type === 'folder').sort((a, b) => naturalCompare(a.name, b.name))
+      const fileChildren = node.children.filter(c => c.type === 'file').sort((a, b) => naturalCompare(a.file.document_id || a.file.path, b.file.document_id || b.file.path))
+      node.children = [...folderChildren, ...fileChildren]
+      return count
+    }
+
+    const tree = folders.value.map(folder => {
+      const node = buildNode(folder, '', 0, folder.name)
+      sortAndCount(node)
+      return node
+    })
     return tree.sort((a, b) => naturalCompare(a.name, b.name))
   })
 

--- a/web/src/composables/useDocumentTree.js
+++ b/web/src/composables/useDocumentTree.js
@@ -47,18 +47,18 @@ export function useDocumentTree(api) {
     // empty folders — including freshly-created nested ones that have a .title
     // but no documents yet — so they'd never render. The API already returns
     // the full hierarchy, including empty folders, so mirror it.
-    function buildNode(apiFolder, parentPath, depth, topFolder) {
+    function buildNode(apiFolder, parentPath, depth) {
       const path = parentPath ? parentPath + '/' + apiFolder.name : apiFolder.name
       const node = { name: apiFolder.name, title: apiFolder.title || '', type: 'folder', path, depth, children: [], fileCount: 0 }
       for (const sub of (apiFolder.subfolders || [])) {
-        node.children.push(buildNode(sub, path, depth + 1, topFolder))
+        node.children.push(buildNode(sub, path, depth + 1))
       }
       for (const file of (apiFolder.files || [])) {
         node.children.push({
           name: formatFileTitle(file),
           type: 'file',
           file: file,
-          folder: file.folder || topFolder,
+          folder: file.folder, // always set by the backend (DocFile.Folder)
           depth: depth + 1,
           path: file.path,
         })
@@ -81,7 +81,7 @@ export function useDocumentTree(api) {
     }
 
     const tree = folders.value.map(folder => {
-      const node = buildNode(folder, '', 0, folder.name)
+      const node = buildNode(folder, '', 0)
       sortAndCount(node)
       return node
     })


### PR DESCRIPTION
Two document-view bug fixes (frontend-only, no migration; 0.6.2).

**Nested folders (closes #70)** — `useDocumentTree.js` built the tree from file paths, so an empty sub-folder (created with a `.title` but no documents) never got a node and stayed invisible. Now the tree mirrors the API folder hierarchy, so empty folders render.

**Header glitch (closes #71)** — the content flex column lacked `min-w-0`, so a wide child (long code line) forced the whole page wider than the viewport → horizontal page scroll → the `sticky top-0` header glitched. Added `min-w-0` so the overflow stays contained in the scrollable child.

Tests: `TestNestedFolderCreation` (empty nested folder renders) and `TestNoHorizontalPageScroll` (wide code line doesn't scroll the page).