### PR TITLE
feat(invite): resend-invite action for pending invited users (#42)

### DIFF
--- a/internal/isms/api/api_auth.go
+++ b/internal/isms/api/api_auth.go
@@ -702,6 +702,65 @@ func (s *Server) handleInviteUser(c echo.Context) error {
 	})
 }
 
+// handleResendInvite re-sends the verification email to a pending (not yet
+// verified) invited user — for invites that were lost or expired (#42).
+func (s *Server) handleResendInvite(c echo.Context) error {
+	if err := requireRole(c, "admin", "manager"); err != nil {
+		return err
+	}
+	orgID := getOrgID(c)
+	ctx := c.Request().Context()
+
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+	}
+	if req.Email == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "email is required")
+	}
+
+	user, err := s.db.GetUserByEmail(ctx, req.Email)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "user not found")
+	}
+	// Must be a member of this org — don't resend across organizations.
+	if _, err := s.db.GetOrgMember(ctx, orgID, user.ID); err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "user is not a member of this organization")
+	}
+	// Only pending invites can be resent; an active user has already accepted.
+	if user.Active {
+		return echo.NewHTTPError(http.StatusConflict, "user has already accepted the invite")
+	}
+
+	if s.mailer == nil || !s.mailer.Enabled() {
+		return echo.NewHTTPError(http.StatusInternalServerError, "email not configured (SMTP_HOST)")
+	}
+
+	// Fresh verification token (72h), same as the original invite.
+	raw := make([]byte, 32)
+	rand.Read(raw)
+	token := hex.EncodeToString(raw)
+	hash := sha256.Sum256([]byte(token))
+	if err := s.db.CreateEmailVerification(ctx, user.ID, hex.EncodeToString(hash[:])); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "creating verification: "+err.Error())
+	}
+
+	m := s.orgMail(ctx, orgID)
+	if err := s.mailer.SendVerificationBranded(user.Email, user.Name, m.PublicURL, token, m.Branding); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "sending email: "+err.Error())
+	}
+
+	s.logAndNotify(ctx, orgID, &db.Activity{
+		Actor:  getUserEmail(c),
+		Action: "user_invite_resent",
+		Detail: fmt.Sprintf("Resent invite to %s", user.Email),
+	})
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "invite_resent", "email": user.Email})
+}
+
 // --- Verify email + set password ---
 
 type verifyEmailRequest struct {

--- a/internal/isms/api/api_auth.go
+++ b/internal/isms/api/api_auth.go
@@ -738,18 +738,27 @@ func (s *Server) handleResendInvite(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "email not configured (SMTP_HOST)")
 	}
 
+	// Invalidate any still-live invite tokens before issuing a new one, so a
+	// leaked/intercepted earlier link can't be used in parallel with this one.
+	if err := s.db.InvalidateEmailVerifications(ctx, user.ID, "verify"); err != nil {
+		log.Printf("resend-invite: invalidating old tokens for %s failed: %v", user.Email, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "creating verification")
+	}
+
 	// Fresh verification token (72h), same as the original invite.
 	raw := make([]byte, 32)
 	rand.Read(raw)
 	token := hex.EncodeToString(raw)
 	hash := sha256.Sum256([]byte(token))
 	if err := s.db.CreateEmailVerification(ctx, user.ID, hex.EncodeToString(hash[:])); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "creating verification: "+err.Error())
+		log.Printf("resend-invite: creating verification for %s failed: %v", user.Email, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "creating verification")
 	}
 
 	m := s.orgMail(ctx, orgID)
 	if err := s.mailer.SendVerificationBranded(user.Email, user.Name, m.PublicURL, token, m.Branding); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "sending email: "+err.Error())
