### PR TITLE
fix(suggestions): default task assignee to the applier on apply (#86)

### DIFF
--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1136,9 +1136,7 @@ func applyTaskCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	}
 	if t.Priority == "" { t.Priority = "medium" }
 	if t.TaskType == "" { t.TaskType = "general" }
-	// Tasks require an assignee (tasks.assignee_id is NOT NULL). A suggested task
-	// often has none, which previously surfaced as a raw SQL constraint error on
-	// apply. Default to the manager applying it — they can reassign in edit.
+	// tasks.assignee_id is NOT NULL; default to the applier when the suggestion carries none.
 	if t.Assignee == "" {
 		t.Assignee = actor
 	}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1136,6 +1136,12 @@ func applyTaskCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	}
 	if t.Priority == "" { t.Priority = "medium" }
 	if t.TaskType == "" { t.TaskType = "general" }
+	// Tasks require an assignee (tasks.assignee_id is NOT NULL). A suggested task
+	// often has none, which previously surfaced as a raw SQL constraint error on
+	// apply. Default to the manager applying it — they can reassign in edit.
+	if t.Assignee == "" {
+		t.Assignee = actor
+	}
 	if err := db.CreateTaskTx(ctx, tx, orgID, &t); err != nil {
 		return "", err
 	}

--- a/tests/test_suggestion_apply_task.py
+++ b/tests/test_suggestion_apply_task.py
@@ -1,0 +1,48 @@
+"""Regression: applying a task-create suggestion with no assignee must not blow
+up with a raw SQL constraint error.
+
+tasks.assignee_id is NOT NULL, but a suggested task often carries no assignee.
+applyTaskCreate used to insert it as-is, surfacing
+  "null value in column assignee_id ... violates not-null constraint"
+to the manager. It now defaults the assignee to the applier, who can reassign
+in edit afterwards.
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL
+
+
+def test_apply_task_suggestion_without_assignee_defaults_to_applier(api_url, admin_headers):
+    title = f"apply-task-noassignee {uuid.uuid4().hex[:8]}"
+
+    # A task suggestion with NO assignee — the exact repro.
+    r = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+        "entity_type": "task",
+        "suggestion_type": "create",
+        "title": title,
+        "rationale": "follow-up proposed during review",
+        "payload": {
+            "title": title,
+            "description": "Investigate the reported issue",
+            "priority": "high",
+            "task_type": "general",
+            # deliberately no "assignee"
+        },
+    })
+    assert r.status_code in (200, 201), f"create suggestion: {r.text}"
+    sid = r.json()["id"]
+
+    # Apply must succeed, not crash on the NOT NULL constraint.
+    r = requests.post(f"{api_url}/suggestions/{sid}/apply", headers=admin_headers, json={})
+    assert r.status_code == 200, f"apply must not crash on missing assignee: {r.status_code} {r.text}"
+    assert r.json().get("status") == "applied", r.text
+
+    # The created task is assigned to the applier (admin), who can reassign later.
+    r = requests.get(f"{api_url}/tasks", headers=admin_headers, params={"limit": 2000})
+    assert r.status_code == 200, r.text
+    rows = r.json().get("data", r.json())
+    match = [t for t in rows if t.get("title") == title]
+    assert match, "task created by the applied suggestion not found"
+    assert match[0]["assignee"] == ADMIN_EMAIL, \
+        f"expected assignee to default to the applier {ADMIN_EMAIL}, got {match[0].get('assignee')!r}"

--- a/tests/test_suggestion_apply_task.py
+++ b/tests/test_suggestion_apply_task.py
@@ -39,7 +39,8 @@ def test_apply_task_suggestion_without_assignee_defaults_to_applier(api_url, adm
     assert r.json().get("status") == "applied", r.text
 
     # The created task is assigned to the applier (admin), who can reassign later.
-    r = requests.get(f"{api_url}/tasks", headers=admin_headers, params={"limit": 2000})
+    # Search by the unique title rather than scanning the whole list.
+    r = requests.get(f"{api_url}/tasks", headers=admin_headers, params={"q": title, "limit": 5})
     assert r.status_code == 200, r.text
     rows = r.json().get("data", r.json())
     match = [t for t in rows if t.get("title") == title]


### PR DESCRIPTION
## The bug
Applying a suggestion that creates a **task** failed with a raw SQL error when the suggestion had no assignee:
```
null value in column "assignee_id" of relation "tasks" violates not-null constraint
```
`tasks.assignee_id` is NOT NULL; `applyTaskCreate` inserted the suggested task with an empty assignee.

## Fix
Default the assignee to the **manager applying** the suggestion when none is given — they can reassign in edit. No schema change (tasks still require an assignee by design).

## Test
`tests/test_suggestion_apply_task.py` — create a task suggestion with no assignee, apply it, assert 200 (no SQL error) and that the task is assigned to the applier. Unique title per run, idempotent on the persistent stack.

Closes #86