### PR TITLE
fix(mail): per-org sender name + links in tenant email — stop leaking the operator (#16)

### DIFF
--- a/internal/isms/api/api_auth.go
+++ b/internal/isms/api/api_auth.go
@@ -666,8 +666,8 @@ func (s *Server) handleInviteUser(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "email not configured (SMTP_HOST)")
 	}
 
-	baseURL := os.Getenv("ISMS_BASE_URL")
-	if err := s.mailer.SendVerification(req.Email, req.Name, baseURL, token); err != nil {
+	m := s.orgMail(ctx, orgID)
+	if err := s.mailer.SendVerificationBranded(req.Email, req.Name, m.PublicURL, token, m.Branding); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "sending email: "+err.Error())
 	}
 

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -363,8 +363,8 @@ func (s *Server) handleForwardReview(c echo.Context) error {
 
 		// Send email notification to reviewer
 		if s.mailer != nil && s.mailer.Enabled() {
-			baseURL := os.Getenv("ISMS_BASE_URL")
-			_ = s.mailer.SendReviewRequest(reviewer, reviewer, actor, review.DocumentID, review.Title, review.Version, baseURL, id, req.Message)
+			m := s.orgMail(ctx, orgID)
+			_ = s.mailer.SendReviewRequestBranded(reviewer, reviewer, actor, review.DocumentID, review.Title, review.Version, m.AppURL, id, req.Message, m.Branding)
 		}
 	}
 
@@ -970,8 +970,8 @@ func (s *Server) handleReviewApprove(c echo.Context) error {
 	} else {
 		// Normal flow: email the review author (human or mixed)
 		if s.mailer != nil && s.mailer.Enabled() {
-			baseURL := os.Getenv("ISMS_BASE_URL")
-			_ = s.mailer.SendReviewDecision(review.RequestedBy, review.RequestedBy, actor, review.DocumentID, review.Title, review.Version, req.Decision, baseURL)
+			m := s.orgMail(ctx, orgID)
+			_ = s.mailer.SendReviewDecisionBranded(review.RequestedBy, review.RequestedBy, actor, review.DocumentID, review.Title, review.Version, req.Decision, m.AppURL, m.Branding)
 		}
 	}
 
@@ -1959,8 +1959,8 @@ func (s *Server) handleCreateTask(c echo.Context) error {
 
 	// Email assignee if set
 	if t.Assignee != "" && s.mailer != nil && s.mailer.Enabled() {
-		baseURL := os.Getenv("ISMS_BASE_URL")
-		_ = s.mailer.SendTaskAssigned(t.Assignee, t.Assignee, t.CreatedBy, t.Title, t.Priority, baseURL)
+		m := s.orgMail(ctx, orgID)
+		_ = s.mailer.SendTaskAssignedBranded(t.Assignee, t.Assignee, t.CreatedBy, t.Title, t.Priority, m.AppURL, m.Branding)
 	}
 
 	return c.JSON(http.StatusCreated, t)
@@ -2565,8 +2565,8 @@ func (s *Server) createChangeFollowupTask(ctx context.Context, orgID int, update
 			if u, err := s.db.GetUserByEmail(ctx, assignee); err == nil && u != nil && u.Name != "" {
 				displayName = u.Name
 			}
-			baseURL := os.Getenv("ISMS_BASE_URL")
-			_ = s.mailer.SendTaskAssigned(assignee, displayName, actor, t.Title, t.Priority, baseURL)
+			m := s.orgMail(ctx, orgID)
+			_ = s.mailer.SendTaskAssignedBranded(assignee, displayName, actor, t.Title, t.Priority, m.AppURL, m.Branding)
 		}
 	}
 }
