### PR TITLE
fix: cron backfill writes changelog; evidence download works on local blob backend (#50, #31)

### DIFF
--- a/cmd/isms/manager.go
+++ b/cmd/isms/manager.go
@@ -101,7 +101,12 @@ func manageOrg(ctx context.Context, d *db.DB, orgID int, quiet bool) (created, b
 				if err := d.UpdateSupplier(ctx, orgID, &s); err == nil {
 					backfilled++
 					if changes := db.DiffFields("supplier", int64(s.ID), "system", "automated next_review backfill", before, s.ToChangeMap()); len(changes) > 0 {
-						_ = d.LogChanges(ctx, orgID, changes)
+						// Unlike an HTTP handler (which has a response as a signal),
+						// the cron's only signal is stdout — surface a silent
+						// audit-trail failure instead of swallowing it.
+						if err := d.LogChanges(ctx, orgID, changes); err != nil && !quiet {
+							fmt.Printf("[warn] changelog write failed for supplier %d: %v\n", s.ID, err)
+						}
 					}
 				}
 			}
@@ -118,7 +123,9 @@ func manageOrg(ctx context.Context, d *db.DB, orgID int, quiet bool) (created, b
 				if err := d.UpdateSystem(ctx, orgID, &sys); err == nil {
 					backfilled++
 					if changes := db.DiffFields("system", int64(sys.ID), "system", "automated next_review backfill", before, sys.ToChangeMap()); len(changes) > 0 {
-						_ = d.LogChanges(ctx, orgID, changes)
+						if err := d.LogChanges(ctx, orgID, changes); err != nil && !quiet {
+							fmt.Printf("[warn] changelog write failed for system %d: %v\n", sys.ID, err)
+						}
 					}
 				}
 			}

--- a/cmd/isms/manager.go
+++ b/cmd/isms/manager.go
@@ -96,9 +96,13 @@ func manageOrg(ctx context.Context, d *db.DB, orgID int, quiet bool) (created, b
 	if err == nil {
 		for _, s := range suppliers {
 			if s.NextReview == nil || s.NextReview.IsZero() {
+				before := s.ToChangeMap()
 				s.CalculateNextReview()
 				if err := d.UpdateSupplier(ctx, orgID, &s); err == nil {
 					backfilled++
+					if changes := db.DiffFields("supplier", int64(s.ID), "system", "automated next_review backfill", before, s.ToChangeMap()); len(changes) > 0 {
+						_ = d.LogChanges(ctx, orgID, changes)
+					}
 				}
 			}
 		}
@@ -109,9 +113,13 @@ func manageOrg(ctx context.Context, d *db.DB, orgID int, quiet bool) (created, b
 	if err == nil {
 		for _, sys := range systems {
 			if sys.NextReview == nil || sys.NextReview.IsZero() {
+				before := sys.ToChangeMap()
 				sys.CalculateNextReview()
 				if err := d.UpdateSystem(ctx, orgID, &sys); err == nil {
 					backfilled++
+					if changes := db.DiffFields("system", int64(sys.ID), "system", "automated next_review backfill", before, sys.ToChangeMap()); len(changes) > 0 {
+						_ = d.LogChanges(ctx, orgID, changes)
+					}
 				}
 			}
 		}

--- a/tests/test_evidence_download.py
+++ b/tests/test_evidence_download.py
@@ -5,6 +5,12 @@ streams the file directly. The frontend now branches on Content-Type to handle
 both. This test pins the backend contract the frontend relies on: on the file
 backend, GET /evidence/:id/download returns the raw file bytes with the file's
 content type — NOT a JSON envelope — so the client can save it.
+
+Coverage gap: the S3 backend path (JSON {url} response) is not covered here —
+the test stack runs ISMS_STORAGE_BACKEND=file and there's no mocked S3 (minio/
+localstack) fixture. The server-side S3 path is unchanged by this fix; only the
+client gained the Content-Type branch. Add a mock-S3 fixture if that path needs
+regression coverage.
 """
 import uuid
 

--- a/tests/test_evidence_download.py
+++ b/tests/test_evidence_download.py
@@ -1,0 +1,49 @@
+"""Regression for #31: evidence download on the local (file) blob backend.
+
+The S3 backend returns JSON {url} (a presigned link); the local/file backend
+streams the file directly. The frontend now branches on Content-Type to handle
+both. This test pins the backend contract the frontend relies on: on the file
+backend, GET /evidence/:id/download returns the raw file bytes with the file's
+content type — NOT a JSON envelope — so the client can save it.
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL
+
+
+def test_evidence_download_local_backend_streams_file_bytes(api_url, admin_headers):
+    suffix = uuid.uuid4().hex[:8]
+    auth = {"Authorization": admin_headers["Authorization"]}  # no JSON CT for multipart
+
+    p = requests.post(f"{api_url}/programs", headers=admin_headers, json={
+        "key": f"EVT{suffix}", "title": f"Evidence test program {suffix}",
+    })
+    assert p.status_code in (200, 201), f"program: {p.text}"
+    pid = p.json()["id"]
+
+    o = requests.post(f"{api_url}/objectives", headers=admin_headers, json={
+        "program_id": pid, "title": f"Evidence test objective {suffix}",
+    })
+    assert o.status_code in (200, 201), f"objective: {o.text}"
+    oid = o.json()["id"]
+
+    ch = requests.post(f"{api_url}/objectives/{oid}/checkins", headers=admin_headers, json={
+        "value_numeric": 1.0, "message": "evidence test", "created_by": ADMIN_EMAIL,
+    })
+    assert ch.status_code in (200, 201), f"checkin: {ch.text}"
+    cid = ch.json()["id"]
+
+    content = f"proof-bytes-{suffix}".encode()
+    up = requests.post(f"{api_url}/checkins/{cid}/evidence", headers=auth,
+                       files={"file": ("proof.txt", content, "text/plain")},
+                       data={"title": "Proof"})
+    assert up.status_code in (200, 201), f"upload: {up.text}"
+    eid = up.json()["id"]
+
+    # The file backend must stream the file, not return a JSON {url} envelope.
+    dl = requests.get(f"{api_url}/evidence/{eid}/download", headers=admin_headers)
+    assert dl.status_code == 200, dl.text
+    assert "application/json" not in dl.headers.get("content-type", ""), \
+        f"file backend should stream the file, got JSON: {dl.headers.get('content-type')}"
+    assert dl.content == content, "downloaded bytes must match the uploaded file"

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -438,7 +438,27 @@ export const api = {
     return res.json()
   },
   getEvidence: (checkinId) => fetchJSON(`${API}/checkins/${checkinId}/evidence`),
-  downloadEvidence: (id) => fetchJSON(`${API}/evidence/${id}/download`),
+  // Evidence download has two backends: S3 returns JSON {url} to redirect to;
+  // the local (file) backend streams the file directly. Branch on Content-Type
+  // so the local backend works instead of failing to parse bytes as JSON (#31).
+  downloadEvidence: async (id) => {
+    const res = await fetch(`${API}/evidence/${id}/download`, { headers: getHeaders() })
+    if (res.status === 401) {
+      clearApiToken()
+      window.dispatchEvent(new Event('isms:unauthorized'))
+      const e = new Error('Authentication required'); e.status = 401; throw e
+    }
+    if (!res.ok) {
+      const e = new Error(`${res.status} ${res.statusText}`); e.status = res.status; throw e
+    }
+    if ((res.headers.get('content-type') || '').includes('application/json')) {
+      return await res.json() // S3 backend: { url, title, content_type }
+    }
+    // Local backend: the file itself — hand back a blob + filename to save.
+    const cd = res.headers.get('content-disposition') || ''
+    const m = /filename="?([^"]+)"?/.exec(cd)
+    return { blob: await res.blob(), filename: m ? m[1] : `evidence-${id}` }
+  },
   deleteEvidence: (id) => deleteJSON(`${API}/evidence/${id}`),
 
   // Overdue

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -442,14 +442,12 @@ export const api = {
   // the local (file) backend streams the file directly. Branch on Content-Type
   // so the local backend works instead of failing to parse bytes as JSON (#31).
   downloadEvidence: async (id) => {
-    const res = await fetch(`${API}/evidence/${id}/download`, { headers: getHeaders() })
-    if (res.status === 401) {
-      clearApiToken()
-      window.dispatchEvent(new Event('isms:unauthorized'))
-      const e = new Error('Authentication required'); e.status = 401; throw e
-    }
+    const res = await safeFetch(`${API}/evidence/${id}/download`, { headers: getHeaders() })
+    checkAuth(res)
     if (!res.ok) {
-      const e = new Error(`${res.status} ${res.statusText}`); e.status = res.status; throw e
+      const e = new Error(`${res.status} ${res.statusText}`)
+      e.status = res.status
+      throw e
     }
     if ((res.headers.get('content-type') || '').includes('application/json')) {
       return await res.json() // S3 backend: { url, title, content_type }

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -1112,7 +1112,18 @@ async function downloadEv(ev) {
   try {
     const result = await api.downloadEvidence(ev.id)
     if (result?.url) {
+      // S3 backend: presigned URL.
       window.open(result.url, '_blank')
+    } else if (result?.blob) {
+      // Local (file) backend: trigger a download of the streamed file.
+      const objUrl = URL.createObjectURL(result.blob)
+      const a = document.createElement('a')
+      a.href = objUrl
+      a.download = result.filename || ev.title || 'evidence'
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(objUrl)
     }
   } catch (e) {
     error.value = e.message

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -1124,6 +1124,8 @@ async function downloadEv(ev) {
       a.click()
       a.remove()
       URL.revokeObjectURL(objUrl)
+    } else {
+      error.value = 'Download failed: unexpected response from server'
     }
   } catch (e) {
     error.value = e.message


### PR DESCRIPTION
Two data/storage bugs, conflict-free with the open #89/#90.

## #50 — cron backfill skipped the changelog
The manager backfills missing `next_review` on suppliers and systems, but did so via `UpdateSupplier`/`UpdateSystem` with **no changelog entry** — automated changes never reached the audit trail. Now logs them with `DiffFields` + `LogChanges` (actor `system`), the same pattern every API update handler uses.

## #31 — evidence download broken on the local (file) backend
`handleDownloadEvidence` returns a JSON `{url}` for S3 but **streams the file directly** on the local backend. The client always did `fetchJSON`, so on the default file backend the download silently failed (binary parsed as JSON). `api.downloadEvidence` now branches on Content-Type; `Objectives.vue` opens the URL for S3 and saves a blob for local.

## Tests
- `tests/test_evidence_download.py` — pins the contract the client depends on: on the file backend, `GET /evidence/:id/download` returns the raw bytes with the file's content type, not a JSON envelope. Green against the stack.
- **#50 testing note:** it's a cron/CLI path with no HTTP trigger and no Go DB test harness, so it isn't reachable from the integration suite. Build-verified; the change is a 1:1 mirror of the changelog logging in the API update handlers. (A testable manager trigger would be a separate improvement.)

Closes #50
Closes #31