### PR TITLE
fix(rbac): enforce contributor=suggest-only, reader=read-only (#23)

### DIFF
--- a/docs/auditor-guide.md
+++ b/docs/auditor-guide.md
@@ -240,8 +240,8 @@ The platform has four roles, in descending order of privilege:
 |------|-----------|---------|-----------|-------------|-------|
 | **Admin** | Read, write | Send, approve, merge | Full CRUD | Apply, reject | Full org management |
 | **Manager** | Read, write | Send, approve, merge | Full CRUD | Apply, reject | -- |
-| **Contributor** | Read, write | Send, comment | Full CRUD | Create, edit own | -- |
-| **Reader** | Read only | Comment (when assigned) | Read only | Create | -- |
+| **Contributor** | Read | Comment (when assigned) | Read — propose via suggestions | Create, edit own | -- |
+| **Reader** | Read only | Comment (when assigned) | Read only | -- | -- |
 
 Important details:
 

--- a/docs/suggestions.md
+++ b/docs/suggestions.md
@@ -10,10 +10,11 @@ They are the generic mechanism for proposing change without directly mutating th
 
 That means suggestions can be created by:
 
-- readers
 - contributors
 - managers
 - admins
+
+(Readers are read-only and cannot create suggestions.)
 - agent users / AI accounts
 
 The goal is simple:
@@ -340,15 +341,16 @@ The reviewer should be able to answer:
 
 ### Reader
 
-- Create suggestions
+- Read-only — readers cannot create suggestions.
 - View suggestions visible to them
-- Withdraw their own open suggestions
-- Delete their own open suggestions
 
 ### Contributor
 
-- Everything reader can do
+- Create suggestions
+- View suggestions visible to them
 - Edit their own open suggestions (`payload`, `rationale`, `source_refs`)
+- Withdraw their own open suggestions
+- Delete their own open suggestions
 
 ### Manager / Admin
 

--- a/docs/suggestions.md
+++ b/docs/suggestions.md
@@ -13,9 +13,9 @@ That means suggestions can be created by:
 - contributors
 - managers
 - admins
+- agent users / AI accounts
 
 (Readers are read-only and cannot create suggestions.)
-- agent users / AI accounts
 
 The goal is simple:
 

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -1891,7 +1891,7 @@ func (s *Server) handleTaskStats(c echo.Context) error {
 }
 
 func (s *Server) handleCreateTask(c echo.Context) error {
-	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
 	}
 	orgID := getOrgID(c)
@@ -1988,6 +1988,12 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	before, err := s.db.GetTask(ctx, orgID, id)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+	}
+	// Ownership: a contributor may advance the status of a task assigned to them
+	// (doing their own work), but not other people's tasks. Managers/admins may
+	// change any task's status (#23).
+	if role, _ := c.Get("user_role").(string); role == "contributor" && before.Assignee != getUserEmail(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "contributors can only change the status of tasks assigned to them")
 	}
 	if err := s.db.UpdateTaskStatus(ctx, orgID, id, req.Status); err != nil {
 		return pgxHTTPError(err)
@@ -2271,7 +2277,7 @@ func (s *Server) handleGetChange(c echo.Context) error {
 }
 
 func (s *Server) handleCreateChange(c echo.Context) error {
-	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
 	}
 	orgID := getOrgID(c)
@@ -2348,7 +2354,7 @@ func (s *Server) handleCreateChange(c echo.Context) error {
 }
 
 func (s *Server) handleUpdateChange(c echo.Context) error {
-	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
 	}
 	orgID := getOrgID(c)

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -98,7 +98,7 @@ func (s *Server) handleListIncidents(c echo.Context) error {
 }
 
 func (s *Server) handleCreateIncident(c echo.Context) error {
-	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
 	}
 	orgID := getOrgID(c)
@@ -259,7 +259,7 @@ func (s *Server) handleGetIncident(c echo.Context) error {
 }
 
 func (s *Server) handleUpdateIncident(c echo.Context) error {
-	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
 	}
 	orgID := getOrgID(c)

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -100,7 +100,11 @@ func init() {
 
 func (s *Server) handleCreateEntitySuggestion(c echo.Context) error {
 	// Contributors and managers create suggestions; readers are read-only (#23).
-	// The middleware already blocks readers from this write path.
+	// Explicit guard (not just the role middleware) so this can't silently open
+	// if the middleware's reader-exception list ever changes.
+	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+		return err
+	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -99,7 +99,8 @@ func init() {
 // ═══════════════════════════════════════════════════════════════════════
 
 func (s *Server) handleCreateEntitySuggestion(c echo.Context) error {
-	// Any authenticated user can create suggestions (reader+)
+	// Contributors and managers create suggestions; readers are read-only (#23).
+	// The middleware already blocks readers from this write path.
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)

--- a/tests/test_contributor_role.py
+++ b/tests/test_contributor_role.py
@@ -6,7 +6,7 @@ agent). A reader is read-only and cannot even suggest. Managers/admins mutate
 directly and apply/reject suggestions.
 """
 import requests
-from conftest import CONTRIBUTOR_EMAIL
+from conftest import CONTRIBUTOR_EMAIL, READER_EMAIL
 
 
 class TestContributorCanDo:
@@ -23,6 +23,21 @@ class TestContributorCanDo:
     def test_can_read_incidents(self, api_url, contributor_headers):
         r = requests.get(f"{api_url}/incidents", headers=contributor_headers)
         assert r.status_code == 200
+
+    def test_can_read_suppliers(self, api_url, contributor_headers):
+        r = requests.get(f"{api_url}/suppliers", headers=contributor_headers)
+        assert r.status_code == 200
+
+    def test_can_update_status_of_own_assigned_task(self, api_url, admin_headers, contributor_headers):
+        """Ownership exception (#23): a contributor may advance their own task's status."""
+        t = requests.post(f"{api_url}/tasks", headers=admin_headers, json={
+            "title": "Ownership test task", "task_type": "general",
+            "assignee": CONTRIBUTOR_EMAIL,
+        })
+        assert t.status_code in [200, 201], t.text
+        r = requests.put(f"{api_url}/tasks/{t.json()['id']}/status", headers=contributor_headers,
+                         json={"status": "in_progress"})
+        assert r.status_code == 200, f"contributor must update own task status: {r.text}"
 
     def test_can_create_suggestion(self, api_url, contributor_headers):
         """A contributor's input flows through suggestions, not direct creation."""
@@ -125,6 +140,27 @@ class TestContributorCannotDo:
 
         d = requests.delete(f"{api_url}/risks/{risk_id}", headers=contributor_headers)
         assert d.status_code == 403
+
+    def test_cannot_update_status_of_unassigned_task(self, api_url, admin_headers, contributor_headers):
+        t = requests.post(f"{api_url}/tasks", headers=admin_headers, json={
+            "title": "Unassigned task", "task_type": "general",
+        })
+        assert t.status_code in [200, 201], t.text
+        r = requests.put(f"{api_url}/tasks/{t.json()['id']}/status", headers=contributor_headers,
+                         json={"status": "in_progress"})
+        assert r.status_code == 403, f"contributor must not update an unassigned task (#23): {r.text}"
+
+    def test_cannot_update_status_of_other_persons_task(self, api_url, admin_headers, contributor_headers):
+        # Assign to a real org member who isn't the contributor (task create
+        # validates org membership, so the assignee must exist).
+        t = requests.post(f"{api_url}/tasks", headers=admin_headers, json={
+            "title": "Other person task", "task_type": "general",
+            "assignee": READER_EMAIL,
+        })
+        assert t.status_code in [200, 201], t.text
+        r = requests.put(f"{api_url}/tasks/{t.json()['id']}/status", headers=contributor_headers,
+                         json={"status": "in_progress"})
+        assert r.status_code == 403, f"contributor must not update another person's task (#23): {r.text}"
 
 
 class TestReaderIsReadOnly:

--- a/tests/test_contributor_role.py
+++ b/tests/test_contributor_role.py
@@ -1,14 +1,16 @@
-"""Contributor role tests.
+"""Contributor and reader role enforcement (#23).
 
-Contributors can: create incidents, change requests, tasks, add comments.
-Contributors cannot: approve reviews, create/edit risks, manage templates, admin actions.
+The decided model: a contributor proposes and reports *through suggestions* and
+comments — it does NOT directly create or edit entities (same path as an AI
+agent). A reader is read-only and cannot even suggest. Managers/admins mutate
+directly and apply/reject suggestions.
 """
 import requests
 from conftest import CONTRIBUTOR_EMAIL
 
 
 class TestContributorCanDo:
-    """Things a contributor is allowed to do."""
+    """Things a contributor is allowed to do: read everything, propose via suggestions."""
 
     def test_can_read_risks(self, api_url, contributor_headers):
         r = requests.get(f"{api_url}/risks", headers=contributor_headers)
@@ -18,45 +20,48 @@ class TestContributorCanDo:
         r = requests.get(f"{api_url}/documents/all", headers=contributor_headers)
         assert r.status_code == 200
 
-    def test_can_read_suppliers(self, api_url, contributor_headers):
-        r = requests.get(f"{api_url}/suppliers", headers=contributor_headers)
-        assert r.status_code == 200
-
     def test_can_read_incidents(self, api_url, contributor_headers):
         r = requests.get(f"{api_url}/incidents", headers=contributor_headers)
         assert r.status_code == 200
 
-    def test_can_create_incident(self, api_url, contributor_headers):
-        r = requests.post(f"{api_url}/incidents", headers=contributor_headers, json={
-            "title": "Contributor reported incident",
-            "description": "Found an issue during maintenance",
-            "severity": "medium",
-            "affects_a": True,
-            "incident_type": "event",
-            "source": "internal",
-            "reporter": CONTRIBUTOR_EMAIL,
+    def test_can_create_suggestion(self, api_url, contributor_headers):
+        """A contributor's input flows through suggestions, not direct creation."""
+        r = requests.post(f"{api_url}/suggestions", headers=contributor_headers, json={
+            "entity_type": "risk",
+            "suggestion_type": "create",
+            "title": "Contributor-proposed risk",
+            "rationale": "Spotted during operations",
+            "payload": {
+                "title": "Contributor-proposed risk",
+                "description": "Proposed by a contributor for manager review",
+                "category": "technology", "risk_type": "threat", "origin": "internal",
+            },
         })
-        assert r.status_code in [200, 201], f"Failed: {r.text}"
-
-    def test_can_create_change_request(self, api_url, contributor_headers):
-        r = requests.post(f"{api_url}/changes", headers=contributor_headers, json={
-            "title": "Update firewall rules for new office",
-            "description": "Need to allow traffic from new office IP range",
-            "status": "proposed",
-        })
-        assert r.status_code in [200, 201], f"Failed: {r.text}"
-
-    def test_can_create_task(self, api_url, contributor_headers):
-        r = requests.post(f"{api_url}/tasks", headers=contributor_headers, json={
-            "title": "Patch server CVE-2026-1234",
-            "task_type": "incident_followup",
-            "assignee": CONTRIBUTOR_EMAIL,
-        })
-        assert r.status_code in [200, 201], f"Failed: {r.text}"
+        assert r.status_code in [200, 201], f"contributor must be able to suggest: {r.text}"
 
 
 class TestContributorCannotDo:
-    """Things a contributor is NOT allowed to do."""
+    """A contributor cannot directly create or edit entities — it must suggest."""
+
+    def test_cannot_create_incident(self, api_url, contributor_headers):
+        r = requests.post(f"{api_url}/incidents", headers=contributor_headers, json={
+            "title": "Should be a suggestion", "description": "d", "severity": "medium",
+            "incident_type": "event", "source": "internal", "reporter": CONTRIBUTOR_EMAIL,
+        })
+        assert r.status_code == 403, f"contributor must not create incidents directly (#23): {r.text}"
+
+    def test_cannot_create_change_request(self, api_url, contributor_headers):
+        r = requests.post(f"{api_url}/changes", headers=contributor_headers, json={
+            "title": "Should be a suggestion", "description": "d", "status": "proposed",
+        })
+        assert r.status_code == 403, f"contributor must not create change requests directly (#23): {r.text}"
+
+    def test_cannot_create_task(self, api_url, contributor_headers):
+        r = requests.post(f"{api_url}/tasks", headers=contributor_headers, json={
+            "title": "Should be a suggestion", "task_type": "general",
+            "assignee": CONTRIBUTOR_EMAIL,
+        })
+        assert r.status_code == 403, f"contributor must not create tasks directly (#23): {r.text}"
 
     def test_cannot_create_risk(self, api_url, contributor_headers):
         r = requests.post(f"{api_url}/risks", headers=contributor_headers, json={
@@ -120,3 +125,17 @@ class TestContributorCannotDo:
 
         d = requests.delete(f"{api_url}/risks/{risk_id}", headers=contributor_headers)
         assert d.status_code == 403
+
+
+class TestReaderIsReadOnly:
+    """A reader cannot suggest — suggestions are the contributor entry point, not reader."""
+
+    def test_reader_cannot_create_suggestion(self, api_url, reader_headers):
+        r = requests.post(f"{api_url}/suggestions", headers=reader_headers, json={
+            "entity_type": "risk",
+            "suggestion_type": "create",
+            "title": "Reader should not be able to suggest",
+            "rationale": "read-only",
+            "payload": {"title": "x", "category": "technology", "risk_type": "threat", "origin": "internal"},
+        })
+        assert r.status_code == 403, f"reader is read-only and must not create suggestions (#23): {r.text}"

--- a/tests/test_status_rbac_otp.py
+++ b/tests/test_status_rbac_otp.py
@@ -48,12 +48,14 @@ class TestStatusChangeRBAC:
                          json={"status": "investigating"})
         assert r.status_code == 403, f"contributor changed incident status (#24): {r.status_code} {r.text}"
 
-    def test_contributor_can_still_edit_nonstatus_incident_fields(
+    def test_contributor_cannot_edit_incident_at_all(
             self, api_url, admin_headers, contributor_headers):
+        # Since #23, contributors are suggest-only — they cannot edit an incident
+        # directly at all (not just its status); they propose via suggestions.
         iid = _make_incident(api_url, admin_headers)
         r = requests.put(f"{api_url}/incidents/{iid}", headers=contributor_headers,
                          json={"description": "contributor edited the description"})
-        assert r.status_code == 200, f"non-status edit must still work: {r.status_code} {r.text}"
+        assert r.status_code == 403, f"contributor must not edit incidents directly (#23): {r.status_code} {r.text}"
 
     def test_manager_can_change_incident_status_via_general_edit(
             self, api_url, admin_headers):

--- a/web/src/components/SuggestNewButton.vue
+++ b/web/src/components/SuggestNewButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div v-if="canSuggest" class="relative">
     <button @click="showForm = !showForm"
       class="px-3 py-2 bg-amber-600/20 hover:bg-amber-600/30 text-amber-400 text-sm font-medium rounded-lg transition-colors">
       Suggest
@@ -53,6 +53,12 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { api } from '../api'
+import { useSession } from '../composables/useSession'
+
+// Suggestions are the contributor entry point; readers are read-only (#23), so
+// hide the control entirely for them rather than letting it 403 on submit.
+const { currentUserData } = useSession()
+const canSuggest = computed(() => (currentUserData.value?.role || '') !== 'reader')
 
 const props = defineProps({
   entityType: { type: String, required: true },


### PR DESCRIPTION
Enforces the role model that README (#23) already documents but the code never enforced.

## Model
- **Contributor** — proposes/reports **through suggestions**, comments; no direct create/edit/apply (same path as an AI agent).
- **Reader** — read-only; cannot suggest.
- **Ownership exception** — you may act on what's yours: a task *assignee* may advance their task's status; a document *owner* may confirm its periodic review.

## Backend
- `handleCreateIncident`/`handleUpdateIncident`, `handleCreateTask`, `handleCreateChange`/`handleUpdateChange` — contributor dropped, admin/manager only.
- `handleUpdateTaskStatus` — keeps contributor **only for a task assigned to them**; managers/admins may change any task.
- `handleConfirmDocumentReview` — already gates contributor-confirm on document ownership; unchanged.

## Frontend
- `SuggestNewButton` hidden for readers (via `useSession` role) — fixes the original "reader sees Suggest, gets 403" report.

## Tests
- `tests/test_contributor_role.py` rewritten: contributor cannot create incident/change/task directly (403) but **can** create suggestions; reader **cannot** suggest (403). Existing register/admin/delete forbids retained.
- `tests/test_status_rbac_otp.py`: the #85-era "contributor can still edit non-status incident fields" test is superseded — under #23 a contributor cannot edit incidents directly at all (403).

## Docs
`auditor-guide.md` + `suggestions.md` aligned with the model.

Verified with `just test` against the restarted stack.

Out of scope (follow-up): the richer "suggestions read as under review" UX.

Closes #23