@@ -3552,8 +3552,8 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 					fmt.Sprintf("Review resubmitted: %s", title),
 					notifBody, fmt.Sprintf("/reviews/%d", existingReview.ID))
 				if s.mailer != nil && s.mailer.Enabled() {
-					baseURL := os.Getenv("ISMS_BASE_URL")
-					_ = s.mailer.SendReviewRequest(a.Reviewer, a.Reviewer, actor, docID, title, version, baseURL, existingReview.ID, req.Message)
+				m := s.orgMail(ctx, orgID)
+				_ = s.mailer.SendReviewRequestBranded(a.Reviewer, a.Reviewer, actor, docID, title, version, m.AppURL, existingReview.ID, req.Message, m.Branding)
 				}
 			}
 			s.logAndNotify(ctx, orgID, &db.Activity{
@@ -3593,8 +3593,8 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 				fmt.Sprintf("Review: %s v%s", title, version),
 				notifBody, fmt.Sprintf("/reviews/%d", existingReview.ID))
 			if s.mailer != nil && s.mailer.Enabled() {
-				baseURL := os.Getenv("ISMS_BASE_URL")
-				_ = s.mailer.SendReviewRequest(reviewer, reviewer, actor, docID, title, version, baseURL, existingReview.ID, req.Message)
+				m := s.orgMail(ctx, orgID)
+				_ = s.mailer.SendReviewRequestBranded(reviewer, reviewer, actor, docID, title, version, m.AppURL, existingReview.ID, req.Message, m.Branding)
 			}
 		}
 		s.logAndNotify(ctx, orgID, &db.Activity{
@@ -3659,8 +3659,8 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 
 		// Send email notification to reviewer
 		if s.mailer != nil && s.mailer.Enabled() {
-			baseURL := os.Getenv("ISMS_BASE_URL")
-			_ = s.mailer.SendReviewRequest(reviewer, reviewer, actor, docID, title, version, baseURL, review.ID, req.Message)
+			m := s.orgMail(ctx, orgID)
+			_ = s.mailer.SendReviewRequestBranded(reviewer, reviewer, actor, docID, title, version, m.AppURL, review.ID, req.Message, m.Branding)
 		}
 	}
 

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -3543,6 +3543,10 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 			}
 			// Notify all assigned reviewers about the resubmission.
 			allAssignments, _ := s.db.ListAssignmentsForReview(ctx, orgID, existingReview.ID)
