### PR TITLE
fix(tasks): persist status from edit form + active-focused default view (#78, #79)

### DIFF
--- a/internal/isms/db/tasks.go
+++ b/internal/isms/db/tasks.go
@@ -281,7 +281,11 @@ func (d *DB) PaginatedTasks(ctx context.Context, orgID int, p TaskListParams) ([
 		args = append(args, "%"+p.Search+"%")
 		idx++
 	}
-	if p.Status != "" {
+	if p.Status == "active" {
+		// "active" is a filter pseudo-status: open + in_progress (the work that
+		// still needs attention), so done/cancelled don't clutter the default view.
+		where += ` AND t.status IN ('open','in_progress')`
+	} else if p.Status != "" {
 		where += fmt.Sprintf(` AND t.status = $%d`, idx)
 		args = append(args, p.Status)
 		idx++

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1497,3 +1497,55 @@ class TestNeedsReviewCardClickable:
             expect(page.get_by_role("heading", name="Send for review")).to_be_visible(timeout=8000)
         finally:
             ctx.close()
+
+
+class TestTaskEditStatusPersists:
+    """Editing a task's status in the detail form and saving must persist it.
+
+    Regression for the combined tasks-fix: the edit-form Save payload omitted
+    `status`, so changing it to Done and saving silently kept the task open. The
+    discriminating check is API-side — assert the server actually stored Done
+    after the UI save, not just that the local view updated. Also covers the
+    Active default view (#2): a done task must drop out of the default list.
+    """
+
+    def test_edit_status_to_done_persists_and_leaves_active_view(self, pw_browser, tokens):
+        t = tokens["admin"]
+        r = api("post", "/tasks", t, json={
+            "title": "E2E status-save task",
+            "task_type": "review",
+            "priority": "medium",
+            "assignee": ADMIN[0],
+        }, expect_status=[200, 201])
+        task_id = r.json()["id"]
+        assert r.json()["status"] == "open"
+
+        ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+        try:
+            do_login(page, ADMIN[0], ADMIN[1], then_goto=f"tasks/{task_id}")
+            # Detail view starts on the open task.
+            expect(page.get_by_text("E2E status-save task").first).to_be_visible(timeout=8000)
+            # Open the overview editor, flip status to Done, save.
+            page.get_by_role("button", name="Edit").first.click()
+            status_select = page.locator('label:has-text("Status") + select').first
+            status_select.wait_for(state="visible", timeout=5000)
+            status_select.select_option("done")
+            page.get_by_role("button", name="Save", exact=True).click()
+            # Save closes the editor (footer is v-if="editingSection").
+            expect(page.get_by_role("button", name="Save", exact=True)).to_have_count(0, timeout=8000)
+
+            # Discriminating check: the server stored Done (catches the omitted-status payload).
+            after = api("get", f"/tasks/{task_id}", t, expect_status=200).json()
+            assert after["status"] == "done", \
+                f"status did not persist through the edit-form save: {after['status']!r}"
+
+            # #2: a done task must not appear in the default (Active) list.
+            page.evaluate(
+                "() => document.querySelector('#app').__vue_app__.config.globalProperties"
+                f".$router.push('/{ORG}/tasks')"
+            )
+            page.wait_for_load_state("networkidle")
+            expect(page.get_by_text("E2E status-save task")).to_have_count(0, timeout=8000)
+        finally:
+            ctx.close()

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -1541,10 +1541,7 @@ class TestTaskEditStatusPersists:
                 f"status did not persist through the edit-form save: {after['status']!r}"
 
             # #2: a done task must not appear in the default (Active) list.
-            page.evaluate(
-                "() => document.querySelector('#app').__vue_app__.config.globalProperties"
-                f".$router.push('/{ORG}/tasks')"
-            )
+            page.goto(f"{BASE}/{ORG}/tasks")
             page.wait_for_load_state("networkidle")
             expect(page.get_by_text("E2E status-save task")).to_have_count(0, timeout=8000)
         finally:

--- a/tests/test_tasks_active_filter.py
+++ b/tests/test_tasks_active_filter.py
@@ -1,0 +1,60 @@
+"""Active-status filter for the task list (#79 default-view declutter).
+
+`?status=active` is a filter pseudo-status: open + in_progress (the work that
+still needs attention). done/cancelled are excluded so they don't clutter the
+default Tasks view. Regression cover for the combined tasks-fix PR.
+"""
+import requests
+from conftest import ADMIN_EMAIL
+
+# The list endpoint is paginated (default page_size 50) and the envelope is
+# {"data": [...], "total": ...}. Pull a large page so freshly-created tasks are
+# included regardless of the (priority ASC) default sort.
+BIG = {"limit": 2000}
+
+
+def _create(api_url, admin_headers, title):
+    r = requests.post(f"{api_url}/tasks", headers=admin_headers, json={
+        "title": title,
+        "task_type": "review",
+        "priority": "medium",
+        "assignee": ADMIN_EMAIL,
+    })
+    assert r.status_code in [200, 201], f"create failed: {r.text}"
+    return r.json()["id"]
+
+
+def _list(api_url, admin_headers, **params):
+    r = requests.get(f"{api_url}/tasks", headers=admin_headers, params={**BIG, **params})
+    assert r.status_code == 200, r.text
+    return r.json()["data"]
+
+
+class TestTaskActiveFilter:
+    def test_active_excludes_done_and_cancelled(self, api_url, admin_headers):
+        open_id = _create(api_url, admin_headers, "active-filter open task")
+        done_id = _create(api_url, admin_headers, "active-filter done task")
+        cancelled_id = _create(api_url, admin_headers, "active-filter cancelled task")
+
+        for tid, status in [(done_id, "done"), (cancelled_id, "cancelled")]:
+            r = requests.put(f"{api_url}/tasks/{tid}/status", headers=admin_headers,
+                             json={"status": status})
+            assert r.status_code == 200, f"status update failed: {r.text}"
+
+        ids = {t["id"] for t in _list(api_url, admin_headers, status="active")}
+        assert open_id in ids, "open task must appear in the active view"
+        assert done_id not in ids, "done task must be hidden from the active view"
+        assert cancelled_id not in ids, "cancelled task must be hidden from the active view"
+
+    def test_explicit_status_still_filters_exactly(self, api_url, admin_headers):
+        """The 'active' pseudo-status must not break a concrete status filter."""
+        done_id = _create(api_url, admin_headers, "explicit-done filter task")
+        r = requests.put(f"{api_url}/tasks/{done_id}/status", headers=admin_headers,
+                         json={"status": "done"})
+        assert r.status_code == 200, r.text
+
+        rows = _list(api_url, admin_headers, status="done")
+        assert all(t["status"] == "done" for t in rows), \
+            "?status=done must return only done tasks"
+        assert any(t["id"] == done_id for t in rows), \
+            "the just-completed task must appear under ?status=done"

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -488,7 +488,7 @@ const form = ref(defaultForm())
 
 const statusStats = computed(() => {
   return [
-    { key: 'active', label: 'Active', count: (stats.value.open || 0) + (stats.value.in_progress || 0), color: 'text-blue-300' },
+    { key: 'active', label: 'Active', count: (stats.value.open || 0) + (stats.value.in_progress || 0), color: 'text-indigo-400' },
     { key: '', label: 'Total', count: stats.value.total || 0, color: 'text-slate-100' },
     { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-blue-400' },
     { key: 'in_progress', label: 'In Progress', count: stats.value.in_progress || 0, color: 'text-amber-400' },

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -427,7 +427,13 @@ const renderMd = renderMarkdown
 
 const loading = ref(true)
 const tasks = ref([])
-const filterStatus = ref('')
+// Default to "active" (open + in_progress) so completed/cancelled tasks don't
+// clutter the working list; remember the user's choice across visits.
+const TASKS_FILTER_KEY = 'isms.tasks.filterStatus'
+const filterStatus = ref(localStorage.getItem(TASKS_FILTER_KEY) ?? 'active')
+watch(filterStatus, (v) => {
+  try { localStorage.setItem(TASKS_FILTER_KEY, v ?? '') } catch { /* storage unavailable */ }
+})
 const filterPriority = ref('')
 const filterTaskType = ref('')
 const filterAssignee = ref('')
@@ -482,6 +488,7 @@ const form = ref(defaultForm())
 
 const statusStats = computed(() => {
   return [
+    { key: 'active', label: 'Active', count: (stats.value.open || 0) + (stats.value.in_progress || 0), color: 'text-blue-300' },
     { key: '', label: 'Total', count: stats.value.total || 0, color: 'text-slate-100' },
     { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-blue-400' },
     { key: 'in_progress', label: 'In Progress', count: stats.value.in_progress || 0, color: 'text-amber-400' },
@@ -743,6 +750,7 @@ async function saveSection() {
       description: editForm.value.description,
       assignee: editForm.value.assignee,
       priority: editForm.value.priority,
+      status: editForm.value.status,
       task_type: editForm.value.task_type,
       notes: editForm.value.notes,
     }


### PR DESCRIPTION
Fixes both task issues from 0.6.2 in one PR.

## #78 — editing Status doesn't save (bug)
`saveSection` built its update payload from every field **except** `status`, so changing a task to Done in the edit form and saving silently kept it open. The backend (`handleUpdateTask`) already applied `status` when present — the fix is to actually send it.

## #79 — default view should focus on active work (enhancement)
- New `?status=active` **filter pseudo-status** = `open` + `in_progress`, handled in `db.ListTasks`. A concrete status filter (`?status=done`) still matches exactly.
- The filter now defaults to an **Active** pill and remembers the last choice in `localStorage`. Done/cancelled tasks stay one click away (Done / Total pills) — nothing is deleted or hidden permanently.

No migration required.

## Verification
- `tests/test_tasks_active_filter.py` — `?status=active` excludes done/cancelled, includes open; `?status=done` still returns only done.
- `TestTaskEditStatusPersists` (E2E) — drives the real edit form (Edit → Done → Save) and asserts **via the API** that the server stored Done (the discriminating check for the omitted-status payload bug), then that the done task drops out of the default Active list.
- Go unit + web build green; both new tests run against the live stack.

Closes #78
Closes #79