+		log.Printf("resend-invite: sending email to %s failed: %v", user.Email, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to send invite email")
 	}
 
 	s.logAndNotify(ctx, orgID, &db.Activity{

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -441,6 +441,7 @@ func (s *Server) routes() {
 
 	// User management (authenticated)
 	api.POST("/auth/invite", s.handleInviteUser)
+	api.POST("/auth/resend-invite", s.handleResendInvite)
 
 	// Self-service (authenticated)
 	api.PUT("/auth/password", s.handleChangePassword)

--- a/internal/isms/db/email_verify.go
+++ b/internal/isms/db/email_verify.go
@@ -14,6 +14,18 @@ type EmailVerification struct {
 	CreatedAt Epoch  `json:"created_at"`
 }
 
+// InvalidateEmailVerifications marks every live (unused) token of the given
+// purpose for a user as used. Call it before issuing a fresh token so a resend
+// doesn't leave older invite/reset links usable in parallel.
+func (d *DB) InvalidateEmailVerifications(ctx context.Context, userID int, purpose string) error {
+	_, err := d.pool.Exec(ctx, `
+		UPDATE email_verifications
+		SET used_at = now()
+		WHERE user_id = $1 AND purpose = $2 AND used_at IS NULL
+	`, userID, purpose)
+	return err
+}
+
 // CreateEmailVerification stores a new verification token (72h expiry).
 func (d *DB) CreateEmailVerification(ctx context.Context, userID int, tokenHash string) error {
 	_, err := d.pool.Exec(ctx, `

--- a/tests/test_resend_invite.py
+++ b/tests/test_resend_invite.py
@@ -1,0 +1,35 @@
+"""Regression for #42: resend-invite for pending invited users.
+
+The happy path (resend succeeds, email sent) needs SMTP, which the test stack
+doesn't configure — so this covers the auth + eligibility guards that run before
+the mailer: only admins/managers may resend, only pending users qualify, and an
+unknown email 404s. (Those guards are the safety-relevant part of the endpoint.)
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL, CONTRIBUTOR_EMAIL
+
+
+def test_resend_requires_manager_or_admin(api_url, contributor_headers):
+    r = requests.post(f"{api_url}/auth/resend-invite", headers=contributor_headers,
+                      json={"email": ADMIN_EMAIL})
+    assert r.status_code == 403, f"contributors must not resend invites: {r.status_code} {r.text}"
+
+
+def test_resend_to_active_user_is_rejected(api_url, admin_headers):
+    # CONTRIBUTOR_EMAIL is an active, accepted member — nothing to resend.
+    r = requests.post(f"{api_url}/auth/resend-invite", headers=admin_headers,
+                      json={"email": CONTRIBUTOR_EMAIL})
+    assert r.status_code == 409, f"resend to an active user should be 409: {r.status_code} {r.text}"
+
+
+def test_resend_to_unknown_user_404(api_url, admin_headers):
+    r = requests.post(f"{api_url}/auth/resend-invite", headers=admin_headers,
+                      json={"email": f"nobody-{uuid.uuid4().hex[:8]}@isms-test.local"})
+    assert r.status_code == 404, f"resend to an unknown user should be 404: {r.status_code} {r.text}"
+
+
+def test_resend_requires_email(api_url, admin_headers):
+    r = requests.post(f"{api_url}/auth/resend-invite", headers=admin_headers, json={})
+    assert r.status_code == 400, f"missing email should be 400: {r.status_code} {r.text}"

--- a/web/src/views/Admin.vue
+++ b/web/src/views/Admin.vue
@@ -905,6 +905,7 @@ async function sendInvite() {
 
 async function resendInvite(member) {
   membersMsg.value = ''
+  membersError.value = false
   try {
     await api.postJSON('/api/v1/auth/resend-invite', { email: member.email })
     membersMsg.value = `Invite resent to ${member.email}`

--- a/web/src/views/Admin.vue
+++ b/web/src/views/Admin.vue
@@ -50,6 +50,7 @@
                     </div>
                     <span class="text-sm text-slate-200">{{ member.name || '-' }}</span>
                     <span v-if="member.is_agent" class="ml-1.5 px-1.5 py-0.5 rounded text-[9px] font-semibold bg-purple-500/15 text-purple-400">AI Agent</span>
+                    <span v-if="!member.active" class="ml-1.5 px-1.5 py-0.5 rounded text-[9px] font-semibold bg-amber-500/15 text-amber-400">Pending</span>
                   </div>
                 </td>
                 <td class="px-5 py-3 text-sm text-slate-400">{{ member.email }}</td>
@@ -66,6 +67,10 @@
                   </select>
                 </td>
                 <td class="px-5 py-3 text-right">
+                  <button v-if="!member.active" @click="resendInvite(member)"
+                    class="text-xs text-blue-400 hover:text-blue-300 px-2 py-1 rounded hover:bg-blue-500/10 transition-colors mr-1">
+                    Resend invite
+                  </button>
                   <button @click="removeMember(member)"
                     class="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-red-500/10 transition-colors">
                     Remove
@@ -895,6 +900,18 @@ async function sendInvite() {
     inviteError.value = true
   } finally {
     inviting.value = false
+  }
+}
+
+async function resendInvite(member) {
+  membersMsg.value = ''
+  try {
+    await api.postJSON('/api/v1/auth/resend-invite', { email: member.email })
+    membersMsg.value = `Invite resent to ${member.email}`
+    membersError.value = false
+  } catch (e) {
+    membersMsg.value = e.message
+    membersError.value = true
   }
 }
 


### PR DESCRIPTION
## #42 — resend a lost/expired invite
An invited user who never verified (email lost or the 72h token expired) was stranded — no way to get a new link short of remove + re-invite.

**Backend:** `POST /auth/resend-invite {email}` (admin/manager). Issues a fresh verification token and re-sends the branded email, but only for someone who is a **member of the caller's org** and still **pending** (`active=false`). An already-active user gets 409; unknown user 404. Reuses the same token + `SendVerificationBranded` path as the original invite (org-branded sender + per-org link, via `orgMail`).

**Frontend:** the Admin → Members list shows a **Pending** badge for unverified members and a **Resend invite** action for them.

## Tests
`tests/test_resend_invite.py` covers the auth + eligibility guards: non-admin → 403, active user → 409, unknown email → 404, missing email → 400.

> Testing note: the happy path sends an email, and the test stack has no SMTP configured (same limitation as #16's per-org email work), so the success path isn't integration-tested. All four asserted guards run **before** the mailer check, so they're covered; the send path mirrors the existing, reviewed invite handler.

Closes #42