### PR TITLE
fix(cli): stop dropping declared flags — audit --summary + add-command relations (#49, #52; +#19 test)

### DIFF
--- a/cmd/isms/audit.go
+++ b/cmd/isms/audit.go
@@ -404,7 +404,14 @@ func auditCompleteCmd() *cobra.Command {
 			}
 
 			c := requireAPI()
-			if err := c.UpdateAuditStatus(id, "completed"); err != nil {
+			// Send the auditor summary alongside the status transition. The
+			// update endpoint routes the status change through UpdateAuditStatus
+			// and persists the summary in the same call — previously the
+			// (required) --summary flag was collected and silently dropped (#49).
+			if _, err := c.UpdateAudit(id, map[string]interface{}{
+				"status":  "completed",
+				"summary": summary,
+			}); err != nil {
 				return err
 			}
 			fmt.Printf("Audit #%d completed.\n", id)

--- a/cmd/isms/audit.go
+++ b/cmd/isms/audit.go
@@ -404,10 +404,7 @@ func auditCompleteCmd() *cobra.Command {
 			}
 
 			c := requireAPI()
-			// Send the auditor summary alongside the status transition. The
-			// update endpoint routes the status change through UpdateAuditStatus
-			// and persists the summary in the same call — previously the
-			// (required) --summary flag was collected and silently dropped (#49).
+			// summary was silently dropped before #49; send it atomically with status.
 			if _, err := c.UpdateAudit(id, map[string]interface{}{
 				"status":  "completed",
 				"summary": summary,

--- a/cmd/isms/cli_relations_test.go
+++ b/cmd/isms/cli_relations_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// recordedReq captures one outbound CLI API call.
+type recordedReq struct {
+	method string
+	path   string
+	body   map[string]interface{}
+}
+
+// cliServer spins an httptest server that records every request body and replies
+// with a minimal JSON object the client can unmarshal. Returns the recorder.
+func cliServer(t *testing.T) (*httptest.Server, *[]recordedReq) {
+	t.Helper()
+	var got []recordedReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]interface{}
+		_ = json.Unmarshal(raw, &body)
+		got = append(got, recordedReq{method: r.Method, path: r.URL.Path, body: body})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"identifier":"X-001","title":"x"}`))
+	}))
+	t.Setenv("ISMS_API_URL", srv.URL)
+	t.Setenv("ISMS_API_KEY", "test-token")
+	return srv, &got
+}
+
+// refSet extracts the {type:[ids]} relations from a recorded create body.
+func refSet(t *testing.T, body map[string]interface{}) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	refs, ok := body["references"].([]interface{})
+	if !ok {
+		return out
+	}
+	for _, r := range refs {
+		m := r.(map[string]interface{})
+		typ, _ := m["type"].(string)
+		id, _ := m["id"].(string)
+		out[typ] = append(out[typ], id)
+	}
+	return out
+}
+
+func TestBuildRefs(t *testing.T) {
+	got := buildRefs(
+		refSpec{"risk", []string{"RISK-1", " RISK-2 ", ""}},
+		refSpec{"asset", []string{"A-1"}},
+		refSpec{"system", nil},
+	)
+	want := []client_Reference{
+		{"risk", "RISK-1"}, {"risk", "RISK-2"}, {"asset", "A-1"},
+	}
+	if !reflect.DeepEqual(toPlain(got), want) {
+		t.Errorf("buildRefs = %+v, want %+v", toPlain(got), want)
+	}
+}
+
+// client_Reference / toPlain decouple the assertion from the client package's
+// import path while still comparing type+id.
+type client_Reference struct{ Type, ID string }
+
+func toPlain(refs interface{}) []client_Reference {
+	v := reflect.ValueOf(refs)
+	out := make([]client_Reference, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		e := v.Index(i)
+		out = append(out, client_Reference{
+			Type: e.FieldByName("Type").String(),
+			ID:   e.FieldByName("ID").String(),
+		})
+	}
+	return out
+}
+
+// #49: `audit complete` must send the (required) --summary, not silently drop it.
+func TestAuditCompleteSendsSummary(t *testing.T) {
+	_, got := cliServer(t)
+	cmd := auditCmd()
+	cmd.SetArgs([]string{"complete", "5", "--summary", "Quarterly audit closed"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(*got) == 0 {
+		t.Fatal("no request sent")
+	}
+	last := (*got)[len(*got)-1]
+	if last.body["summary"] != "Quarterly audit closed" {
+		t.Errorf("summary not sent: body=%v", last.body)
+	}
+	if last.body["status"] != "completed" {
+		t.Errorf("status not sent: body=%v", last.body)
+	}
+}
+
+// #52: `incident add` must send its declared relation flags as references.
+func TestIncidentAddSendsRelations(t *testing.T) {
+	_, got := cliServer(t)
+	cmd := incidentCmd()
+	cmd.SetArgs([]string{"add", "--title", "Phish", "--description", "phishing wave",
+		"--severity", "high",
+		"--risks", "RISK-1,RISK-2", "--assets", "A-1", "--systems", "SYS-9"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	refs := refSet(t, (*got)[0].body)
+	for typ, want := range map[string][]string{
+		"risk": {"RISK-1", "RISK-2"}, "asset": {"A-1"}, "system": {"SYS-9"}} {
+		if !reflect.DeepEqual(refs[typ], want) {
+			t.Errorf("%s refs = %v, want %v (full=%v)", typ, refs[typ], want, refs)
+		}
+	}
+}
+
+// #52: `risk add` must send --assets and --documents as references.
+func TestRiskAddSendsRelations(t *testing.T) {
+	_, got := cliServer(t)
+	cmd := riskCmd()
+	cmd.SetArgs([]string{"add", "--title", "R", "--owner", "o@x.io",
+		"--likelihood", "3", "--impact", "4",
+		"--assets", "A-1,A-2", "--documents", "iso27001-5-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	refs := refSet(t, (*got)[0].body)
+	if !reflect.DeepEqual(refs["asset"], []string{"A-1", "A-2"}) {
+		t.Errorf("asset refs = %v (full=%v)", refs["asset"], refs)
+	}
+	if !reflect.DeepEqual(refs["document"], []string{"iso27001-5-1"}) {
+		t.Errorf("document refs = %v (full=%v)", refs["document"], refs)
+	}
+}
+
+// #52: `legal add` must send --documents as references.
+func TestLegalAddSendsRelations(t *testing.T) {
+	_, got := cliServer(t)
+	cmd := legalCmd()
+	cmd.SetArgs([]string{"add", "--title", "GDPR", "--documents", "iso27001-18-1,iso27001-18-2"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	refs := refSet(t, (*got)[0].body)
+	if !reflect.DeepEqual(refs["document"], []string{"iso27001-18-1", "iso27001-18-2"}) {
+		t.Errorf("document refs = %v (full=%v)", refs["document"], refs)
+	}
+}

--- a/cmd/isms/cli_relations_test.go
+++ b/cmd/isms/cli_relations_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"isms.sh/internal/isms/client"
 )
 
 // recordedReq captures one outbound CLI API call.
@@ -57,34 +59,18 @@ func TestBuildRefs(t *testing.T) {
 		refSpec{"asset", []string{"A-1"}},
 		refSpec{"system", nil},
 	)
-	want := []client_Reference{
-		{"risk", "RISK-1"}, {"risk", "RISK-2"}, {"asset", "A-1"},
+	want := []client.Reference{
+		{Type: "risk", ID: "RISK-1"}, {Type: "risk", ID: "RISK-2"}, {Type: "asset", ID: "A-1"},
 	}
-	if !reflect.DeepEqual(toPlain(got), want) {
-		t.Errorf("buildRefs = %+v, want %+v", toPlain(got), want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildRefs = %+v, want %+v", got, want)
 	}
-}
-
-// client_Reference / toPlain decouple the assertion from the client package's
-// import path while still comparing type+id.
-type client_Reference struct{ Type, ID string }
-
-func toPlain(refs interface{}) []client_Reference {
-	v := reflect.ValueOf(refs)
-	out := make([]client_Reference, 0, v.Len())
-	for i := 0; i < v.Len(); i++ {
-		e := v.Index(i)
-		out = append(out, client_Reference{
-			Type: e.FieldByName("Type").String(),
-			ID:   e.FieldByName("ID").String(),
-		})
-	}
-	return out
 }
 
 // #49: `audit complete` must send the (required) --summary, not silently drop it.
 func TestAuditCompleteSendsSummary(t *testing.T) {
-	_, got := cliServer(t)
+	srv, got := cliServer(t)
+	defer srv.Close()
 	cmd := auditCmd()
 	cmd.SetArgs([]string{"complete", "5", "--summary", "Quarterly audit closed"})
 	if err := cmd.Execute(); err != nil {
@@ -104,7 +90,8 @@ func TestAuditCompleteSendsSummary(t *testing.T) {
 
 // #52: `incident add` must send its declared relation flags as references.
 func TestIncidentAddSendsRelations(t *testing.T) {
-	_, got := cliServer(t)
+	srv, got := cliServer(t)
+	defer srv.Close()
 	cmd := incidentCmd()
 	cmd.SetArgs([]string{"add", "--title", "Phish", "--description", "phishing wave",
 		"--severity", "high",
@@ -123,7 +110,8 @@ func TestIncidentAddSendsRelations(t *testing.T) {
 
 // #52: `risk add` must send --assets and --documents as references.
 func TestRiskAddSendsRelations(t *testing.T) {
-	_, got := cliServer(t)
+	srv, got := cliServer(t)
+	defer srv.Close()
 	cmd := riskCmd()
 	cmd.SetArgs([]string{"add", "--title", "R", "--owner", "o@x.io",
 		"--likelihood", "3", "--impact", "4",
@@ -142,7 +130,8 @@ func TestRiskAddSendsRelations(t *testing.T) {
 
 // #52: `legal add` must send --documents as references.
 func TestLegalAddSendsRelations(t *testing.T) {
-	_, got := cliServer(t)
+	srv, got := cliServer(t)
+	defer srv.Close()
 	cmd := legalCmd()
 	cmd.SetArgs([]string{"add", "--title", "GDPR", "--documents", "iso27001-18-1,iso27001-18-2"})
 	if err := cmd.Execute(); err != nil {

--- a/cmd/isms/incident.go
+++ b/cmd/isms/incident.go
@@ -56,7 +56,11 @@ func incidentAddCmd() *cobra.Command {
 				Assignee:     assignee,
 			}
 
-			result, err := c.CreateIncident(inc)
+			result, err := c.CreateIncident(inc, buildRefs(
+				refSpec{"risk", risks},
+				refSpec{"asset", assets},
+				refSpec{"system", systems},
+			))
 			if err != nil {
 				return err
 			}

--- a/cmd/isms/legal.go
+++ b/cmd/isms/legal.go
@@ -53,7 +53,9 @@ func legalAddCmd() *cobra.Command {
 				Completion:        completion,
 			}
 
-			result, err := c.CreateLegal(lr)
+			result, err := c.CreateLegal(lr, buildRefs(
+				refSpec{"document", linkedDocs},
+			))
 			if err != nil {
 				return err
 			}

--- a/cmd/isms/main.go
+++ b/cmd/isms/main.go
@@ -225,6 +225,28 @@ func requireAPI() *client.Client {
 	return c
 }
 
+// refSpec pairs a reference type with the target IDs from a CLI relation flag
+// (e.g. --risks RISK-001,RISK-002 → {typ: "risk", ids: [...]}).
+type refSpec struct {
+	typ string
+	ids []string
+}
+
+// buildRefs flattens relation-flag values into client references, skipping
+// blanks. Used by `add` commands so their declared relation flags are sent
+// rather than silently dropped (#52).
+func buildRefs(specs ...refSpec) []client.Reference {
+	var refs []client.Reference
+	for _, s := range specs {
+		for _, id := range s.ids {
+			if id = strings.TrimSpace(id); id != "" {
+				refs = append(refs, client.Reference{Type: s.typ, ID: id})
+			}
+		}
+	}
+	return refs
+}
+
 // intVal safely dereferences an *int, returning 0 for nil.
 func intVal(p *int) int {
 	if p == nil {

--- a/cmd/isms/risk.go
+++ b/cmd/isms/risk.go
@@ -41,7 +41,6 @@ func riskAddCmd() *cobra.Command {
 		treatment                    string
 		treatmentPlan                string
 		linkedDocs []string
-		interestedParties            []string
 		owner                        string
 		status                       string
 		reviewDate                   string
@@ -122,7 +121,6 @@ func riskAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&treatment, "treatment", "mitigate", "Treatment: accept, mitigate, transfer, avoid")
 	cmd.Flags().StringVar(&treatmentPlan, "plan", "", "Treatment plan")
 	cmd.Flags().StringSliceVar(&linkedDocs, "documents", nil, "Linked document IDs (comma-separated)")
-	cmd.Flags().StringSliceVar(&interestedParties, "interested-parties", nil, "Interested parties (comma-separated)")
 	cmd.Flags().StringVar(&owner, "owner", "", "Risk owner")
 	cmd.Flags().StringVar(&status, "status", "open", "Status: draft, open, closed")
 	cmd.Flags().StringVar(&reviewDate, "review-date", "", "Next review date (YYYY-MM-DD)")

--- a/cmd/isms/risk.go
+++ b/cmd/isms/risk.go
@@ -89,7 +89,10 @@ func riskAddCmd() *cobra.Command {
 				NextReview:                     rd,
 				Notes:                          notes,
 			}
-			result, err := c.AddRisk(r)
+			result, err := c.AddRisk(r, buildRefs(
+				refSpec{"asset", assets},
+				refSpec{"document", linkedDocs},
+			))
 			if err != nil {
 				return err
 			}

--- a/internal/isms/client/client.go
+++ b/internal/isms/client/client.go
@@ -299,8 +299,20 @@ func (c *Client) ListRisks() ([]db.Risk, error) {
 	return result, unwrapList(data, &result)
 }
 
-func (c *Client) AddRisk(risk *db.Risk) (*db.Risk, error) {
-	data, err := c.post("/v1/risks", risk)
+// Reference is an entity relation to create alongside a new entity. It mirrors
+// the API's "references" field ({type, id}); the create handlers turn each into
+// a bidirectional entity reference.
+type Reference struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func (c *Client) AddRisk(risk *db.Risk, refs []Reference) (*db.Risk, error) {
+	body := struct {
+		*db.Risk
+		References []Reference `json:"references,omitempty"`
+	}{risk, refs}
+	data, err := c.post("/v1/risks", body)
 	if err != nil {
 		return nil, err
 	}
@@ -819,8 +831,12 @@ func (c *Client) ListLegal(status string) ([]db.LegalRequirement, error) {
 	return result, unwrapList(data, &result)
 }
 
-func (c *Client) CreateLegal(lr *db.LegalRequirement) (*db.LegalRequirement, error) {
-	data, err := c.post("/v1/legal", lr)
+func (c *Client) CreateLegal(lr *db.LegalRequirement, refs []Reference) (*db.LegalRequirement, error) {
+	body := struct {
+		*db.LegalRequirement
+		References []Reference `json:"references,omitempty"`
+	}{lr, refs}
+	data, err := c.post("/v1/legal", body)
 	if err != nil {
 		return nil, err
 	}
@@ -869,8 +885,12 @@ func (c *Client) ListIncidents(status, severity string) ([]db.Incident, error) {
 	return result, unwrapList(data, &result)
 }
 
-func (c *Client) CreateIncident(inc *db.Incident) (*db.Incident, error) {
-	data, err := c.post("/v1/incidents", inc)
+func (c *Client) CreateIncident(inc *db.Incident, refs []Reference) (*db.Incident, error) {
+	body := struct {
+		*db.Incident
+		References []Reference `json:"references,omitempty"`
+	}{inc, refs}
+	data, err := c.post("/v1/incidents", body)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/test_needs_review_lifecycle.py
+++ b/tests/test_needs_review_lifecycle.py
@@ -1,0 +1,92 @@
+"""Regression for #19: "Needs Review keeps listing documents that are already
+approved."
+
+Empirically (against the live stack) the core of this is already handled by the
+#3 fix (merge_commit baseline + body comparison): an approved, unchanged
+document does not appear, and re-approving a changed document clears it again.
+The #3 test only covered a single approval + a metadata-vs-body edit; it never
+exercised the *re-approval cycle* that #19 describes ("keeps listing"). These
+tests lock in the full lifecycle so the "keeps listing" regression can't return.
+
+Conclusion captured here: an approved document only appears in needs-review when
+its reviewed body has genuinely drifted from the approved baseline, and going
+through review again always clears it. A never-reviewed document is surfaced
+(correct — it has no governance baseline) and clears once it is actually
+reviewed in-system.
+"""
+import uuid
+
+import requests
+from conftest import READER_EMAIL
+
+BODY = "# Control\n\nApproved, reviewed body.\n"
+BODY2 = BODY + "\nA genuine second-round content change.\n"
+
+
+def _approve_and_merge(api_url, admin_headers, reader_headers, doc_id):
+    r = requests.post(f"{api_url}/documents/{doc_id}/reviews", headers=admin_headers,
+                      json={"reviewers": [READER_EMAIL], "message": "review"})
+    assert r.status_code in (200, 201), f"send for review: {r.text}"
+    rid = r.json()["review_id"]
+    r = requests.post(f"{api_url}/reviews/{rid}/approve", headers=reader_headers,
+                      json={"decision": "approved", "comment": "LGTM"})
+    assert r.status_code == 200, f"approve: {r.text}"
+    r = requests.post(f"{api_url}/reviews/{rid}/merge", headers=admin_headers, json={})
+    assert r.status_code == 200, f"merge: {r.text}"
+
+
+def _listed(api_url, admin_headers, doc_id):
+    r = requests.get(f"{api_url}/documents/needs-review", headers=admin_headers)
+    assert r.status_code == 200, r.text
+    return any(d["document_id"] == doc_id for d in r.json()["data"])
+
+
+def _create(api_url, admin_headers, doc_id):
+    r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+        "folder": "iso27001", "filename": doc_id + ".md",
+        "document_id": doc_id, "title": "NR lifecycle", "content": BODY})
+    assert r.status_code in (200, 201, 409), r.text
+    requests.put(f"{api_url}/documents/{doc_id}/content", headers=admin_headers, json={"content": BODY})
+
+
+class TestNeedsReviewLifecycle:
+    def test_approved_doc_does_not_keep_listing_across_reapproval(
+            self, api_url, admin_headers, reader_headers):
+        # Unique id per run — the test stack persists state, and these assertions
+        # depend on the document's review history, so each run needs a fresh doc.
+        doc = "nr-cycle-" + uuid.uuid4().hex[:8]
+        _create(api_url, admin_headers, doc)
+
+        # First approval → cleared.
+        _approve_and_merge(api_url, admin_headers, reader_headers, doc)
+        assert not _listed(api_url, admin_headers, doc), \
+            "freshly approved document must not be listed"
+
+        # Genuine body change → correctly flagged.
+        requests.put(f"{api_url}/documents/{doc}/content", headers=admin_headers,
+                     json={"content": BODY2})
+        assert _listed(api_url, admin_headers, doc), \
+            "a real body change must flag needs-review"
+
+        # Re-approval must clear it again — this is the #19 "keeps listing" guard.
+        _approve_and_merge(api_url, admin_headers, reader_headers, doc)
+        assert not _listed(api_url, admin_headers, doc), \
+            "#19: re-approved document must NOT keep listing in needs-review"
+
+    def test_never_reviewed_doc_is_surfaced_then_clears_after_review(
+            self, api_url, admin_headers, reader_headers):
+        # Unique id per run — on the persistent stack a fixed id would already be
+        # approved from a prior run, so "never reviewed" would no longer hold.
+        doc = "nr-never-" + uuid.uuid4().hex[:8]
+        _create(api_url, admin_headers, doc)
+
+        # A document with no in-system review baseline is correctly surfaced —
+        # frontmatter status alone is not a governance trail.
+        assert _listed(api_url, admin_headers, doc), \
+            "a never-reviewed document should be surfaced for review"
+
+        # Reviewing it once clears it — so an imported repo settles after review,
+        # it does not keep listing forever.
+        _approve_and_merge(api_url, admin_headers, reader_headers, doc)
+        assert not _listed(api_url, admin_headers, doc), \
+            "once actually reviewed, the document must clear from needs-review"


### PR DESCRIPTION
Two CLI bugs where a declared flag was collected and silently dropped.

## #49 — `audit complete` drops the required `--summary`
The flag was declared (and `MarkFlagRequired`) but the command only called `UpdateAuditStatus(id, "completed")` — the summary went nowhere. It now sends `summary` + `status` through the audit update endpoint, which routes the status transition through the same `UpdateAuditStatus` path.

## #52 — `add` commands drop relation flags
`incident add` (`--risks`/`--assets`/`--systems`), `risk add` (`--assets`/`--documents`) and `legal add` (`--documents`) declared relation flags, but the client posted the bare entity struct — which has no `references` field — so they were dropped. The client create methods (`AddRisk`/`CreateIncident`/`CreateLegal`) now take a `[]Reference` and send it as the API's existing `references` field (the server already turns those into bidirectional entity references). Commands build the references from the flags via a shared `buildRefs` helper (`risk`/`asset`/`system`/`document` types).

## Tests
`cmd/isms/cli_relations_test.go` runs each command against an httptest server and asserts the outbound request body:
- `audit complete` → body carries `summary` + `status`.
- `incident/risk/legal add` → body carries the right `{type,id}` references.
- `buildRefs` unit-tested (flag → references, blanks skipped).

All green (`go test ./cmd/isms`), full Go unit suite green, build clean.

## Also: #19 needs-review regression test (test-only)
`tests/test_needs_review_lifecycle.py` rides along. #19 ("Needs Review keeps listing approved docs") needed **no product change** — it was already fixed by #3 (merge_commit baseline + body comparison). Verified against the stack: approved+unchanged → not listed; body change → flagged; re-approval → cleared; never-reviewed → surfaced then cleared after review. This locks that lifecycle in. Uses unique doc ids so it's idempotent on the persistent test stack (verified by running twice + the full `just test` suite).

> Note: `gofmt -l` lists a few touched files (`main.go`, `audit.go`, `risk.go`, `client.go`) — that's the **pre-existing** repo-wide drift tracked in #83, not introduced here; my added lines are gofmt-clean.

Closes #49
Closes #52
Closes #19