### PR TITLE
fix(security): status changes manager/admin-only + OTP disable needs re-auth (#24, #27)

### DIFF
--- a/internal/isms/api/api_auth.go
+++ b/internal/isms/api/api_auth.go
@@ -583,11 +583,28 @@ func (s *Server) handleOTPVerify(c echo.Context) error {
 // --- Self-service: OTP disable ---
 
 func (s *Server) handleOTPDisable(c echo.Context) error {
+	var req otpVerifyRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+	}
+
 	ctx := c.Request().Context()
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+	}
+
+	// Re-authenticate with the current OTP code before removing the second
+	// factor — otherwise a hijacked session could silently disable 2FA (#27).
+	if user.OTPSecret == nil || *user.OTPSecret == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "OTP is not enabled")
+	}
+	if req.Code == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "current OTP code is required to disable OTP")
+	}
+	if !verifyTOTP(*user.OTPSecret, req.Code) {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid OTP code")
 	}
 
 	if err := s.db.ClearOTP(ctx, user.ID); err != nil {

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2396,6 +2396,11 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 	// Route status changes through the dedicated transition function so that
 	// approved_at / implemented_at are cleared correctly on reverse transitions.
 	if req.Status != nil && *req.Status != old.Status {
+		// Changing status is a manager/admin action — match the dedicated status
+		// endpoint so the general edit endpoint can't be used as an RBAC bypass (#24).
+		if err := requireRole(c, "admin", "manager"); err != nil {
+			return err
+		}
 		if err := s.db.UpdateChangeRequestStatus(ctx, orgID, id, *req.Status, getUserEmail(c)); err != nil {
 			return pgxHTTPError(err)
 		}

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -324,6 +324,12 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	// Route status changes through the dedicated transition function so that
 	// contained_at / resolved_at / closed_at are cleared correctly on reverse transitions.
 	if req.Status != nil && *req.Status != existing.Status {
+		// Changing status is a manager/admin action. The dedicated status
+		// endpoint already enforces this; the general edit endpoint must apply
+		// the same rule so it can't be used as an RBAC bypass (#24).
+		if err := requireRole(c, "admin", "manager"); err != nil {
+			return err
+		}
 		// Same rule as the dedicated status endpoint: cannot resolve/close an
 		// incident with open corrective actions still linked.
 		if *req.Status == "closed" || *req.Status == "resolved" {

--- a/tests/test_status_rbac_otp.py
+++ b/tests/test_status_rbac_otp.py
@@ -1,0 +1,119 @@
+"""Regressions for two security bugs:
+
+#24 — a contributor could change incident / change-request status through the
+      *general* edit endpoint (PUT /incidents/:id, PUT /changes/:id), bypassing
+      the manager/admin role the dedicated /status endpoints enforce.
+
+#27 — disabling OTP required no re-authentication: a hijacked session could
+      silently remove 2FA. Disabling now requires a valid current OTP code.
+"""
+import base64
+import hashlib
+import hmac
+import struct
+import time
+import uuid
+
+import requests
+from conftest import _signup, ADMIN_EMAIL
+
+
+# ── #24: status changes via the general edit endpoint are manager/admin only ──
+
+def _make_incident(api_url, admin_headers):
+    r = requests.post(f"{api_url}/incidents", headers=admin_headers, json={
+        "title": "RBAC probe incident", "description": "for status-rbac test",
+        "severity": "medium", "incident_type": "incident", "source": "internal",
+        "reporter": ADMIN_EMAIL,
+    })
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+def _make_change(api_url, admin_headers):
+    r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+        "title": "RBAC probe change", "description": "for status-rbac test",
+        "justification": "test", "priority": "medium", "category": "technology",
+        "risk_level": "low", "rollback_plan": "revert",
+    })
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+class TestStatusChangeRBAC:
+    def test_contributor_cannot_change_incident_status_via_general_edit(
+            self, api_url, admin_headers, contributor_headers):
+        iid = _make_incident(api_url, admin_headers)
+        r = requests.put(f"{api_url}/incidents/{iid}", headers=contributor_headers,
+                         json={"status": "investigating"})
+        assert r.status_code == 403, f"contributor changed incident status (#24): {r.status_code} {r.text}"
+
+    def test_contributor_can_still_edit_nonstatus_incident_fields(
+            self, api_url, admin_headers, contributor_headers):
+        iid = _make_incident(api_url, admin_headers)
+        r = requests.put(f"{api_url}/incidents/{iid}", headers=contributor_headers,
+                         json={"description": "contributor edited the description"})
+        assert r.status_code == 200, f"non-status edit must still work: {r.status_code} {r.text}"
+
+    def test_manager_can_change_incident_status_via_general_edit(
+            self, api_url, admin_headers):
+        iid = _make_incident(api_url, admin_headers)
+        r = requests.put(f"{api_url}/incidents/{iid}", headers=admin_headers,
+                         json={"status": "investigating"})
+        assert r.status_code == 200, f"admin/manager status change must work: {r.text}"
+
+    def test_contributor_cannot_change_change_status_via_general_edit(
+            self, api_url, admin_headers, contributor_headers):
+        cid = _make_change(api_url, admin_headers)
+        r = requests.put(f"{api_url}/changes/{cid}", headers=contributor_headers,
+                         json={"status": "approved"})
+        assert r.status_code == 403, f"contributor changed change-request status (#24): {r.status_code} {r.text}"
+
+    def test_manager_can_change_change_status_via_general_edit(
+            self, api_url, admin_headers):
+        cid = _make_change(api_url, admin_headers)
+        r = requests.put(f"{api_url}/changes/{cid}", headers=admin_headers,
+                         json={"status": "approved"})
+        assert r.status_code == 200, f"admin/manager change status must work: {r.text}"
+
+
+# ── #27: disabling OTP requires a valid current code ──
+
+def _totp(secret_b32, at=None):
+    """RFC 6238 TOTP (SHA1, 6 digits, 30s) for a base32 secret (no padding)."""
+    padded = secret_b32 + "=" * (-len(secret_b32) % 8)
+    key = base64.b32decode(padded, casefold=True)
+    counter = int((at or time.time()) // 30)
+    digest = hmac.new(key, struct.pack(">Q", counter), hashlib.sha1).digest()
+    off = digest[-1] & 0x0F
+    code = (struct.unpack(">I", digest[off:off + 4])[0] & 0x7FFFFFFF) % 1_000_000
+    return f"{code:06d}"
+
+
+class TestOTPDisableRequiresReauth:
+    def test_disable_otp_needs_current_code(self, api_url):
+        # Unique throwaway user per run — never touch a shared account's 2FA
+        # state on the persistent stack.
+        email = f"otp-{uuid.uuid4().hex[:8]}@isms-test.local"
+        token = _signup(email, "TestPass123!", "OTP Disable Test")
+        assert token, "signup did not return a token"
+        h = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+        # Enable OTP.
+        r = requests.post(f"{api_url}/auth/otp/setup", headers=h, json={})
+        assert r.status_code == 200, f"otp setup: {r.text}"
+        secret = r.json()["secret"]
+        r = requests.post(f"{api_url}/auth/otp/verify", headers=h, json={"code": _totp(secret)})
+        assert r.status_code == 200, f"otp verify (enable): {r.text}"
+
+        # Disable WITHOUT a code → rejected (the #27 fix).
+        r = requests.delete(f"{api_url}/auth/otp", headers=h)
+        assert r.status_code == 400, f"disable without code must be rejected (#27): {r.status_code} {r.text}"
+
+        # Disable with a WRONG code → rejected.
+        r = requests.delete(f"{api_url}/auth/otp", headers=h, json={"code": "000000"})
+        assert r.status_code in (400, 401), f"disable with wrong code must be rejected: {r.status_code} {r.text}"
+
+        # Disable with a VALID current code → succeeds.
+        r = requests.delete(f"{api_url}/auth/otp", headers=h, json={"code": _totp(secret)})
+        assert r.status_code == 200, f"disable with valid code must succeed: {r.status_code} {r.text}"

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -113,8 +113,10 @@ async function putJSON(url, data) {
   return res.json()
 }
 
-async function deleteJSON(url) {
-  const res = await safeFetch(url, { method: 'DELETE', headers: getHeaders() })
+async function deleteJSON(url, data) {
+  const opts = { method: 'DELETE', headers: getHeaders() }
+  if (data !== undefined) opts.body = JSON.stringify(data)
+  const res = await safeFetch(url, opts)
   checkAuth(res)
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -214,7 +214,7 @@
                           <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option><option value="critical">Critical</option>
                         </select>
                       </div>
-                      <div>
+                      <div v-if="canWrite">
                         <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
                           <option value="proposed">Proposed</option>
@@ -462,6 +462,9 @@ useModalEscape(showCreate)
 useModalEscape(computed(() => !!selectedChange.value), () => closeDetail())
 
 const canCreate = computed(() => ['admin', 'manager', 'contributor'].includes(userRole.value))
+// Status transitions are manager/admin-only (the API rejects others with 403),
+// so only managers/admins see the status control (#24).
+const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 const pendingRefs = ref([])
 
 const form = ref({ title: '', priority: 'medium', category: 'process' })

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -70,6 +70,7 @@
         <p class="text-xs text-slate-500">Enter a current code from your authenticator to turn it off.</p>
         <div class="flex items-center gap-2">
           <input v-model="disableCode" type="text" maxlength="6" inputmode="numeric" placeholder="000000"
+            @input="disableCode = disableCode.replace(/\D/g, '').slice(0, 6)"
             class="w-28 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white tracking-widest text-center focus:outline-none focus:border-red-500" />
           <button @click="disableOTP" :disabled="disablingOTP || disableCode.length !== 6"
             class="px-4 py-2 bg-red-600/20 hover:bg-red-600/30 text-red-400 text-sm rounded-lg border border-red-600/30 transition-colors disabled:opacity-50">

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -67,10 +67,15 @@
           <span class="text-sm text-emerald-400">OTP is enabled</span>
         </div>
         <p class="text-xs text-slate-500">Your account is protected with a time-based one-time password.</p>
-        <button @click="disableOTP" :disabled="disablingOTP"
-          class="px-4 py-2 bg-red-600/20 hover:bg-red-600/30 text-red-400 text-sm rounded-lg border border-red-600/30 transition-colors disabled:opacity-50">
-          {{ disablingOTP ? 'Disabling...' : 'Disable OTP' }}
-        </button>
+        <p class="text-xs text-slate-500">Enter a current code from your authenticator to turn it off.</p>
+        <div class="flex items-center gap-2">
+          <input v-model="disableCode" type="text" maxlength="6" inputmode="numeric" placeholder="000000"
+            class="w-28 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white tracking-widest text-center focus:outline-none focus:border-red-500" />
+          <button @click="disableOTP" :disabled="disablingOTP || disableCode.length !== 6"
+            class="px-4 py-2 bg-red-600/20 hover:bg-red-600/30 text-red-400 text-sm rounded-lg border border-red-600/30 transition-colors disabled:opacity-50">
+            {{ disablingOTP ? 'Disabling...' : 'Disable OTP' }}
+          </button>
+        </div>
       </div>
 
       <!-- OTP setup flow -->
@@ -290,6 +295,7 @@ const otpEnabled = ref(false)
 const otpSecret = ref('')
 const otpURI = ref('')
 const otpCode = ref('')
+const disableCode = ref('')
 const settingUpOTP = ref(false)
 const verifyingOTP = ref(false)
 const disablingOTP = ref(false)
@@ -384,8 +390,9 @@ async function disableOTP() {
   disablingOTP.value = true
   otpMsg.value = ''
   try {
-    await api.deleteJSON('/api/v1/auth/otp')
+    await api.deleteJSON('/api/v1/auth/otp', { code: disableCode.value })
     otpEnabled.value = false
+    disableCode.value = ''
     otpMsg.value = 'OTP disabled'
     otpError.value = false
   } catch (e) {


### PR DESCRIPTION
Two security fixes, conflict-free with the open CLI PR.

## #24 — RBAC bypass on status via the general edit endpoint
`handleUpdateIncident` and `handleUpdateChange` route a status change through the dedicated status-transition functions, but only required the **contributor** role — while `PUT /incidents/:id/status` and `PUT /changes/:id/status` require **admin/manager**. So a contributor could change status through the general edit endpoint. The general handlers now require admin/manager **when the status actually changes**; non-status edits are unaffected.

## #27 — disabling OTP required no re-authentication
`handleOTPDisable` cleared the OTP secret straight from the session — a hijacked session could silently remove 2FA. It now requires a **valid current OTP code**. Frontend: the Settings disable action prompts for the code; `deleteJSON` gained an optional body.

## Tests — `tests/test_status_rbac_otp.py`
- Contributor blocked (403) from status changes on both `PUT /incidents/:id` and `PUT /changes/:id`; non-status edits still 200; manager status changes still 200.
- OTP disable rejected without a code (400) and with a wrong code (401), accepted with a valid code (200). Uses a unique throwaway user per run + RFC 6238 TOTP, so it's idempotent on the persistent stack.

Verified against the live stack with `just test` (run twice for idempotency).