### PR TITLE
fix(cli): review approve uses the approval handler (not a dead status path) + document completion (#51, #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ isms document list
 isms risk list
 ```
 
+### Shell completion
+
+The CLI ships completion for bash, zsh, fish, and PowerShell:
+
+```bash
+isms completion bash        # print the script
+source <(isms completion bash)   # load it for the current shell
+
+# install permanently (bash, Linux):
+isms completion bash | sudo tee /etc/bash_completion.d/isms >/dev/null
+
+# zsh:
+isms completion zsh > "${fpath[1]}/_isms"
+```
+
+Run `isms completion --help` for per-shell install instructions.
+
 ### Setup AI Agent
 
 ```bash

--- a/cmd/isms/cli_relations_test.go
+++ b/cmd/isms/cli_relations_test.go
@@ -164,4 +164,7 @@ func TestReviewApproveUsesApprovalEndpoint(t *testing.T) {
 	if r.body["decision"] != "approved" {
 		t.Errorf("decision not sent as 'approved': body=%v", r.body)
 	}
+	if r.body["comment"] != "LGTM" {
+		t.Errorf("comment not forwarded: body=%v", r.body)
+	}
 }

--- a/cmd/isms/cli_relations_test.go
+++ b/cmd/isms/cli_relations_test.go
@@ -142,3 +142,26 @@ func TestLegalAddSendsRelations(t *testing.T) {
 		t.Errorf("document refs = %v (full=%v)", refs["document"], refs)
 	}
 }
+
+// #51: `review approve` must go through the dedicated approval handler
+// (POST /reviews/:id/approve), not PUT /reviews/:id/status (which the server
+// rejects for anything but "closed") — and must not side-step it via /approvals.
+func TestReviewApproveUsesApprovalEndpoint(t *testing.T) {
+	srv, got := cliServer(t)
+	defer srv.Close()
+	cmd := reviewCmd()
+	cmd.SetArgs([]string{"approve", "7", "--comment", "LGTM"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("expected exactly one request, got %d: %+v", len(*got), *got)
+	}
+	r := (*got)[0]
+	if r.method != "POST" || r.path != "/v1/reviews/7/approve" {
+		t.Errorf("approve hit %s %s, want POST /v1/reviews/7/approve", r.method, r.path)
+	}
+	if r.body["decision"] != "approved" {
+		t.Errorf("decision not sent as 'approved': body=%v", r.body)
+	}
+}

--- a/cmd/isms/review.go
+++ b/cmd/isms/review.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"isms.sh/internal/isms/client"
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
 )
 
@@ -137,15 +136,12 @@ func reviewApproveCmd() *cobra.Command {
 			}
 
 			c := requireAPI()
