### PR TITLE
chore(devenv): configurable bind address; untrack .env

### DIFF
--- a/devenv/.env
+++ b/devenv/.env
@@ -1,4 +1,0 @@
-ISMS_SRC_ROOT=/home/ahall/Projects
-CLAUDE_HOME=/home/ahall/.claude
-CLAUDE_JSON=/home/ahall/.claude.json
-COMPOSE_CMD="podman compose"

--- a/devenv/.env.example
+++ b/devenv/.env.example
@@ -1,0 +1,13 @@
+# Copy to devenv/.env and adjust for your machine.
+# .env is gitignored (*.env) and must stay local — never commit it.
+
+ISMS_SRC_ROOT=/home/youruser/Projects
+CLAUDE_HOME=/home/youruser/.claude
+CLAUDE_JSON=/home/youruser/.claude.json
+COMPOSE_CMD="podman compose"
+
+# Host bind address for the dev (9090) and test (9091) servers.
+# Compose defaults to 127.0.0.1 (loopback only). Override here to expose on a
+# network — e.g. 0.0.0.0 (all interfaces) or your WireGuard interface IP for
+# VPN-only access.
+# ISMS_BIND_ADDRESS=0.0.0.0

--- a/devenv/compose.yml
+++ b/devenv/compose.yml
@@ -33,7 +33,9 @@ services:
     hostname: isms-dev
     depends_on: [postgres]
     ports:
-      - "127.0.0.1:9090:9090"
+      # Loopback-only by default; override ISMS_BIND_ADDRESS in devenv/.env to
+      # expose on a network (e.g. 0.0.0.0, or a WireGuard interface IP).
+      - "${ISMS_BIND_ADDRESS:-127.0.0.1}:9090:9090"
     volumes:
       - ${ISMS_SRC_ROOT}/isms:/home/isms/workspace/isms
       - ${ISMS_SRC_ROOT}/isms-templates:/home/isms/workspace/isms-templates
@@ -100,7 +102,7 @@ services:
         aliases: [acme-logistics.localhost]
     depends_on: [postgres-test]
     ports:
-      - "127.0.0.1:9091:9090"
+      - "${ISMS_BIND_ADDRESS:-127.0.0.1}:9091:9090"
     volumes:
       - ${ISMS_SRC_ROOT}/isms:/home/isms/workspace/isms
       - ${ISMS_SRC_ROOT}/isms-templates:/home/isms/workspace/isms-templates

--- a/devenv/compose.yml
+++ b/devenv/compose.yml
@@ -3,8 +3,9 @@
 #   isms-test + postgres-test   — isolated test server (port 9091), ephemeral DB
 #
 # Postgres is reachable ONLY on the compose network (no host port published) —
-# host-side Postgres instances on :5432 are untouched. ISMS server ports are
-# bound to 127.0.0.1 only, not 0.0.0.0, so they aren't exposed to the LAN.
+# host-side Postgres instances on :5432 are untouched. ISMS server ports default
+# to 127.0.0.1 (loopback only); override ISMS_BIND_ADDRESS in devenv/.env to
+# expose them on a network (e.g. 0.0.0.0, or a WireGuard interface IP).
 #
 # The test server auto-starts on container boot. Reset its state any time with
 #   just test-reset


### PR DESCRIPTION
Lets the dev (9090) and test (9091) servers be reached over a network (e.g. WireGuard) without weakening the default.

- compose binds to `${ISMS_BIND_ADDRESS:-127.0.0.1}` — default loopback-only, so nothing is exposed unless you opt in via devenv/.env.
- Override to `0.0.0.0` (all interfaces) or, preferably, a WireGuard interface IP (VPN-only).
- **Stops tracking devenv/.env** — it held machine-specific host paths and is the place for local overrides, so it must not be in git. Adds **devenv/.env.example** as the template; existing clones recreate their .env from it.

Heads-up for anyone with a clone: after pulling, your tracked .env is removed — copy .env.example to .env and fill in your paths.