+			var m orgMailCtx
+			if s.mailer != nil && s.mailer.Enabled() {
+				m = s.orgMail(ctx, orgID)
+			}
 			for _, a := range allAssignments {
 				notifBody := fmt.Sprintf("%s resubmitted %s (%s v%s) for review", actor, docID, title, version)
 				if req.Message != "" {
@@ -3552,8 +3556,7 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 					fmt.Sprintf("Review resubmitted: %s", title),
 					notifBody, fmt.Sprintf("/reviews/%d", existingReview.ID))
 				if s.mailer != nil && s.mailer.Enabled() {
-				m := s.orgMail(ctx, orgID)
-				_ = s.mailer.SendReviewRequestBranded(a.Reviewer, a.Reviewer, actor, docID, title, version, m.AppURL, existingReview.ID, req.Message, m.Branding)
+					_ = s.mailer.SendReviewRequestBranded(a.Reviewer, a.Reviewer, actor, docID, title, version, m.AppURL, existingReview.ID, req.Message, m.Branding)
 				}
 			}
 			s.logAndNotify(ctx, orgID, &db.Activity{

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -166,9 +166,9 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 			fmt.Sprintf("Corrective action assigned: %s", ca.Title),
 			ca.Description, "/corrective-actions")
 		if s.mailer.Enabled() {
-			s.mailer.Send(ca.Assignee,
-				fmt.Sprintf("ISMS Corrective Action: %s", ca.Title),
-				ca.Description)
+			s.mailer.SendBranded(ca.Assignee,
+				fmt.Sprintf("Corrective Action: %s", ca.Title),
+				ca.Description, s.orgMail(ctx, orgID).Branding)
 		}
 	}
 

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -237,9 +237,9 @@ func (s *Server) handleCreateIncident(c echo.Context) error {
 
 	// Email assignee if set
 	if inc.Assignee != "" && s.mailer.Enabled() {
-		s.mailer.Send(inc.Assignee,
-			fmt.Sprintf("ISMS Incident [%s]: %s", strings.ToUpper(inc.Severity), inc.Title),
-			inc.Description)
+		s.mailer.SendBranded(inc.Assignee,
+			fmt.Sprintf("Incident [%s]: %s", strings.ToUpper(inc.Severity), inc.Title),
+			inc.Description, s.orgMail(ctx, orgID).Branding)
 	}
 
 	return c.JSON(http.StatusCreated, inc)

--- a/internal/isms/api/orgurls_test.go
+++ b/internal/isms/api/orgurls_test.go
@@ -13,11 +13,11 @@ func ptr(s string) *string { return &s }
 // public pages (verify-email, login) are never mounted under /:org.
 func TestOrgURLs(t *testing.T) {
 	cases := []struct {
-		name           string
-		base           string
-		org            *db.Organization
-		wantApp        string
-		wantPublic     string
+		name       string
+		base       string
+		org        *db.Organization
+		wantApp    string
+		wantPublic string
 	}{
 		{
 			name:       "subdomain host: org becomes the subdomain for both",

--- a/internal/isms/api/orgurls_test.go
+++ b/internal/isms/api/orgurls_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"testing"
+
+	"isms.sh/internal/isms/db"
+)
+
+func ptr(s string) *string { return &s }
+
+// orgURLs must build links into the tenant's own space — never a flat shared
+// base — matching the SPA router: org-scoped pages carry the slug/subdomain,
+// public pages (verify-email, login) are never mounted under /:org.
+func TestOrgURLs(t *testing.T) {
+	cases := []struct {
+		name           string
+		base           string
+		org            *db.Organization
+		wantApp        string
+		wantPublic     string
+	}{
+		{
+			name:       "subdomain host: org becomes the subdomain for both",
+			base:       "https://isms.sh",
+			org:        &db.Organization{Slug: "sts"},
+			wantApp:    "https://sts.isms.sh",
+			wantPublic: "https://sts.isms.sh",
+		},
+		{
+			name:       "path-based host: app carries the slug, public does not",
+			base:       "http://localhost:9090",
+			org:        &db.Organization{Slug: "sts"},
+			wantApp:    "http://localhost:9090/sts",
+			wantPublic: "http://localhost:9090",
+		},
+		{
+			name:       "custom domain wins for both app and public",
+			base:       "https://isms.sh",
+			org:        &db.Organization{Slug: "sts", Domain: ptr("audit.sts.is")},
+			wantApp:    "https://audit.sts.is",
+			wantPublic: "https://audit.sts.is",
+		},
+		{
+			name:       "custom domain with explicit scheme is preserved",
+			base:       "https://isms.sh",
+			org:        &db.Organization{Slug: "sts", Domain: ptr("https://audit.sts.is/")},
+			wantApp:    "https://audit.sts.is",
+			wantPublic: "https://audit.sts.is",
+		},
+		{
+			name:       "www is stripped from the apex",
+			base:       "https://www.isms.sh",
+			org:        &db.Organization{Slug: "sts"},
+			wantApp:    "https://sts.isms.sh",
+			wantPublic: "https://sts.isms.sh",
+		},
+		{
+			name:       "port is preserved on the subdomain",
+			base:       "https://isms.sh:8443",
+			org:        &db.Organization{Slug: "sts"},
+			wantApp:    "https://sts.isms.sh:8443",
+			wantPublic: "https://sts.isms.sh:8443",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app, public := orgURLs(tc.base, tc.org)
+			if app != tc.wantApp {
+				t.Errorf("app = %q, want %q", app, tc.wantApp)
+			}
+			if public != tc.wantPublic {
+				t.Errorf("public = %q, want %q", public, tc.wantPublic)
+			}
+		})
+	}
+}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -65,6 +65,84 @@ type Server struct {
 
 // storeForOrg returns (or creates and caches) a store for the given organization.
 // Uses LoadOrStore to prevent duplicate Store creation under concurrent requests.
+// orgMailCtx carries everything an email needs to address a tenant correctly:
+// the brand (sender name + color) and the org's own base URLs for links.
+type orgMailCtx struct {
+	Branding mail.Branding
+	// AppURL is the base for in-app, org-scoped pages (e.g. /reviews/123): a
+	// tenant subdomain/custom domain, or <base>/<slug> on path-based hosts.
+	AppURL string
+	// PublicURL is the base for public pages (e.g. /verify-email), which are
+	// never mounted under /:org: a tenant subdomain/custom domain, or the bare
+	// <base> on path-based hosts.
+	PublicURL string
+}
+
+// orgMail resolves the per-org email context (brand + link bases). It falls back
+// to neutral defaults — the bare ISMS_BASE_URL and an "ISMS" brand — so a
+// tenant's mail never carries another org's identity, the operator's SMTP_FROM
+// display name (#16 sender leak), or a link into the wrong org.
+func (s *Server) orgMail(ctx context.Context, orgID int) orgMailCtx {
+	raw := strings.TrimRight(os.Getenv("ISMS_BASE_URL"), "/")
+	m := orgMailCtx{AppURL: raw, PublicURL: raw}
+	org, err := s.db.GetOrganization(ctx, orgID)
+	if err != nil || org == nil {
+		return m
+	}
+	m.Branding.Name = org.Name
+	if color, err := s.db.GetOrgSetting(ctx, orgID, "branding_color"); err == nil {
+		m.Branding.Color = color
+	}
+	m.AppURL, m.PublicURL = orgURLs(raw, org)
+	return m
+}
+
+// orgURLs returns the per-org base URLs for in-app (org-scoped) pages and for
+// public pages, mirroring the SPA router's mounting rules:
+//   - custom domain:  https://<domain> for both
+//   - subdomain host: https://<slug>.<apex> for both (the org IS the host)
+//   - path-based:     <base>/<slug> for app pages, <base> for public pages
+//
+// The subdomain-vs-path decision uses the same heuristic as the post-OIDC
+// redirect (orgTokenRedirectURL): a dotted, non-localhost, non-IP host can serve
+// per-org subdomains.
+func orgURLs(baseURL string, org *db.Organization) (app, public string) {
+	if org.Domain != nil && *org.Domain != "" {
+		d := *org.Domain
+		if !strings.Contains(d, "://") {
+			scheme := "https"
+			if strings.HasPrefix(baseURL, "http://") {
+				scheme = "http"
+			}
+			d = scheme + "://" + d
+		}
+		d = strings.TrimRight(d, "/")
+		return d, d
+	}
+	const sep = "://"
+	i := strings.Index(baseURL, sep)
+	if i < 0 {
+		return baseURL, baseURL
+	}
+	scheme := baseURL[:i]
+	hostAndPort := baseURL[i+len(sep):]
+	host := hostAndPort
+	port := ""
+	if c := strings.LastIndex(hostAndPort, ":"); c > 0 {
+		host = hostAndPort[:c]
+		port = hostAndPort[c:] // includes ':'
+	}
+	canSubdomain := strings.Contains(host, ".") &&
+		!strings.HasPrefix(host, "localhost") &&
+		!isIPLiteral(host)
+	if canSubdomain {
+		apex := strings.TrimPrefix(host, "www.")
+		sub := fmt.Sprintf("%s://%s.%s%s", scheme, org.Slug, apex, port)
+		return sub, sub
+	}
+	return baseURL + "/" + org.Slug, baseURL
+}
+
 func (s *Server) storeForOrg(ctx context.Context, orgID int) (*store.Store, error) {
 	if v, ok := s.stores.Load(orgID); ok {
 		return v.(*store.Store), nil

--- a/internal/isms/mail/mail.go
+++ b/internal/isms/mail/mail.go
@@ -242,8 +242,10 @@ func (m *Mailer) SendTaskAssignedBranded(to, assigneeName, actor, taskTitle, pri
 	return m.sendAs(to, fmt.Sprintf("%s — Task assigned: %s", b.name(), taskTitle), body, b.name())
 }
 
-// SendOTPCode sends a one-time login code via email (magic link alternative).
-func (m *Mailer) SendOTPCode(to, name, code string) error {
+// SendOTPCode sends a one-time login code via email (magic link alternative),
+// branded with the org so the From display name is the tenant's, not the
+// operator's SMTP_FROM identity — consistent with every other Send* here.
+func (m *Mailer) SendOTPCode(to, name, code string, b Branding) error {
 	body := fmt.Sprintf(`<div style="font-family: sans-serif; max-width: 500px; margin: 0 auto;">
 <h2>Login Code</h2>
 <p>Hi %s,</p>
@@ -252,5 +254,5 @@ func (m *Mailer) SendOTPCode(to, name, code string) error {
 <p style="color: #666; font-size: 12px;">This code expires in 10 minutes.</p>
 </div>`, name, code)
 
-	return m.Send(to, "Login code", body)
+	return m.sendAs(to, fmt.Sprintf("%s — Login code", b.name()), body, b.name())
 }

--- a/internal/isms/mail/mail.go
+++ b/internal/isms/mail/mail.go
@@ -59,25 +59,51 @@ func (b Branding) name() string {
 	return "ISMS"
 }
 
-// Send sends an email.
+// resolveFrom builds the From header and the SMTP envelope sender.
+//
+// SMTP_FROM may be a bare email (`noreply@host`) or `"Display Name" <addr@host>`.
+// The envelope sender (MAIL FROM) must always be the bare address — Postmark and
+// most SMTP servers reject envelope senders with display-name syntax.
+//
+// When fromName is set it overrides the SMTP_FROM display name with the per-org
+// brand while keeping the configured envelope address, so a tenant's mail shows
+// the tenant's own name in the inbox — never the operator's SMTP_FROM display
+// name (the multi-tenant sender leak this guards against). The envelope address
+// is unchanged, so SPF/DKIM alignment is preserved.
+func resolveFrom(configFrom, fromName string) (header, envelope string) {
+	envelope = configFrom
+	if strings.Contains(configFrom, "<") {
+		if parsed, err := netmail.ParseAddress(configFrom); err == nil {
+			envelope = parsed.Address
+		}
+	}
+	if fromName == "" {
+		return configFrom, envelope
+	}
+	// Address.String() quotes the display name and RFC 2047-encodes it when it
+	// contains non-ASCII (org names like "Þórð ehf"), so the header stays valid.
+	return (&netmail.Address{Name: fromName, Address: envelope}).String(), envelope
+}
+
+// Send sends an email using the configured SMTP_FROM as-is.
 func (m *Mailer) Send(to, subject, body string) error {
+	return m.sendAs(to, subject, body, "")
+}
+
+// SendBranded sends an email with the org brand as the From display name, so the
+// recipient sees the tenant's name rather than the operator's SMTP_FROM identity.
+func (m *Mailer) SendBranded(to, subject, body string, b Branding) error {
+	return m.sendAs(to, subject, body, b.name())
+}
+
+// sendAs sends an email, overriding the From display name with fromName when set.
+func (m *Mailer) sendAs(to, subject, body, fromName string) error {
 	if m == nil {
 		return fmt.Errorf("mailer not configured")
 	}
 
 	addr := net.JoinHostPort(m.config.Host, m.config.Port)
-
-	// SMTP_FROM may be either a bare email or `"Display Name" <addr@host>`.
-	// The header takes the full string; the SMTP envelope sender (MAIL FROM)
-	// must be the bare address only — Postmark and most SMTP servers reject
-	// envelope senders with display-name syntax.
-	fromHeader := m.config.From
-	envelopeFrom := m.config.From
-	if strings.Contains(m.config.From, "<") {
-		if parsed, err := netmail.ParseAddress(m.config.From); err == nil {
-			envelopeFrom = parsed.Address
-		}
-	}
+	fromHeader, envelopeFrom := resolveFrom(m.config.From, fromName)
 
 	msg := strings.Join([]string{
 		"From: " + fromHeader,
@@ -115,7 +141,7 @@ func (m *Mailer) SendVerificationBranded(to, name, baseURL, token string, b Bran
 <p style="color: #666; font-size: 12px;">This link expires in 72 hours.</p>
 </div>`, b.name(), name, link, b.color(), link)
 
-	return m.Send(to, fmt.Sprintf("%s — Verify your email", b.name()), body)
+	return m.sendAs(to, fmt.Sprintf("%s — Verify your email", b.name()), body, b.name())
 }
 
 // SendPasswordReset sends a password reset link. The same flow also activates
@@ -138,7 +164,7 @@ func (m *Mailer) SendPasswordResetBranded(to, name, baseURL, token string, b Bra
 <p style="color: #666; font-size: 12px;">If you didn't request a password reset, you can safely ignore this email.</p>
 </div>`, b.name(), name, link, b.color(), link)
 
-	return m.Send(to, fmt.Sprintf("%s — Reset your password", b.name()), body)
+	return m.sendAs(to, fmt.Sprintf("%s — Reset your password", b.name()), body, b.name())
 }
 
 // SendReviewRequest notifies a reviewer that their review has been requested.
@@ -165,7 +191,7 @@ func (m *Mailer) SendReviewRequestBranded(to, reviewerName, actor, docID, title,
 <p>Or copy this link: %s</p>
 </div>`, reviewerName, actor, docID, title, version, note, link, b.color(), link)
 
-	return m.Send(to, fmt.Sprintf("%s — Review requested: %s v%s", b.name(), docID, version), body)
+	return m.sendAs(to, fmt.Sprintf("%s — Review requested: %s v%s", b.name(), docID, version), body, b.name())
 }
 
 // SendReviewDecision notifies the document author that a review was approved or rejected.
@@ -192,7 +218,7 @@ func (m *Mailer) SendReviewDecisionBranded(to, authorName, reviewer, docID, titl
 <p><a href="%s" style="display: inline-block; padding: 12px 24px; background: %s; color: white; text-decoration: none; border-radius: 6px;">View Document</a></p>
 </div>`, color, icon, authorName, reviewer, color, icon, docID, title, version, link, b.color())
 
-	return m.Send(to, fmt.Sprintf("%s — Review %s: %s v%s", b.name(), icon, docID, version), body)
+	return m.sendAs(to, fmt.Sprintf("%s — Review %s: %s v%s", b.name(), icon, docID, version), body, b.name())
 }
 
 // SendTaskAssigned notifies an assignee about a new task.
@@ -213,7 +239,7 @@ func (m *Mailer) SendTaskAssignedBranded(to, assigneeName, actor, taskTitle, pri
 <p><a href="%s" style="display: inline-block; padding: 12px 24px; background: %s; color: white; text-decoration: none; border-radius: 6px;">View Tasks</a></p>
 </div>`, assigneeName, actor, taskTitle, priority, link, b.color())
 
-	return m.Send(to, fmt.Sprintf("%s — Task assigned: %s", b.name(), taskTitle), body)
+	return m.sendAs(to, fmt.Sprintf("%s — Task assigned: %s", b.name(), taskTitle), body, b.name())
 }
 
 // SendOTPCode sends a one-time login code via email (magic link alternative).

--- a/internal/isms/mail/mail_test.go
+++ b/internal/isms/mail/mail_test.go
@@ -1,0 +1,90 @@
+package mail
+
+import (
+	netmail "net/mail"
+	"strings"
+	"testing"
+)
+
+// resolveFrom is the guard against the multi-tenant sender leak (#16): a tenant's
+// email must show the tenant's brand in the From display name, never the
+// operator's SMTP_FROM display name — while the envelope address (SPF/DKIM)
+// stays the configured sender.
+func TestResolveFrom(t *testing.T) {
+	const addr = "noreply@isms.sh"
+
+	t.Run("no brand keeps SMTP_FROM verbatim", func(t *testing.T) {
+		configFrom := `"CommandVector" <` + addr + `>`
+		header, envelope := resolveFrom(configFrom, "")
+		if header != configFrom {
+			t.Errorf("header = %q, want unchanged %q", header, configFrom)
+		}
+		if envelope != addr {
+			t.Errorf("envelope = %q, want bare %q", envelope, addr)
+		}
+	})
+
+	t.Run("brand overrides the operator display name", func(t *testing.T) {
+		// The operator's SMTP_FROM carries their own brand; a tenant must not see it.
+		configFrom := `"CommandVector" <` + addr + `>`
+		header, envelope := resolveFrom(configFrom, "STS Audit ehf")
+
+		if strings.Contains(header, "CommandVector") {
+			t.Fatalf("LEAK: operator display name present in tenant From header: %q", header)
+		}
+		if envelope != addr {
+			t.Errorf("envelope = %q, want bare %q (SPF/DKIM alignment)", envelope, addr)
+		}
+		// Round-trip: the header must parse back to the tenant brand + the
+		// configured envelope address, regardless of quoting details.
+		parsed, err := netmail.ParseAddress(header)
+		if err != nil {
+			t.Fatalf("From header does not parse: %q: %v", header, err)
+		}
+		if parsed.Name != "STS Audit ehf" {
+			t.Errorf("display name = %q, want %q", parsed.Name, "STS Audit ehf")
+		}
+		if parsed.Address != addr {
+			t.Errorf("address = %q, want %q", parsed.Address, addr)
+		}
+	})
+
+	t.Run("bare SMTP_FROM gains the brand display name", func(t *testing.T) {
+		header, envelope := resolveFrom(addr, "Acme Corp")
+		if envelope != addr {
+			t.Errorf("envelope = %q, want %q", envelope, addr)
+		}
+		parsed, err := netmail.ParseAddress(header)
+		if err != nil {
+			t.Fatalf("From header does not parse: %q: %v", header, err)
+		}
+		if parsed.Name != "Acme Corp" || parsed.Address != addr {
+			t.Errorf("parsed = %q <%q>, want %q <%q>", parsed.Name, parsed.Address, "Acme Corp", addr)
+		}
+	})
+
+	t.Run("non-ASCII brand stays a valid encoded header", func(t *testing.T) {
+		header, _ := resolveFrom(addr, "Þórð slf")
+		if strings.Contains(header, "Þórð") {
+			t.Errorf("non-ASCII name must be RFC 2047 encoded, got raw bytes: %q", header)
+		}
+		parsed, err := netmail.ParseAddress(header)
+		if err != nil {
+			t.Fatalf("encoded From header does not parse: %q: %v", header, err)
+		}
+		if parsed.Name != "Þórð slf" {
+			t.Errorf("decoded display name = %q, want %q", parsed.Name, "Þórð slf")
+		}
+	})
+}
+
+// SendBranded with an empty Branding must fall back to the neutral platform name
+// ("ISMS"), never the operator's SMTP_FROM display name.
+func TestBrandingNameFallback(t *testing.T) {
+	if got := (Branding{}).name(); got != "ISMS" {
+		t.Errorf("empty Branding.name() = %q, want %q", got, "ISMS")
+	}
+	if got := (Branding{Name: "STS"}).name(); got != "STS" {
+		t.Errorf("Branding.name() = %q, want %q", got, "STS")
+	}
+}


### PR DESCRIPTION
Tenant email leaked the platform operator's identity **two** ways. One fix for both.

## 1. Sender name
Every tenant email went out with the operator's `SMTP_FROM` display name (e.g. **"CommandVector"**) in `From:`. STS saw the operator as the sender.
- **`resolveFrom`** overrides the From *display name* with the org brand, keeping the configured **envelope address** unchanged — SPF/DKIM alignment preserved (display names are cosmetic; the authenticated address stays the platform sender). The `noreply@…` address is the one thing we don't change.
- Unbranded paths (self-service signup, password reset — no single clear org) fall back to neutral **"ISMS"**, never the operator name. Leak closed structurally everywhere.

## 2. Links
Emails linked to a flat `ISMS_BASE_URL`, landing recipients on the apex / wrong org. We **know** the org, so we link into its own space.
- **`Server.orgMail`** resolves each org's brand + base URLs in one place. **`orgURLs`** mirrors the SPA router:
  - custom domain → `https://<domain>`
  - subdomain host → `https://<slug>.<apex>` (same heuristic the OIDC post-login redirect already uses)
  - path-based → `<base>/<slug>` for org-scoped pages; `<base>` for public pages (`verify-email`/`login` are never mounted under `/:org`)
- Review / decision / task / corrective / incident links use the org-scoped base; member-invite verification uses the public base.

## Verification
- `mail/mail_test.go::TestResolveFrom` — operator display name **never** in a tenant From header (`LEAK:` guard); brand in display; envelope bare (SPF/DKIM); non-ASCII org names (e.g. "Þórð slf") RFC 2047-encoded + round-trip.
- `api/orgurls_test.go::TestOrgURLs` — custom domain / subdomain / path-based, www-strip, port preservation, and the app-vs-public slug rule.
- Full Go unit + integration suite green. (Email isn't exercised by integration tests — no SMTP catcher in the test env — so these unit tests are the durable regression.)

No migration. Out of scope: a mail-catcher (mailpit) integration test that would assert a full rendered From + link end-to-end — a small devenv addition, worth a follow-up.

Closes #16