-			approval := &db.Approval{
-				ReviewID: &id,
-				Decision: "approved",
-				Comment:  comment,
-			}
-			if err := c.AddApproval(approval); err != nil {
-				return err
-			}
-			if err := c.UpdateReviewStatus(id, "approved"); err != nil {
+			// Go through the dedicated approval handler so the decision log,
+			// content hash and status transition happen atomically. The old code
+			// hit PUT /reviews/:id/status with "approved", which the server
+			// rejects (status endpoint only allows "closed"), and side-stepped the
+			// approval governance (#51).
+			if err := c.ApproveReview(id, "approved", comment); err != nil {
 				return err
 			}
 			fmt.Printf("Review #%d approved.\n", id)

--- a/cmd/isms/review.go
+++ b/cmd/isms/review.go
@@ -136,11 +136,8 @@ func reviewApproveCmd() *cobra.Command {
 			}
 
 			c := requireAPI()
-			// Go through the dedicated approval handler so the decision log,
-			// content hash and status transition happen atomically. The old code
-			// hit PUT /reviews/:id/status with "approved", which the server
-			// rejects (status endpoint only allows "closed"), and side-stepped the
-			// approval governance (#51).
+			// The status endpoint only accepts "closed"; other transitions go
+			// through dedicated handlers — approve via the real approval handler (#51).
 			if err := c.ApproveReview(id, "approved", comment); err != nil {
 				return err
 			}

--- a/internal/isms/client/client.go
+++ b/internal/isms/client/client.go
@@ -518,11 +518,6 @@ func (c *Client) ResolveComment(id int) error {
 
 // --- Approvals ---
 
-func (c *Client) AddApproval(approval *db.Approval) error {
-	_, err := c.post("/v1/approvals", approval)
-	return err
-}
-
 // ApproveReview runs a review through the dedicated approval handler
 // (POST /reviews/:id/approve), which records the decision log, content hash and
 // status transition atomically. decision is "approved" or "changes_requested".

--- a/internal/isms/client/client.go
+++ b/internal/isms/client/client.go
@@ -523,6 +523,17 @@ func (c *Client) AddApproval(approval *db.Approval) error {
 	return err
 }
 
+// ApproveReview runs a review through the dedicated approval handler
+// (POST /reviews/:id/approve), which records the decision log, content hash and
+// status transition atomically. decision is "approved" or "changes_requested".
+func (c *Client) ApproveReview(id int, decision, comment string) error {
+	_, err := c.post(fmt.Sprintf("/v1/reviews/%d/approve", id), map[string]string{
+		"decision": decision,
+		"comment":  comment,
+	})
+	return err
+}
+
 // --- Tasks ---
 
 func (c *Client) ListTasks(assignee, status string) ([]db.Task, error) {

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -321,6 +321,7 @@ class TestCrossEntityLinkage:
         })
         assert r.status_code in [200, 201]
         TestCrossEntityLinkage.incident_id = r.json()["id"]
+        TestCrossEntityLinkage.incident_identifier = r.json()["identifier"]
 
         r = requests.post(f"{api_url}/corrective-actions", headers=admin_headers, json={
             "title": "Linkage test CA",
@@ -337,7 +338,7 @@ class TestCrossEntityLinkage:
             "source_type": "corrective_action",
             "source_id": ca["identifier"],
             "target_type": "incident",
-            "target_id": f"INC-{TestCrossEntityLinkage.incident_id}",
+            "target_id": TestCrossEntityLinkage.incident_identifier,
         })
         assert ref.status_code in [200, 201], f"Create reference failed: {ref.text}"
 


### PR DESCRIPTION
Two CLI items, conflict-free with the open #89.

## #51 — `review approve` bypassed the approval flow
The command called `AddApproval` (/approvals) then `UpdateReviewStatus(id, "approved")` → `PUT /reviews/:id/status`. But that endpoint **only accepts `closed`** (all other transitions go through dedicated handlers), so approve hit a dead path and side-stepped the real governance (decision log, content hash, atomic status transition in `handleReviewApprove`). It now calls the dedicated **POST /reviews/:id/approve** via a new `client.ApproveReview`, the same path the web UI uses.

## #54 — shell completion
Cobra already provides `isms completion <shell>`; added a README **Shell completion** section with load/install one-liners for bash/zsh.

## Tests
- `cmd/isms/cli_relations_test.go::TestReviewApproveUsesApprovalEndpoint` — `review approve 7` makes exactly **one** request, `POST /v1/reviews/7/approve` with `decision=approved` (no `PUT /status`, no `/approvals`).
- Verified `isms completion bash` emits a completion script (exit 0).
- `go test ./cmd/isms` green; build clean.

## Also: flaky-test fix (found running the suite)
`test_incident_reopen_clears_closure_metadata` was intermittently failing with "cannot resolve incident: 1 open corrective action(s) still linked". Root cause: `TestCrossEntityLinkage` created a CA→incident reference using the incident's numeric PK (`INC-<id>`) instead of its identifier. Identifiers are a monotonic sequence, so `INC-<pk>` is a **dangling** reference; once the sequence climbs to that value a later fresh incident inherits the dangling open-CA link and can't resolve — flaky and CI-seed-dependent. Fixed to reference the incident's real identifier. (Bundled here since it's a one-line test fix found during this PR's suite run.)

> `gofmt -l` may list `review.go`/`client.go` — pre-existing repo drift (#83), not from these changes.

Closes #51
Closes #54