### PR TITLE
docs: add GitHub issue templates (bug, feature, documentation) (#66)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The fields below are what we'd otherwise have to
+        ask for — filling them in gets your issue triaged and fixed faster.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what you observed.
+      placeholder: When I …, the app …
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so we can see it too.
+      placeholder: |
+        1. Go to …
+        2. Click …
+        3. See …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual
+      description: What you expected to happen, and what actually happened instead.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component / surface
+      description: Which part of ISMS is affected?
+      options:
+        - CLI
+        - Web UI
+        - TUI
+        - REST API
+        - MCP server
+        - Document engine / git store
+        - "Registers (risks, assets, suppliers, …)"
+        - "Auth (OIDC, TOTP, passkeys)"
+        - "Notifications (Slack, Matrix, email)"
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: ISMS version or commit — the release tag (e.g. 0.6.1) or `isms version`.
+      placeholder: 0.6.x
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Logs, screenshots, and deployment details (self-hosted? which storage backend?) all help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,8 +2,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Report a security vulnerability
-    url: https://github.com/unidoc/isms/blob/master/SECURITY.md
-    about: Do NOT open a public issue for security problems. Email security@isms.sh — see SECURITY.md for coordinated disclosure.
+    url: mailto:security@isms.sh
+    about: Do NOT open a public issue for security problems. Emails security@isms.sh directly — see SECURITY.md for what to include and our coordinated-disclosure policy.
   - name: Question or support
     url: https://github.com/unidoc/isms/discussions
     about: Ask questions and get help in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Maintainers still file rich free-form issues — keep the blank option.
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/unidoc/isms/blob/master/SECURITY.md
+    about: Do NOT open a public issue for security problems. Email security@isms.sh — see SECURITY.md for coordinated disclosure.
+  - name: Question or support
+    url: https://github.com/unidoc/isms/discussions
+    about: Ask questions and get help in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,6 @@
 name: Documentation
 description: Report a gap or inaccuracy in the documentation
+title: "[Docs]: "
 labels: ["documentation"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,26 @@
+name: Documentation
+description: Report a gap or inaccuracy in the documentation
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where?
+      description: Which doc, page, or file — a link or path.
+      placeholder: README.md / docs/releasing.md / docs page URL
+    validations:
+      required: true
+  - type: textarea
+    id: gap
+    attributes:
+      label: What's missing or wrong?
+      description: The gap, inaccuracy, or point of confusion.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: Optional — how you'd improve it.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature request
 description: Suggest an improvement or a new capability
+title: "[Feature]: "
 labels: ["enhancement"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an improvement or a new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what's getting in the way? Lead with the why, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why they fall short.
+    validations:
+      required: false


### PR DESCRIPTION
Closes #66. Adds structured YAML issue forms under `.github/ISSUE_TEMPLATE/`.

- **bug_report.yml** — `bug`; Component/surface dropdown scoped to ISMS (CLI, Web UI, TUI, REST API, MCP, document engine, registers, auth, notifications, other), Version field, required repro + expected/actual.
- **feature_request.yml** — `enhancement`; problem / proposed solution / alternatives.
- **documentation.yml** — `documentation`; lightweight doc-gap form.
- **config.yml** — `blank_issues_enabled: true` (maintainers keep filing rich free-form issues); contact links: security → SECURITY.md (`security@isms.sh`, never a public issue, per the security policy) and questions → Discussions.

All four are valid YAML; template `labels:` match existing repo labels. Picker shows the three forms + two contact links + the blank option.