### PR TITLE
fix: valid task types in manual form + drop dead 'control' title-resolver case (#32, #37)

### DIFF
--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -266,22 +266,6 @@ func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, entityType, 
 		}
 		return p.Title
 
-	case "control":
-		// Controls are documents — resolve via document_id lookup.
-		st, err := s.storeForOrg(ctx, orgID)
-		if err != nil {
-			return entityID
-		}
-		path := st.FindDocumentByID(entityID)
-		if path == "" {
-			return entityID
-		}
-		doc, err := st.LoadDocument(path)
-		if err != nil {
-			return entityID
-		}
-		return doc.Frontmatter.Title
-
 	case "document":
 		st, err := s.storeForOrg(ctx, orgID)
 		if err != nil {

--- a/tests/test_task_types.py
+++ b/tests/test_task_types.py
@@ -1,0 +1,42 @@
+"""Regression for #32: the manual task-creation form must only offer task types
+the API actually accepts.
+
+The Add Task form used to list types (risk_review, supplier_review, ...) that
+aren't in the task_type enum at all, so picking them 400'd. This pins the
+contract: every type the form now offers is accepted, and the removed bogus ones
+are rejected. (The *_followup types are valid but system-generated, so they're
+intentionally not in the manual form — only in the filter.)
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL
+
+# The types the manual create form offers after #32.
+MANUAL_TYPES = ["general", "review", "onboarding", "offboarding", "training", "other"]
+
+# Types the old form wrongly offered — not in the enum.
+REMOVED_BOGUS_TYPES = [
+    "risk_review", "supplier_review", "access_review",
+    "legal_review", "document_review", "objective_checkin", "corrective_action",
+]
+
+
+def test_manual_task_types_are_accepted(api_url, admin_headers):
+    for t in MANUAL_TYPES:
+        r = requests.post(f"{api_url}/tasks", headers=admin_headers, json={
+            "title": f"task-type {t} {uuid.uuid4().hex[:8]}",
+            "task_type": t,
+            "assignee": ADMIN_EMAIL,
+        })
+        assert r.status_code in (200, 201), f"manual type {t!r} must be accepted: {r.status_code} {r.text}"
+
+
+def test_removed_form_types_are_rejected(api_url, admin_headers):
+    for t in REMOVED_BOGUS_TYPES:
+        r = requests.post(f"{api_url}/tasks", headers=admin_headers, json={
+            "title": f"bogus-type {t} {uuid.uuid4().hex[:8]}",
+            "task_type": t,
+            "assignee": ADMIN_EMAIL,
+        })
+        assert r.status_code == 400, f"removed type {t!r} should be rejected by the API: {r.status_code} {r.text}"

--- a/tests/test_task_types.py
+++ b/tests/test_task_types.py
@@ -6,6 +6,9 @@ aren't in the task_type enum at all, so picking them 400'd. This pins the
 contract: every type the form now offers is accepted, and the removed bogus ones
 are rejected. (The *_followup types are valid but system-generated, so they're
 intentionally not in the manual form — only in the filter.)
+
+Covers both manual forms: Tasks.vue and Inbox.vue (which also wrongly offered
+implementation and change_request).
 """
 import uuid
 
@@ -15,10 +18,13 @@ from conftest import ADMIN_EMAIL
 # The types the manual create form offers after #32.
 MANUAL_TYPES = ["general", "review", "onboarding", "offboarding", "training", "other"]
 
-# Types the old form wrongly offered — not in the enum.
+# Types the old forms wrongly offered — not in the enum.
+# Tasks.vue offered the *_review / objective_checkin / corrective_action set;
+# Inbox.vue additionally offered implementation and change_request (#32).
 REMOVED_BOGUS_TYPES = [
     "risk_review", "supplier_review", "access_review",
     "legal_review", "document_review", "objective_checkin", "corrective_action",
+    "implementation", "change_request",
 ]
 
 

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -263,11 +263,14 @@
             <div>
               <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
               <select v-model="newTask.task_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                <option value="review">Review</option>
-                <option value="implementation">Implementation</option>
-                <option value="corrective_action">Corrective Action</option>
-                <option value="change_request">Change Request</option>
+                <!-- Manual task types only. The *_followup types are created
+                     automatically by the system, not chosen here (#32). -->
                 <option value="general">General</option>
+                <option value="review">Review</option>
+                <option value="onboarding">Onboarding</option>
+                <option value="offboarding">Offboarding</option>
+                <option value="training">Training</option>
+                <option value="other">Other</option>
               </select>
             </div>
             <div>

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -43,14 +43,13 @@
           <div>
             <label class="block text-xs text-slate-500 mb-1">Type</label>
             <select v-model="form.task_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
+              <!-- Manual task types only. The *_followup types are created
+                   automatically by the system, not chosen here (#32). -->
               <option value="general">General</option>
-              <option value="risk_review">Risk review</option>
-              <option value="supplier_review">Supplier review</option>
-              <option value="access_review">Access review</option>
-              <option value="legal_review">Legal review</option>
-              <option value="document_review">Document review</option>
-              <option value="objective_checkin">Objective check-in</option>
-              <option value="corrective_action">Corrective action</option>
+              <option value="review">Review</option>
+              <option value="onboarding">Onboarding</option>
+              <option value="offboarding">Offboarding</option>
+              <option value="training">Training</option>
               <option value="other">Other</option>
             </select>
           </div>
@@ -100,13 +99,14 @@
         <select v-model="filterTaskType" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
           <option value="">All types</option>
           <option value="general">General</option>
-          <option value="risk_review">Risk review</option>
-          <option value="supplier_review">Supplier review</option>
-          <option value="access_review">Access review</option>
-          <option value="legal_review">Legal review</option>
-          <option value="document_review">Document review</option>
-          <option value="objective_checkin">Objective check-in</option>
-          <option value="corrective_action">Corrective action</option>
+          <option value="review">Review</option>
+          <option value="incident_followup">Incident follow-up</option>
+          <option value="audit_followup">Audit follow-up</option>
+          <option value="ca_followup">Corrective action follow-up</option>
+          <option value="change_followup">Change follow-up</option>
+          <option value="onboarding">Onboarding</option>
+          <option value="offboarding">Offboarding</option>
+          <option value="training">Training</option>
           <option value="other">Other</option>
         </select>
         <div class="w-48">
@@ -244,14 +244,17 @@
                       <div>
                         <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
                         <select v-model="editForm.task_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
+                          <!-- All real task types, so an auto-generated task's
+                               type is representable when editing (#32). -->
                           <option value="general">General</option>
-                          <option value="risk_review">Risk review</option>
-                          <option value="supplier_review">Supplier review</option>
-                          <option value="access_review">Access review</option>
-                          <option value="legal_review">Legal review</option>
-                          <option value="document_review">Document review</option>
-                          <option value="objective_checkin">Objective check-in</option>
-                          <option value="corrective_action">Corrective action</option>
+                          <option value="review">Review</option>
+                          <option value="incident_followup">Incident follow-up</option>
+                          <option value="audit_followup">Audit follow-up</option>
+                          <option value="ca_followup">Corrective action follow-up</option>
+                          <option value="change_followup">Change follow-up</option>
+                          <option value="onboarding">Onboarding</option>
+                          <option value="offboarding">Offboarding</option>
+                          <option value="training">Training</option>
                           <option value="other">Other</option>
                         </select>
                       </div>


### PR DESCRIPTION
Two cleanups, conflict-free with the open #91.

## #32 — Add Task form offered invalid task types
The create form (and the type filter) listed types that aren't in the `task_type` enum (`risk_review`, `supplier_review`, `access_review`, `legal_review`, `document_review`, `objective_checkin`, `corrective_action`). `handleCreateTask` validates `task_type`, so picking any of them **400'd** on submit — manual task creation was broken for everything except General/Other. The create form now offers only valid **manual** types (general, review, onboarding, offboarding, training, other); the `*_followup` types are system-generated so they're not in the manual form. The filter lists all real types (so you can filter auto-generated tasks too).

## #37 — dead 'control' case in the title resolver
`resolveEntityTitle` had a `case "control"` that resolved via document lookup — but references use type `"document"` for documents; `"control"` is never a reference type (only a frontmatter *subtype* for display). The case duplicated the `"document"` branch. Pure dead-code removal, no behaviour change.

## Tests
- `tests/test_task_types.py` — pins the form↔enum contract: every manual type the form offers is accepted by `POST /tasks`; the removed bogus types are rejected (400). Green against the stack.
- #37 is dead-code removal (the case was unreachable), so no behaviour to test — build-verified.

Closes #32
Closes #37