### PR TITLE
fix: Needs Review cards are clickable (and unbreak openNeedsReviewDoc) (#18)

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1441,3 +1441,54 @@ class TestPrintPagination:
             assert pages > 1, f"long document printed only {pages} page(s) — content clipped to one viewport (#5)"
         finally:
             ctx.close()
+
+
+# ── Needs Review cards are clickable (regression #18) ──
+
+class TestNeedsReviewCardClickable:
+    def test_card_body_opens_the_document(self, pw_browser, tokens):
+        """In Documents → Needs Review, clicking the card body (not just the
+        small Review button) must open the document — matching the Inbox, where
+        the whole card is clickable. The card body used to have no click handler
+        despite a hover affordance (#18)."""
+        t = tokens["admin"]
+        doc = "e2e-nrcard"
+        content = "# Card click\n\nA never-approved doc to populate the Needs Review list.\n"
+        api("post", "/documents", t, json={
+            "folder": "iso27001", "filename": doc + ".md",
+            "document_id": doc, "title": "E2E NR Card", "content": content,
+        }, expect_status=[200, 201, 409])
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            click_sidebar(page, "Documents")
+            # Needs Review is the default tab; surface never-approved docs so our
+            # freshly created (unapproved) doc shows.
+            page.get_by_text("Include never approved").click()
+            # The card body is a role=button region containing the document id.
+            card = page.locator('[role="button"]').filter(has_text=doc).first
+            card.wait_for(state="visible", timeout=8000)
+            card.click()
+            # openNeedsReviewDoc selects the doc and opens the review modal.
+            expect(page.get_by_role("heading", name="Send for review")).to_be_visible(timeout=8000)
+        finally:
+            ctx.close()
+
+    def test_card_body_is_keyboard_accessible(self, pw_browser, tokens):
+        """The card body opens on Enter too (role=button + tabindex)."""
+        t = tokens["admin"]
+        doc = "e2e-nrcard"
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1])
+            click_sidebar(page, "Documents")
+            page.get_by_text("Include never approved").click()
+            card = page.locator('[role="button"]').filter(has_text=doc).first
+            card.wait_for(state="visible", timeout=8000)
+            card.focus()
+            card.press("Enter")
+            expect(page.get_by_role("heading", name="Send for review")).to_be_visible(timeout=8000)
+        finally:
+            ctx.close()

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1479,6 +1479,11 @@ class TestNeedsReviewCardClickable:
         """The card body opens on Enter too (role=button + tabindex)."""
         t = tokens["admin"]
         doc = "e2e-nrcard"
+        # Self-contained: don't depend on the click test having created the doc.
+        api("post", "/documents", t, json={
+            "folder": "iso27001", "filename": doc + ".md",
+            "document_id": doc, "title": "E2E NR Card", "content": "# Card click\n\nKeyboard-accessible card test.\n",
+        }, expect_status=[200, 201, 409])
         ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
         page = ctx.new_page()
         try:

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -201,9 +201,11 @@
             </div>
             <div v-else class="space-y-2">
               <div v-for="doc in needsReviewDocs" :key="doc.document_id"
-                class="bg-slate-900 border border-slate-800 rounded-lg p-4 hover:border-slate-700 transition-colors">
+                class="bg-slate-900 border border-slate-800 rounded-lg p-4">
                 <div class="flex items-start gap-3">
-                  <div class="flex-1 min-w-0 cursor-pointer rounded focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+                  <!-- Hover affordance lives on the clickable content region (not the
+                       whole card) so it tracks the actual click target — no dead zone. -->
+                  <div class="flex-1 min-w-0 cursor-pointer rounded px-2 py-1 -mx-2 -my-1 hover:bg-slate-800/40 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
                     role="button" tabindex="0"
                     @click="openNeedsReviewDoc(doc)"
                     @keydown.enter="openNeedsReviewDoc(doc)"
@@ -2089,9 +2091,7 @@ async function loadNeedsReview() {
 }
 
 function openNeedsReviewDoc(doc) {
-  // (No showNeedsReview flag — selecting the doc switches the view via activeId.
-  // The orphaned `showNeedsReview` reference here used to throw a ReferenceError,
-  // silently breaking both this card click and the Review button — #18.)
+  // showNeedsReview was removed; selecting the doc switches the view via activeId.
   if (doc.folder && doc.document_id) {
     const file = findFileInFolder(doc.folder, doc.document_id)
     if (file) {

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -203,7 +203,11 @@
               <div v-for="doc in needsReviewDocs" :key="doc.document_id"
                 class="bg-slate-900 border border-slate-800 rounded-lg p-4 hover:border-slate-700 transition-colors">
                 <div class="flex items-start gap-3">
-                  <div class="flex-1 min-w-0">
+                  <div class="flex-1 min-w-0 cursor-pointer rounded focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+                    role="button" tabindex="0"
+                    @click="openNeedsReviewDoc(doc)"
+                    @keydown.enter="openNeedsReviewDoc(doc)"
+                    @keydown.space.prevent="openNeedsReviewDoc(doc)">
                     <div class="flex items-center gap-2 mb-1">
                       <span class="text-sm font-medium text-blue-400">{{ doc.document_id }}</span>
                       <span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-800 text-slate-500">{{ doc.folder }}</span>
@@ -2085,7 +2089,9 @@ async function loadNeedsReview() {
 }
 
 function openNeedsReviewDoc(doc) {
-  showNeedsReview.value = false
+  // (No showNeedsReview flag — selecting the doc switches the view via activeId.
+  // The orphaned `showNeedsReview` reference here used to throw a ReferenceError,
+  // silently breaking both this card click and the Review button — #18.)
   if (doc.folder && doc.document_id) {
     const file = findFileInFolder(doc.folder, doc.document_id)
     if (file) {


### PR DESCRIPTION
Closes #18.

**The card** — in Documents → Needs Review, the card body had a hover affordance but no click handler; only the small **Review** button worked, unlike the Inbox where the whole card is clickable. Made the card's content region a keyboard-accessible `role=button` (`@click` + Enter/Space, focus ring) that opens the document, matching the Inbox. Review/Diff buttons stay separate (no nested-interactive a11y issue).

**The latent bug it surfaced** — a real-browser test showed `openNeedsReviewDoc` threw `ReferenceError: showNeedsReview is not defined` (an orphaned reference left after that flag was removed). It silently broke **both** the new card click **and** the existing Review button. Removed it — the view switches to the doc via `selectItem`/`activeId`.

**Test** — `TestNeedsReviewCardClickable`: click the card body and press Enter on it; both open the document (review modal). This is exactly the kind of runtime ReferenceError a real E2E run catches and a build/unit check doesn't. Full backend+E2E suite green (638).