### PR TITLE
fix: metadata-only edits don't mark a doc 'changed since approval' (#3)

### DIFF
--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1590,13 +1590,17 @@ func (s *Server) handleNeedsReview(c echo.Context) error {
 					return nil // no changes since approval
 				}
 				// The commit advanced, but only flag a re-review if the reviewed
-				// content (the body) actually changed. Metadata-only edits — owner,
-				// author, version, classification, review_cycle — write a new commit
+				// content (the body) actually changed. A frontmatter-only edit
+				// (any metadata field — not the markdown body) writes a new commit
 				// without changing what's reviewed, and must not trigger "changed
 				// since last approval" (#3).
 				if approvedRef != "" {
-					if approvedBody, bodyErr := st.DocumentBodyAtRef(approvedRef, gitPath); bodyErr == nil &&
-						strings.TrimSpace(approvedBody) == strings.TrimSpace(pf.Body) {
+					approvedBody, bodyErr := st.DocumentBodyAtRef(approvedRef, gitPath)
+					if bodyErr != nil {
+						// Safe fallback: flag for review. Log it so intermittent
+						// git-read failures don't silently cause false positives.
+						c.Logger().Warnf("needs-review: body-at-ref failed, flagging %s: ref=%s err=%v", gitPath, approvedRef, bodyErr)
+					} else if strings.TrimSpace(approvedBody) == strings.TrimSpace(pf.Body) {
 						return nil // only frontmatter metadata changed since approval
 					}
 				}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1589,6 +1589,17 @@ func (s *Server) handleNeedsReview(c echo.Context) error {
 				if approvedRef == commitHash {
 					return nil // no changes since approval
 				}
+				// The commit advanced, but only flag a re-review if the reviewed
+				// content (the body) actually changed. Metadata-only edits — owner,
+				// author, version, classification, review_cycle — write a new commit
+				// without changing what's reviewed, and must not trigger "changed
+				// since last approval" (#3).
+				if approvedRef != "" {
+					if approvedBody, bodyErr := st.DocumentBodyAtRef(approvedRef, gitPath); bodyErr == nil &&
+						strings.TrimSpace(approvedBody) == strings.TrimSpace(pf.Body) {
+						return nil // only frontmatter metadata changed since approval
+					}
+				}
 				// Changed since approval
 				var changeSummary []string
 				if approvedRef != "" {

--- a/internal/isms/store/document.go
+++ b/internal/isms/store/document.go
@@ -141,3 +141,17 @@ func parseFrontmatter(content string) (string, string, error) {
 
 	return fm, body, nil
 }
+
+// DocumentBodyAtRef returns the markdown body (frontmatter stripped) of the
+// document at the given repo-relative path as it existed at the given git ref.
+// Used to tell whether the reviewed content actually changed between two
+// commits, ignoring metadata-only edits (owner, author, version, …) in the
+// frontmatter that still produce a new commit.
+func (s *Store) DocumentBodyAtRef(ref, gitPath string) (string, error) {
+	raw, err := s.ReadFileAtRef(ref, gitPath)
+	if err != nil {
+		return "", err
+	}
+	_, body, err := parseFrontmatter(string(raw))
+	return body, err
+}

--- a/internal/isms/store/document.go
+++ b/internal/isms/store/document.go
@@ -143,10 +143,10 @@ func parseFrontmatter(content string) (string, string, error) {
 }
 
 // DocumentBodyAtRef returns the markdown body (frontmatter stripped) of the
-// document at the given repo-relative path as it existed at the given git ref.
-// Used to tell whether the reviewed content actually changed between two
-// commits, ignoring metadata-only edits (owner, author, version, …) in the
-// frontmatter that still produce a new commit.
+// document at gitPath as it existed at the given git ref.
+// Used to detect whether the reviewed content actually changed between two
+// commits; a frontmatter-only edit (any field that is not the markdown body)
+// still produces a new commit but must not trigger a re-review prompt.
 func (s *Store) DocumentBodyAtRef(ref, gitPath string) (string, error) {
 	raw, err := s.ReadFileAtRef(ref, gitPath)
 	if err != nil {

--- a/internal/isms/store/document_test.go
+++ b/internal/isms/store/document_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDocumentBodyAtRef covers the body-comparison primitive behind the
+// "changed since approval" fix (#3): a metadata-only frontmatter edit produces
+// a new commit but must leave the stripped body identical, while a body edit
+// must change it.
+func TestDocumentBodyAtRef(t *testing.T) {
+	dir := t.TempDir()
+	st := initBareStore(t, dir)
+	absPath := filepath.Join(st.Root(), "documents", "test", "doc.md")
+
+	v1 := "---\ndocument_id: d\ntitle: T\nstatus: approved\nowner: alice@test.com\n---\nReviewed body.\n"
+	h1, err := st.CommitFile(absPath, []byte(v1), "A", "a@test.com", "initial")
+	if err != nil {
+		t.Fatalf("commit v1: %v", err)
+	}
+
+	// Metadata-only change (owner) — the stripped body must still match v1.
+	v2 := "---\ndocument_id: d\ntitle: T\nstatus: approved\nowner: bob@test.com\n---\nReviewed body.\n"
+	if _, err := st.CommitFile(absPath, []byte(v2), "A", "a@test.com", "owner change"); err != nil {
+		t.Fatalf("commit v2: %v", err)
+	}
+
+	b1, err := st.DocumentBodyAtRef(h1, "documents/test/doc.md")
+	if err != nil {
+		t.Fatalf("body at h1: %v", err)
+	}
+	head, err := st.HeadHash()
+	if err != nil {
+		t.Fatalf("head hash: %v", err)
+	}
+	b2, err := st.DocumentBodyAtRef(head, "documents/test/doc.md")
+	if err != nil {
+		t.Fatalf("body at HEAD: %v", err)
+	}
+	if strings.TrimSpace(b1) != strings.TrimSpace(b2) {
+		t.Errorf("metadata-only edit changed the body:\nh1:   %q\nHEAD: %q", b1, b2)
+	}
+
+	// Body change — the stripped bodies must now differ.
+	v3 := "---\ndocument_id: d\ntitle: T\nstatus: draft\n---\nUpdated body.\n"
+	if _, err := st.CommitFile(absPath, []byte(v3), "A", "a@test.com", "body change"); err != nil {
+		t.Fatalf("commit v3: %v", err)
+	}
+	head2, err := st.HeadHash()
+	if err != nil {
+		t.Fatalf("head hash 2: %v", err)
+	}
+	b3, err := st.DocumentBodyAtRef(head2, "documents/test/doc.md")
+	if err != nil {
+		t.Fatalf("body at HEAD2: %v", err)
+	}
+	if strings.TrimSpace(b1) == strings.TrimSpace(b3) {
+		t.Error("body change was not detected (bodies still equal)")
+	}
+
+	// A missing ref must error (the caller falls back to flagging on error).
+	if _, err := st.DocumentBodyAtRef("0000000000000000000000000000000000000000", "documents/test/doc.md"); err == nil {
+		t.Error("expected error for a non-existent ref, got nil")
+	}
+}

--- a/tests/test_needs_review_frontmatter.py
+++ b/tests/test_needs_review_frontmatter.py
@@ -1,0 +1,61 @@
+"""Regression for #3: changing a frontmatter metadata field (e.g. owner) must
+NOT mark an approved document as "changed since last approval" — only a change
+to the reviewed body should. The needs-review check used to compare the git
+commit hash, so a metadata-only edit (which still produces a commit) wrongly
+flagged the document for re-review.
+"""
+import requests
+from conftest import READER_EMAIL
+
+DOC = "needs-review-fm-test"
+BODY = "# Heading\n\nReviewed body content — a metadata edit must not re-flag this.\n"
+
+
+def _approve_and_merge(api_url, admin_headers, reader_headers, doc_id):
+    r = requests.post(f"{api_url}/documents/{doc_id}/reviews", headers=admin_headers,
+                      json={"reviewers": [READER_EMAIL], "message": "review"})
+    assert r.status_code in (200, 201), f"send for review: {r.text}"
+    rid = r.json()["review_id"]
+    r = requests.post(f"{api_url}/reviews/{rid}/approve", headers=reader_headers,
+                      json={"decision": "approved", "comment": "LGTM"})
+    assert r.status_code == 200, f"approve: {r.text}"
+    r = requests.post(f"{api_url}/reviews/{rid}/merge", headers=admin_headers, json={})
+    assert r.status_code == 200, f"merge: {r.text}"
+
+
+def _needs_review(api_url, admin_headers, doc_id):
+    r = requests.get(f"{api_url}/documents/needs-review", headers=admin_headers)
+    assert r.status_code == 200
+    return any(d["document_id"] == doc_id for d in r.json()["data"])
+
+
+class TestNeedsReviewIgnoresMetadata:
+    def test_owner_change_does_not_flag_but_body_change_does(self, api_url, admin_headers, reader_headers):
+        # 1. Create a document with real body content.
+        r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+            "folder": "iso27001", "filename": DOC + ".md",
+            "document_id": DOC, "title": "Needs Review FM", "content": BODY,
+        })
+        assert r.status_code in (200, 201, 409), r.text
+        requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers, json={"content": BODY})
+
+        # 2. Approve + merge → there is now an approved baseline.
+        _approve_and_merge(api_url, admin_headers, reader_headers, DOC)
+
+        # 3. Freshly approved: must NOT be in needs-review.
+        assert not _needs_review(api_url, admin_headers, DOC), "flagged immediately after approval"
+
+        # 4. Change ONLY a frontmatter metadata field (owner).
+        r = requests.put(f"{api_url}/documents/{DOC}/metadata", headers=admin_headers,
+                         json={"fields": {"owner": "someone-else@test.local"}})
+        assert r.status_code == 200, f"owner update: {r.text}"
+
+        # 5. THE FIX (#3): a metadata-only edit must NOT mark it changed-since-approval.
+        assert not _needs_review(api_url, admin_headers, DOC), \
+            "owner change wrongly flagged the document as needing review (#3)"
+
+        # 6. Sanity: a real body change DOES still flag it — detection isn't broken.
+        requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                     json={"content": BODY + "\nA new paragraph — a genuine content change.\n"})
+        assert _needs_review(api_url, admin_headers, DOC), \
+            "a real body change should flag needs-review"


### PR DESCRIPTION
Closes #3.

**Root cause** — `handleNeedsReview` compared the file's last commit hash to the approved commit ref. Changing a frontmatter field (e.g. `owner`) goes through `PUT /documents/:id/metadata`, which writes a new commit — so the commit moved ahead of the approved ref and the document was flagged "changed since last approval", even though the reviewed body never changed. (The diff panel in the screenshot already showed `0 removed / 0 added` — the body was identical; only the flag was wrong.)

**Fix** — when the commit is ahead of the approved ref, compare the document **body** (frontmatter stripped) at the approved ref vs current, and only flag a re-review if the body actually differs. Metadata-only edits (owner, author, version, classification, review_cycle) no longer trigger it. New store helper `DocumentBodyAtRef(ref, gitPath)`.

This is one source of truth (`/documents/needs-review`) feeding both the tree 'review required' dot and the doc Info 'Changed since last approval' prompt, so both are fixed.

**Test** — `tests/test_needs_review_frontmatter.py`: approve+merge a doc → not flagged; change owner → still not flagged (#3); change body → flagged (detection intact). Full backend+integration suite green (636).