### PR TITLE
chore: gofmt the tree + gofmt CI gate (#83)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: gofmt
+        # Fail the build on any file that isn't gofmt-formatted, so diffs stay
+        # free of import-order / whitespace churn. Fix locally with `just fmt`.
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-formatted:"
+            echo "$unformatted"
+            echo "Run: just fmt"
+            exit 1
+          fi
       - name: Placeholder web dist
         # cmd/isms embeds web/dist (go:embed fails on an empty pattern); the
         # unit job doesn't exercise the SPA, so a placeholder satisfies it

--- a/Justfile
+++ b/Justfile
@@ -135,6 +135,10 @@ release VERSION:
 
 # ── Maintenance ──────────────────────────────────────────────────────────────
 
+# Format all Go files (matches the gofmt CI gate in tests.yml)
+fmt:
+    gofmt -w .
+
 # Run go mod tidy
 tidy:
     go mod tidy

--- a/cmd/isms/asset.go
+++ b/cmd/isms/asset.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/db"
 )
 
 func assetCmd() *cobra.Command {

--- a/cmd/isms/audit.go
+++ b/cmd/isms/audit.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/db"
 )
 
 func auditCmd() *cobra.Command {

--- a/cmd/isms/export.go
+++ b/cmd/isms/export.go
@@ -67,11 +67,11 @@ func exportPolicyCmd() *cobra.Command {
 	var format, output string
 
 	cmd := &cobra.Command{
-		Use:   "policy <doc-id>",
-		Short: "Export a single policy as markdown",
-		Long:  "Export a policy document. Use the document ID (e.g. POL-AC-001).",
+		Use:     "policy <doc-id>",
+		Short:   "Export a single policy as markdown",
+		Long:    "Export a policy document. Use the document ID (e.g. POL-AC-001).",
 		Example: "  isms export policy POL-AC-001\n  isms export policy POL-AC-001 --output policy.md",
-		Args:  cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkExportFormat(format); err != nil {
 				return err

--- a/cmd/isms/main.go
+++ b/cmd/isms/main.go
@@ -205,7 +205,7 @@ func apiClient() *client.Client {
 	}
 	apiKey := os.Getenv("ISMS_API_KEY")
 	if apiKey == "" {
-		apiKey = os.Getenv("ISMS_API_TOKEN") 
+		apiKey = os.Getenv("ISMS_API_TOKEN")
 	}
 	return client.New(client.Config{
 		BaseURL:        apiURL,

--- a/cmd/isms/migrate.go
+++ b/cmd/isms/migrate.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/db"
 )
 
 //go:embed migrations/*.sql

--- a/cmd/isms/review.go
+++ b/cmd/isms/review.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"isms.sh/internal/isms/client"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/client"
 )
 
 func reviewCmd() *cobra.Command {

--- a/cmd/isms/risk.go
+++ b/cmd/isms/risk.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
 	"isms.sh/internal/isms/db"
 	riskpkg "isms.sh/internal/isms/risk"
-	"github.com/spf13/cobra"
 )
 
 func riskCmd() *cobra.Command {
@@ -20,31 +20,31 @@ func riskCmd() *cobra.Command {
 
 func riskAddCmd() *cobra.Command {
 	var (
-		title                        string
-		description                  string
-		riskType                     string
-		origin                       string
-		category                     string
-		assets                       []string
-		currentLikelihood            int
-		currentImpact                int
-		confidentialityImpact        int
-		integrityImpact              int
-		availabilityImpact           int
-		inherentLikelihood           int
-		inherentImpact               int
+		title                         string
+		description                   string
+		riskType                      string
+		origin                        string
+		category                      string
+		assets                        []string
+		currentLikelihood             int
+		currentImpact                 int
+		confidentialityImpact         int
+		integrityImpact               int
+		availabilityImpact            int
+		inherentLikelihood            int
+		inherentImpact                int
 		inherentConfidentialityImpact int
-		inherentIntegrityImpact      int
-		inherentAvailabilityImpact   int
-		targetLikelihood             int
-		targetImpact                 int
-		treatment                    string
-		treatmentPlan                string
-		linkedDocs []string
-		owner                        string
-		status                       string
-		reviewDate                   string
-		notes                        string
+		inherentIntegrityImpact       int
+		inherentAvailabilityImpact    int
+		targetLikelihood              int
+		targetImpact                  int
+		treatment                     string
+		treatmentPlan                 string
+		linkedDocs                    []string
+		owner                         string
+		status                        string
+		reviewDate                    string
+		notes                         string
 	)
 
 	cmd := &cobra.Command{
@@ -66,27 +66,27 @@ func riskAddCmd() *cobra.Command {
 			r := &db.Risk{
 				Title:                         title,
 				Description:                   description,
-				RiskType:                       riskType,
-				Origin:                         origin,
-				Category:                       category,
-				CurrentLikelihood:              &currentLikelihood,
-				CurrentImpact:                  &currentImpact,
-				ConfidentialityImpact:          &confidentialityImpact,
-				IntegrityImpact:                &integrityImpact,
-				AvailabilityImpact:             &availabilityImpact,
-				InherentLikelihood:             &inherentLikelihood,
-				InherentImpact:                 &inherentImpact,
-				InherentConfidentialityImpact:  &inherentConfidentialityImpact,
-				InherentIntegrityImpact:        &inherentIntegrityImpact,
-				InherentAvailabilityImpact:     &inherentAvailabilityImpact,
-				TargetLikelihood:               &targetLikelihood,
-				TargetImpact:                   &targetImpact,
-				Treatment:                      treatment,
-				TreatmentPlan:                  treatmentPlan,
-				Owner:                          owner,
-				Status:                         status,
-				NextReview:                     rd,
-				Notes:                          notes,
+				RiskType:                      riskType,
+				Origin:                        origin,
+				Category:                      category,
+				CurrentLikelihood:             &currentLikelihood,
+				CurrentImpact:                 &currentImpact,
+				ConfidentialityImpact:         &confidentialityImpact,
+				IntegrityImpact:               &integrityImpact,
+				AvailabilityImpact:            &availabilityImpact,
+				InherentLikelihood:            &inherentLikelihood,
+				InherentImpact:                &inherentImpact,
+				InherentConfidentialityImpact: &inherentConfidentialityImpact,
+				InherentIntegrityImpact:       &inherentIntegrityImpact,
+				InherentAvailabilityImpact:    &inherentAvailabilityImpact,
+				TargetLikelihood:              &targetLikelihood,
+				TargetImpact:                  &targetImpact,
+				Treatment:                     treatment,
+				TreatmentPlan:                 treatmentPlan,
+				Owner:                         owner,
+				Status:                        status,
+				NextReview:                    rd,
+				Notes:                         notes,
 			}
 			result, err := c.AddRisk(r, buildRefs(
 				refSpec{"asset", assets},

--- a/cmd/isms/serve.go
+++ b/cmd/isms/serve.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/spf13/cobra"
 	"isms.sh/internal/isms/api"
 	"isms.sh/internal/isms/db"
-	"github.com/spf13/cobra"
 )
 
 func serveCmd() *cobra.Command {

--- a/cmd/isms/supplier.go
+++ b/cmd/isms/supplier.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/db"
 )
 
 func supplierCmd() *cobra.Command {

--- a/cmd/isms/system.go
+++ b/cmd/isms/system.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/db"
 )
 
 func systemCmd() *cobra.Command {

--- a/cmd/isms/token.go
+++ b/cmd/isms/token.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"text/tabwriter"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/db"
 )
 
 // connectDB connects to Postgres using DATABASE_URL.

--- a/cmd/isms/tui.go
+++ b/cmd/isms/tui.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"isms.sh/internal/isms/tui"
 	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/tui"
 )
 
 func tuiCmd() *cobra.Command {

--- a/cmd/isms/user.go
+++ b/cmd/isms/user.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"isms.sh/internal/isms/db"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
+	"isms.sh/internal/isms/db"
 )
 
 func userCmd() *cobra.Command {

--- a/internal/isms/api/api_admin.go
+++ b/internal/isms/api/api_admin.go
@@ -323,11 +323,11 @@ func (s *Server) handleAdminTestOIDC(c echo.Context) error {
 	// Extract endpoint info
 	endpoint := oidcProvider.Endpoint()
 	return c.JSON(http.StatusOK, map[string]interface{}{
-		"success":        true,
-		"auth_url":       endpoint.AuthURL,
-		"token_url":      endpoint.TokenURL,
-		"discovery_url":  provider.DiscoveryURL,
-		"scopes":         strings.Split(provider.Scopes, " "),
+		"success":       true,
+		"auth_url":      endpoint.AuthURL,
+		"token_url":     endpoint.TokenURL,
+		"discovery_url": provider.DiscoveryURL,
+		"scopes":        strings.Split(provider.Scopes, " "),
 	})
 }
 

--- a/internal/isms/api/api_audit.go
+++ b/internal/isms/api/api_audit.go
@@ -32,15 +32,15 @@ type auditProgrammeUpdateRequest struct {
 }
 
 type auditCreateRequest struct {
-	ProgrammeID *int       `json:"programme_id"`
-	Title       string     `json:"title"`
-	Scope       string     `json:"scope"`
-	Auditor     string     `json:"auditor"`
-	AuditType   string     `json:"audit_type"`
-	Status      string     `json:"status"`
-	PlannedDate *db.Epoch  `json:"planned_date"`
-	EndDate     *db.Epoch  `json:"end_date"`
-	Notes       string     `json:"notes"`
+	ProgrammeID *int      `json:"programme_id"`
+	Title       string    `json:"title"`
+	Scope       string    `json:"scope"`
+	Auditor     string    `json:"auditor"`
+	AuditType   string    `json:"audit_type"`
+	Status      string    `json:"status"`
+	PlannedDate *db.Epoch `json:"planned_date"`
+	EndDate     *db.Epoch `json:"end_date"`
+	Notes       string    `json:"notes"`
 }
 
 // auditUpdateRequest is the API contract for updating an audit. nil = leave alone.

--- a/internal/isms/api/api_auth.go
+++ b/internal/isms/api/api_auth.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"isms.sh/internal/isms/db"
 	"golang.org/x/crypto/bcrypt"
+	"isms.sh/internal/isms/db"
 )
 
 // --- Per-account brute-force protection (DB-backed) ---

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -408,7 +408,7 @@ func (s *Server) handleReviewTimeline(c echo.Context) error {
 
 	// Build unified timeline entries.
 	type TimelineEntry struct {
-		Type        string      `json:"type"`       // "activity", "comment", "approval", "assignment", "decision"
+		Type        string      `json:"type"` // "activity", "comment", "approval", "assignment", "decision"
 		Actor       string      `json:"actor"`
 		Action      string      `json:"action"`
 		Detail      string      `json:"detail,omitempty"`
@@ -1023,12 +1023,12 @@ func (s *Server) handleReviewApprove(c echo.Context) error {
 	}
 
 	resp := map[string]interface{}{
-		"approval":           approval,
-		"review_status":      newStatus,
-		"round":              review.Round,
-		"total_reviewers":    totalAssigned,
-		"approved_count":     approvedCount,
-		"pending_reviewers":  pendingReviewers,
+		"approval":          approval,
+		"review_status":     newStatus,
+		"round":             review.Round,
+		"total_reviewers":   totalAssigned,
+		"approved_count":    approvedCount,
+		"pending_reviewers": pendingReviewers,
 	}
 	if autoMerged {
 		resp["auto_merged"] = true

--- a/internal/isms/api/api_oidc.go
+++ b/internal/isms/api/api_oidc.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/labstack/echo/v4"
-	"isms.sh/internal/isms/db"
 	"golang.org/x/oauth2"
+	"isms.sh/internal/isms/db"
 )
 
 // handleOIDCProviders returns the list of enabled OIDC providers for an organization.
@@ -107,12 +107,12 @@ func (s *Server) handleOIDCAuthorize(c echo.Context) error {
 
 	// Store session (10 minute expiry)
 	session := &db.OIDCSession{
-		State:       state,
-		Nonce:       nonce,
-		ProviderID:  provider.ID,
+		State:          state,
+		Nonce:          nonce,
+		ProviderID:     provider.ID,
 		OrganizationID: org.ID,
-		RedirectURI: redirectURI,
-		ExpiresAt:   time.Now().Add(10 * time.Minute),
+		RedirectURI:    redirectURI,
+		ExpiresAt:      time.Now().Add(10 * time.Minute),
 	}
 	if err := s.db.CreateOIDCSession(ctx, session); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "creating OIDC session: "+err.Error())

--- a/internal/isms/api/api_passkey.go
+++ b/internal/isms/api/api_passkey.go
@@ -22,9 +22,9 @@ type webAuthnUser struct {
 	creds []webauthn.Credential
 }
 
-func (u *webAuthnUser) WebAuthnID() []byte            { return []byte(fmt.Sprintf("%d", u.user.ID)) }
-func (u *webAuthnUser) WebAuthnName() string           { return u.user.Email }
-func (u *webAuthnUser) WebAuthnDisplayName() string    { return u.user.Name }
+func (u *webAuthnUser) WebAuthnID() []byte                         { return []byte(fmt.Sprintf("%d", u.user.ID)) }
+func (u *webAuthnUser) WebAuthnName() string                       { return u.user.Email }
+func (u *webAuthnUser) WebAuthnDisplayName() string                { return u.user.Name }
 func (u *webAuthnUser) WebAuthnCredentials() []webauthn.Credential { return u.creds }
 
 // dbCredToWebAuthn converts a stored DB credential to the library's Credential type.

--- a/internal/isms/api/api_policies.go
+++ b/internal/isms/api/api_policies.go
@@ -224,4 +224,3 @@ func (s *Server) handleReviewPolicyStatus(c echo.Context) error {
 		"can_auto_merge": canAutoMerge,
 	})
 }
-

--- a/internal/isms/api/api_readings.go
+++ b/internal/isms/api/api_readings.go
@@ -581,4 +581,3 @@ func writeSystemFromReading(ctx context.Context, tx pgx.Tx, s *Server, orgID int
 	_ = actor
 	return db.UpdateSystemTx(ctx, tx, orgID, sys)
 }
-

--- a/internal/isms/api/api_search.go
+++ b/internal/isms/api/api_search.go
@@ -21,10 +21,10 @@ type SearchEntry struct {
 
 // SearchIndex is a per-org in-memory search index that avoids 10+ DB queries per keystroke.
 type SearchIndex struct {
-	mu      sync.RWMutex
-	entries map[int][]SearchEntry // orgID -> entries
-	built   map[int]time.Time    // orgID -> last build time
-	building sync.Map            // orgID -> struct{} — prevents concurrent builds for same org
+	mu       sync.RWMutex
+	entries  map[int][]SearchEntry // orgID -> entries
+	built    map[int]time.Time     // orgID -> last build time
+	building sync.Map              // orgID -> struct{} — prevents concurrent builds for same org
 }
 
 const searchIndexTTL = 5 * time.Minute
@@ -150,9 +150,9 @@ func (s *Server) buildSearchIndex(orgID int) {
 	defer cancel()
 
 	var (
-		mu      sync.Mutex
-		wg      sync.WaitGroup
-		all     []SearchEntry
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+		all []SearchEntry
 	)
 
 	collect := func(fn func() []SearchEntry) {

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -544,15 +544,15 @@ func (s *Server) notifySuggestionResolved(ctx context.Context, orgID int, sg *db
 
 func applyRiskCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *db.Suggestion, actor string) (string, error) {
 	var payload struct {
-		Title              string   `json:"title"`
-		Description        string   `json:"description"`
-		RiskType           string   `json:"risk_type"`
-		Origin             string   `json:"origin"`
-		Category           string   `json:"category"`
-		CurrentLikelihood  *int     `json:"current_likelihood"`
-		CurrentImpact *int   `json:"current_impact"`
-		TreatmentPlan string `json:"treatment_plan"`
-		Treatment     string `json:"treatment"`
+		Title             string `json:"title"`
+		Description       string `json:"description"`
+		RiskType          string `json:"risk_type"`
+		Origin            string `json:"origin"`
+		Category          string `json:"category"`
+		CurrentLikelihood *int   `json:"current_likelihood"`
+		CurrentImpact     *int   `json:"current_impact"`
+		TreatmentPlan     string `json:"treatment_plan"`
+		Treatment         string `json:"treatment"`
 	}
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid risk payload: %w", err)
@@ -657,19 +657,29 @@ func applyRiskUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	old := risk.ToChangeMap()
 
 	if v, ok := payload.Fields["owner"]; ok {
-		if s, ok := v.(string); ok { risk.Owner = s }
+		if s, ok := v.(string); ok {
+			risk.Owner = s
+		}
 	}
 	if v, ok := payload.Fields["status"]; ok {
-		if s, ok := v.(string); ok { risk.Status = s }
+		if s, ok := v.(string); ok {
+			risk.Status = s
+		}
 	}
 	if v, ok := payload.Fields["treatment"]; ok {
-		if s, ok := v.(string); ok { risk.Treatment = s }
+		if s, ok := v.(string); ok {
+			risk.Treatment = s
+		}
 	}
 	if v, ok := payload.Fields["treatment_plan"]; ok {
-		if s, ok := v.(string); ok { risk.TreatmentPlan = s }
+		if s, ok := v.(string); ok {
+			risk.TreatmentPlan = s
+		}
 	}
 	if v, ok := payload.Fields["notes"]; ok {
-		if s, ok := v.(string); ok { risk.Notes = s }
+		if s, ok := v.(string); ok {
+			risk.Notes = s
+		}
 	}
 
 	if err := db.UpdateRiskTx(ctx, tx, orgID, risk); err != nil {
@@ -757,25 +767,39 @@ func applyIncidentUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 	old := inc.ToChangeMap()
 
 	if v, ok := payload.Fields["severity"]; ok {
-		if sv, ok := v.(string); ok { inc.Severity = sv }
+		if sv, ok := v.(string); ok {
+			inc.Severity = sv
+		}
 	}
 	if v, ok := payload.Fields["status"]; ok {
-		if sv, ok := v.(string); ok { inc.Status = sv }
+		if sv, ok := v.(string); ok {
+			inc.Status = sv
+		}
 	}
 	if v, ok := payload.Fields["assignee"]; ok {
-		if sv, ok := v.(string); ok { inc.Assignee = sv }
+		if sv, ok := v.(string); ok {
+			inc.Assignee = sv
+		}
 	}
 	if v, ok := payload.Fields["root_cause"]; ok {
-		if sv, ok := v.(string); ok { inc.RootCause = sv }
+		if sv, ok := v.(string); ok {
+			inc.RootCause = sv
+		}
 	}
 	if v, ok := payload.Fields["affects_c"]; ok {
-		if bv, ok := v.(bool); ok { inc.AffectsC = bv }
+		if bv, ok := v.(bool); ok {
+			inc.AffectsC = bv
+		}
 	}
 	if v, ok := payload.Fields["affects_i"]; ok {
-		if bv, ok := v.(bool); ok { inc.AffectsI = bv }
+		if bv, ok := v.(bool); ok {
+			inc.AffectsI = bv
+		}
 	}
 	if v, ok := payload.Fields["affects_a"]; ok {
-		if bv, ok := v.(bool); ok { inc.AffectsA = bv }
+		if bv, ok := v.(bool); ok {
+			inc.AffectsA = bv
+		}
 	}
 
 	if err := db.UpdateIncidentTx(ctx, tx, orgID, inc); err != nil {
@@ -881,13 +905,19 @@ func applySupplierUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 	old := sup.ToChangeMap()
 
 	if v, ok := payload.Fields["criticality"]; ok {
-		if sv, ok := v.(string); ok { sup.Criticality = sv }
+		if sv, ok := v.(string); ok {
+			sup.Criticality = sv
+		}
 	}
 	if v, ok := payload.Fields["notes"]; ok {
-		if sv, ok := v.(string); ok { sup.Notes = sv }
+		if sv, ok := v.(string); ok {
+			sup.Notes = sv
+		}
 	}
 	if v, ok := payload.Fields["status"]; ok {
-		if sv, ok := v.(string); ok { sup.Status = sv }
+		if sv, ok := v.(string); ok {
+			sup.Status = sv
+		}
 	}
 
 	if err := db.UpdateSupplierTx(ctx, tx, orgID, sup); err != nil {
@@ -961,10 +991,14 @@ func applyLegalUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 	old := lr.ToChangeMap()
 
 	if v, ok := payload.Fields["owner"]; ok {
-		if sv, ok := v.(string); ok { lr.Owner = sv }
+		if sv, ok := v.(string); ok {
+			lr.Owner = sv
+		}
 	}
 	if v, ok := payload.Fields["notes"]; ok {
-		if sv, ok := v.(string); ok { lr.Notes = sv }
+		if sv, ok := v.(string); ok {
+			lr.Notes = sv
+		}
 	}
 
 	if err := db.UpdateLegalRequirementTx(ctx, tx, orgID, lr); err != nil {
@@ -1037,10 +1071,26 @@ func applyChangeUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 	if err != nil {
 		return "", fmt.Errorf("change request %s not found: %w", sg.EntityID, err)
 	}
-	if v, ok := payload.Fields["priority"]; ok { if sv, ok := v.(string); ok { cr.Priority = sv } }
-	if v, ok := payload.Fields["risk_level"]; ok { if sv, ok := v.(string); ok { cr.RiskLevel = sv } }
-	if v, ok := payload.Fields["rollback_plan"]; ok { if sv, ok := v.(string); ok { cr.RollbackPlan = sv } }
-	if v, ok := payload.Fields["assigned_to"]; ok { if sv, ok := v.(string); ok { cr.AssignedTo = sv } }
+	if v, ok := payload.Fields["priority"]; ok {
+		if sv, ok := v.(string); ok {
+			cr.Priority = sv
+		}
+	}
+	if v, ok := payload.Fields["risk_level"]; ok {
+		if sv, ok := v.(string); ok {
+			cr.RiskLevel = sv
+		}
+	}
+	if v, ok := payload.Fields["rollback_plan"]; ok {
+		if sv, ok := v.(string); ok {
+			cr.RollbackPlan = sv
+		}
+	}
+	if v, ok := payload.Fields["assigned_to"]; ok {
+		if sv, ok := v.(string); ok {
+			cr.AssignedTo = sv
+		}
+	}
 	if err := db.UpdateChangeRequestTx(ctx, tx, orgID, cr.ID, cr); err != nil {
 		return "", err
 	}
@@ -1102,10 +1152,26 @@ func applyCorrActiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 		return "", fmt.Errorf("corrective action %s not found: %w", sg.EntityID, err)
 	}
 	old := ca.ToChangeMap()
-	if v, ok := payload.Fields["assignee"]; ok { if sv, ok := v.(string); ok { ca.Assignee = sv } }
-	if v, ok := payload.Fields["status"]; ok { if sv, ok := v.(string); ok { ca.Status = sv } }
-	if v, ok := payload.Fields["root_cause"]; ok { if sv, ok := v.(string); ok { ca.RootCause = sv } }
-	if v, ok := payload.Fields["notes"]; ok { if sv, ok := v.(string); ok { ca.Notes = sv } }
+	if v, ok := payload.Fields["assignee"]; ok {
+		if sv, ok := v.(string); ok {
+			ca.Assignee = sv
+		}
+	}
+	if v, ok := payload.Fields["status"]; ok {
+		if sv, ok := v.(string); ok {
+			ca.Status = sv
+		}
+	}
+	if v, ok := payload.Fields["root_cause"]; ok {
+		if sv, ok := v.(string); ok {
+			ca.RootCause = sv
+		}
+	}
+	if v, ok := payload.Fields["notes"]; ok {
+		if sv, ok := v.(string); ok {
+			ca.Notes = sv
+		}
+	}
 	if err := db.UpdateCorrectiveActionTx(ctx, tx, orgID, ca); err != nil {
 		return "", err
 	}
@@ -1139,8 +1205,12 @@ func applyTaskCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 		Assignee: payload.Assignee, CreatedBy: actor,
 		Priority: payload.Priority, TaskType: payload.TaskType, Status: "open",
 	}
-	if t.Priority == "" { t.Priority = "medium" }
-	if t.TaskType == "" { t.TaskType = "general" }
+	if t.Priority == "" {
+		t.Priority = "medium"
+	}
+	if t.TaskType == "" {
+		t.TaskType = "general"
+	}
 	// tasks.assignee_id is NOT NULL; default to the applier when the suggestion carries none.
 	if t.Assignee == "" {
 		t.Assignee = actor
@@ -1164,10 +1234,26 @@ func applyTaskUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 		return "", fmt.Errorf("task %s not found: %w", sg.EntityID, err)
 	}
 	old := t.ToChangeMap()
-	if v, ok := payload.Fields["assignee"]; ok { if sv, ok := v.(string); ok { t.Assignee = sv } }
-	if v, ok := payload.Fields["priority"]; ok { if sv, ok := v.(string); ok { t.Priority = sv } }
-	if v, ok := payload.Fields["title"]; ok { if sv, ok := v.(string); ok { t.Title = sv } }
-	if v, ok := payload.Fields["status"]; ok { if sv, ok := v.(string); ok { t.Status = sv } }
+	if v, ok := payload.Fields["assignee"]; ok {
+		if sv, ok := v.(string); ok {
+			t.Assignee = sv
+		}
+	}
+	if v, ok := payload.Fields["priority"]; ok {
+		if sv, ok := v.(string); ok {
+			t.Priority = sv
+		}
+	}
+	if v, ok := payload.Fields["title"]; ok {
+		if sv, ok := v.(string); ok {
+			t.Title = sv
+		}
+	}
+	if v, ok := payload.Fields["status"]; ok {
+		if sv, ok := v.(string); ok {
+			t.Status = sv
+		}
+	}
 	if err := db.UpdateTaskTx(ctx, tx, orgID, t); err != nil {
 		return "", err
 	}
@@ -1238,11 +1324,31 @@ func applyObjectiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, 
 		return "", fmt.Errorf("objective %s not found: %w", sg.EntityID, err)
 	}
 	old := o.ToChangeMap()
-	if v, ok := payload.Fields["title"]; ok { if sv, ok := v.(string); ok { o.Title = sv } }
-	if v, ok := payload.Fields["description"]; ok { if sv, ok := v.(string); ok { o.Description = sv } }
-	if v, ok := payload.Fields["owner"]; ok { if sv, ok := v.(string); ok { o.Owner = sv } }
-	if v, ok := payload.Fields["measurement_method"]; ok { if sv, ok := v.(string); ok { o.MeasurementMethod = sv } }
-	if v, ok := payload.Fields["status"]; ok { if sv, ok := v.(string); ok { o.Status = sv } }
+	if v, ok := payload.Fields["title"]; ok {
+		if sv, ok := v.(string); ok {
+			o.Title = sv
+		}
+	}
+	if v, ok := payload.Fields["description"]; ok {
+		if sv, ok := v.(string); ok {
+			o.Description = sv
+		}
+	}
+	if v, ok := payload.Fields["owner"]; ok {
+		if sv, ok := v.(string); ok {
+			o.Owner = sv
+		}
+	}
+	if v, ok := payload.Fields["measurement_method"]; ok {
+		if sv, ok := v.(string); ok {
+			o.MeasurementMethod = sv
+		}
+	}
+	if v, ok := payload.Fields["status"]; ok {
+		if sv, ok := v.(string); ok {
+			o.Status = sv
+		}
+	}
 	if err := db.UpdateObjectiveTx(ctx, tx, orgID, o); err != nil {
 		return "", err
 	}
@@ -1321,13 +1427,41 @@ func applySystemUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 		return "", fmt.Errorf("system %s not found: %w", sg.EntityID, err)
 	}
 	old := sys.ToChangeMap()
-	if v, ok := payload.Fields["name"]; ok { if sv, ok := v.(string); ok { sys.Name = sv } }
-	if v, ok := payload.Fields["criticality"]; ok { if sv, ok := v.(string); ok { sys.Criticality = sv } }
-	if v, ok := payload.Fields["classification"]; ok { if sv, ok := v.(string); ok { sys.Classification = sv } }
-	if v, ok := payload.Fields["owner"]; ok { if sv, ok := v.(string); ok { sys.Owner = sv } }
-	if v, ok := payload.Fields["notes"]; ok { if sv, ok := v.(string); ok { sys.Notes = sv } }
-	if v, ok := payload.Fields["department"]; ok { if sv, ok := v.(string); ok { sys.Department = sv } }
-	if v, ok := payload.Fields["status"]; ok { if sv, ok := v.(string); ok { sys.Status = sv } }
+	if v, ok := payload.Fields["name"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Name = sv
+		}
+	}
+	if v, ok := payload.Fields["criticality"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Criticality = sv
+		}
+	}
+	if v, ok := payload.Fields["classification"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Classification = sv
+		}
+	}
+	if v, ok := payload.Fields["owner"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Owner = sv
+		}
+	}
+	if v, ok := payload.Fields["notes"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Notes = sv
+		}
+	}
+	if v, ok := payload.Fields["department"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Department = sv
+		}
+	}
+	if v, ok := payload.Fields["status"]; ok {
+		if sv, ok := v.(string); ok {
+			sys.Status = sv
+		}
+	}
 	if err := db.UpdateSystemTx(ctx, tx, orgID, sys); err != nil {
 		return "", err
 	}
@@ -1395,11 +1529,31 @@ func applyAssetUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 		return "", fmt.Errorf("asset %s not found: %w", sg.EntityID, err)
 	}
 	old := asset.ToChangeMap()
-	if v, ok := payload.Fields["name"]; ok { if sv, ok := v.(string); ok { asset.Name = sv } }
-	if v, ok := payload.Fields["owner"]; ok { if sv, ok := v.(string); ok { asset.Owner = sv } }
-	if v, ok := payload.Fields["status"]; ok { if sv, ok := v.(string); ok { asset.Status = sv } }
-	if v, ok := payload.Fields["notes"]; ok { if sv, ok := v.(string); ok { asset.Notes = sv } }
-	if v, ok := payload.Fields["asset_type"]; ok { if sv, ok := v.(string); ok { asset.AssetType = sv } }
+	if v, ok := payload.Fields["name"]; ok {
+		if sv, ok := v.(string); ok {
+			asset.Name = sv
+		}
+	}
+	if v, ok := payload.Fields["owner"]; ok {
+		if sv, ok := v.(string); ok {
+			asset.Owner = sv
+		}
+	}
+	if v, ok := payload.Fields["status"]; ok {
+		if sv, ok := v.(string); ok {
+			asset.Status = sv
+		}
+	}
+	if v, ok := payload.Fields["notes"]; ok {
+		if sv, ok := v.(string); ok {
+			asset.Notes = sv
+		}
+	}
+	if v, ok := payload.Fields["asset_type"]; ok {
+		if sv, ok := v.(string); ok {
+			asset.AssetType = sv
+		}
+	}
 	if err := db.UpdateAssetTx(ctx, tx, orgID, asset); err != nil {
 		return "", err
 	}
@@ -1443,7 +1597,9 @@ func applyAuditFindingCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID in
 		Description: desc,
 		Status:      "open",
 	}
-	if f.FindingType == "" { f.FindingType = "observation" }
+	if f.FindingType == "" {
+		f.FindingType = "observation"
+	}
 	if err := db.AddAuditFindingTx(ctx, tx, orgID, &f); err != nil {
 		return "", err
 	}

--- a/internal/isms/api/api_users.go
+++ b/internal/isms/api/api_users.go
@@ -196,8 +196,8 @@ func (s *Server) handleMyOrganizations(c echo.Context) error {
 // handleCreateOrganization creates a new org and adds the current user as admin.
 func (s *Server) handleCreateOrganization(c echo.Context) error {
 	var req struct {
-		Name      string `json:"name"`
-		Slug      string `json:"slug"`
+		Name     string `json:"name"`
+		Slug     string `json:"slug"`
 		Template string `json:"template"` // optional: iso27001, soc2, nis2
 	}
 	if err := c.Bind(&req); err != nil {
@@ -333,7 +333,6 @@ func emailToName(email string) string {
 	return name
 }
 
-
 // handleListAvailableTemplates returns all templates available in the registry.
 // GET /api/v1/templates/available
 func (s *Server) handleListAvailableTemplates(c echo.Context) error {
@@ -387,7 +386,6 @@ func (s *Server) handleAddTemplate(c echo.Context) error {
 	if err := scaffold.ScaffoldToRepo(st, req.Template, authorName, email); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("scaffolding template: %v", err))
 	}
-
 
 	// Invalidate store cache to pick up new files
 	s.stores.Delete(orgID)

--- a/internal/isms/api/middleware.go
+++ b/internal/isms/api/middleware.go
@@ -29,7 +29,7 @@ type AuthConfig struct {
 	CloudflareTeamDomain string // e.g. "mycompany.cloudflareaccess.com"
 	CloudflareAudience   string // CF Access Application Audience (AUD) tag — set via ISMS_CF_AUDIENCE
 	DB                   *db.DB // for API token lookups
-	Secret            string // for validating JWT session tokens
+	Secret               string // for validating JWT session tokens
 }
 
 // AuthMiddleware validates authentication on all API routes.

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -21,12 +21,12 @@ import (
 	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"gopkg.in/yaml.v3"
 	"isms.sh/internal/isms/blob"
 	"isms.sh/internal/isms/db"
 	"isms.sh/internal/isms/mail"
 	"isms.sh/internal/isms/notify"
-"isms.sh/internal/isms/store"
-	"gopkg.in/yaml.v3"
+	"isms.sh/internal/isms/store"
 )
 
 // Server is the ISMS API server.
@@ -37,8 +37,8 @@ type Server struct {
 	echo     *echo.Echo
 	addr     string
 	webDir   string
-	webFS    fs.FS      // embedded web assets (optional, used if webDir is empty)
-	stores   sync.Map   // orgID -> *store.Store cache
+	webFS    fs.FS    // embedded web assets (optional, used if webDir is empty)
+	stores   sync.Map // orgID -> *store.Store cache
 
 	// Unified storage for org files (branding, evidence, etc.).
 	// Local filesystem by default, S3 with ISMS_STORAGE_BACKEND=s3.
@@ -53,8 +53,8 @@ type Server struct {
 	passkeyLogins        sync.Map // email -> *webauthn.SessionData
 
 	// Platform-level legal docs (markdown files on disk, rendered and served)
-	termsFile      string // ISMS_TERMS_FILE
-	privacyFile    string // ISMS_PRIVACY_FILE
+	termsFile        string // ISMS_TERMS_FILE
+	privacyFile      string // ISMS_PRIVACY_FILE
 	hidePoweredBy    bool   // ISMS_HIDE_POWERED_BY=1
 	subdomainRouting bool   // ISMS_SUBDOMAIN_ROUTING=1 enables (default off)
 	apexHost         string // derived from ISMS_BASE_URL — the deployment's canonical apex
@@ -176,7 +176,6 @@ func (s *Server) storeForOrg(ctx context.Context, orgID int) (*store.Store, erro
 	actual, _ := s.stores.LoadOrStore(orgID, st)
 	return actual.(*store.Store), nil
 }
-
 
 // New creates a new API server.
 func New(addr, webDir string, database *db.DB) *Server {
@@ -349,12 +348,12 @@ func NewWithFS(addr, webDir string, database *db.DB, embeddedFS fs.FS) *Server {
 
 	// Authentication + role enforcement
 	teamDomain := os.Getenv("CLOUDFLARE_TEAM_DOMAIN") // e.g. mycompany.cloudflareaccess.com
-	cfAudience := os.Getenv("ISMS_CF_AUDIENCE")        // CF Access Application Audience (AUD) tag
+	cfAudience := os.Getenv("ISMS_CF_AUDIENCE")       // CF Access Application Audience (AUD) tag
 	srv.echo.Use(AuthMiddleware(AuthConfig{
 		CloudflareTeamDomain: teamDomain,
 		CloudflareAudience:   cfAudience,
 		DB:                   database,
-		Secret:            srv.secret,
+		Secret:               srv.secret,
 	}))
 	srv.echo.Use(srv.RoleMiddleware())
 	// Tenant isolation model (defense in depth):
@@ -838,11 +837,11 @@ func (s *Server) handleGetConfig(c echo.Context) error {
 		Branding         map[string]string `json:"branding,omitempty"`
 		OrganizationName string            `json:"organization_name"`
 		OrganizationSlug string            `json:"organization_slug"`
-		HasTerms       bool   `json:"has_terms"`
-		HasPrivacy     bool   `json:"has_privacy"`
-		ShowPoweredBy  bool   `json:"show_powered_by"`
-		TermsURL       string `json:"terms_url,omitempty"`
-		PrivacyURL     string `json:"privacy_url,omitempty"`
+		HasTerms         bool              `json:"has_terms"`
+		HasPrivacy       bool              `json:"has_privacy"`
+		ShowPoweredBy    bool              `json:"show_powered_by"`
+		TermsURL         string            `json:"terms_url,omitempty"`
+		PrivacyURL       string            `json:"privacy_url,omitempty"`
 
 		// Routing: does this deployment serve tenant orgs on wildcard
 		// subdomains (<slug>.<apex>), or only path-based (<apex>/<slug>)?
@@ -1155,16 +1154,16 @@ func (s *Server) handleGetDocumentBody(c echo.Context) error {
 	}
 
 	resp := map[string]interface{}{
-		"document_id":   pf.Frontmatter.DocumentID,
-		"title":         pf.Frontmatter.Title,
-		"version":       pf.Frontmatter.Version,
-		"status":        pf.Frontmatter.Status,
-		"author":        pf.Frontmatter.Author,
-		"owner":         pf.Frontmatter.Owner,
-		"review_cycle":  pf.Frontmatter.ReviewCycle,
-		"next_review":   pf.Frontmatter.NextReview,
-		"body":          pf.Body,
-		"path":        path,
+		"document_id":  pf.Frontmatter.DocumentID,
+		"title":        pf.Frontmatter.Title,
+		"version":      pf.Frontmatter.Version,
+		"status":       pf.Frontmatter.Status,
+		"author":       pf.Frontmatter.Author,
+		"owner":        pf.Frontmatter.Owner,
+		"review_cycle": pf.Frontmatter.ReviewCycle,
+		"next_review":  pf.Frontmatter.NextReview,
+		"body":         pf.Body,
+		"path":         path,
 	}
 	// Include active review ID so the frontend can link directly to it
 	if pf.Frontmatter.Status == "in_review" {
@@ -1323,12 +1322,12 @@ func (s *Server) handleCreateDocument(c echo.Context) error {
 
 	var req struct {
 		Folder     string `json:"folder"`      // e.g. "iso27001/policies"
-		Filename   string `json:"filename"`     // e.g. "data-classification.md"
-		DocumentID string `json:"document_id"`  // e.g. "data-classification"
-		Title      string `json:"title"`        // e.g. "Data Classification Policy"
-		Type       string `json:"type"`         // optional: control, policy, procedure, etc.
-		Content    string `json:"content"`      // optional initial body
-		Author     string `json:"author"`       // optional
+		Filename   string `json:"filename"`    // e.g. "data-classification.md"
+		DocumentID string `json:"document_id"` // e.g. "data-classification"
+		Title      string `json:"title"`       // e.g. "Data Classification Policy"
+		Type       string `json:"type"`        // optional: control, policy, procedure, etc.
+		Content    string `json:"content"`     // optional initial body
+		Author     string `json:"author"`      // optional
 	}
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -2150,7 +2149,6 @@ func (s *Server) handleRiskMatrix(c echo.Context) error {
 	return c.JSON(http.StatusOK, cells)
 }
 
-
 // handleRiskAdvisories returns advisory messages about CIA consistency between
 // a risk and its linked assets. This is informational only, not enforcement.
 func (s *Server) handleRiskAdvisories(c echo.Context) error {
@@ -2175,7 +2173,7 @@ func (s *Server) handleRiskAdvisories(c echo.Context) error {
 	}
 
 	type Advisory struct {
-		Level   string `json:"level"`   // "warning" or "info"
+		Level   string `json:"level"` // "warning" or "info"
 		Message string `json:"message"`
 	}
 
@@ -3036,7 +3034,6 @@ func (s *Server) handleCreateOverdueTasks(c echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
-
 // stripFrontmatter removes YAML frontmatter from markdown content.
 // incrementVersion bumps a version string by 0.1 (e.g. "1.0" → "1.1", "2.3" → "2.4").
 // If the version is empty or unparseable, returns "0.1".
@@ -3062,15 +3059,23 @@ func compareVersions(a, b string) int {
 	aMaj, aMin := 0, 0
 	bMaj, bMin := 0, 0
 	fmt.Sscanf(pa[0], "%d", &aMaj)
-	if len(pa) > 1 { fmt.Sscanf(pa[1], "%d", &aMin) }
+	if len(pa) > 1 {
+		fmt.Sscanf(pa[1], "%d", &aMin)
+	}
 	fmt.Sscanf(pb[0], "%d", &bMaj)
-	if len(pb) > 1 { fmt.Sscanf(pb[1], "%d", &bMin) }
+	if len(pb) > 1 {
+		fmt.Sscanf(pb[1], "%d", &bMin)
+	}
 	if aMaj != bMaj {
-		if aMaj < bMaj { return -1 }
+		if aMaj < bMaj {
+			return -1
+		}
 		return 1
 	}
 	if aMin != bMin {
-		if aMin < bMin { return -1 }
+		if aMin < bMin {
+			return -1
+		}
 		return 1
 	}
 	return 0

--- a/internal/isms/client/client.go
+++ b/internal/isms/client/client.go
@@ -147,8 +147,8 @@ type DocSummary struct {
 
 // DocFolder is a folder of documents returned by /documents/all.
 type DocFolder struct {
-	Name       string      `json:"name"`
-	Title      string      `json:"title,omitempty"`
+	Name       string       `json:"name"`
+	Title      string       `json:"title,omitempty"`
 	Files      []DocSummary `json:"files"`
 	SubFolders []DocFolder  `json:"subfolders,omitempty"`
 }
@@ -441,8 +441,6 @@ func (c *Client) DeleteAccessReview(id string) error {
 	_, err := c.delete("/v1/access-reviews/" + id)
 	return err
 }
-
-
 
 // --- Reviews ---
 

--- a/internal/isms/db/access_reviews.go
+++ b/internal/isms/db/access_reviews.go
@@ -6,9 +6,9 @@ import (
 
 // AccessReview represents a periodic access review for a system.
 type AccessReview struct {
-	ID             int64     `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	SystemID       int64     `json:"system_id"`
+	ID             int64  `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	SystemID       int64  `json:"system_id"`
 	ReviewedAt     Epoch  `json:"reviewed_at"`
 	ReviewedBy     string `json:"reviewed_by"`
 	UsersAdded     int    `json:"users_added"`

--- a/internal/isms/db/approval_policies_test.go
+++ b/internal/isms/db/approval_policies_test.go
@@ -102,10 +102,10 @@ func TestPolicyMatches(t *testing.T) {
 // EvaluatePolicy is extracted pure logic for testing CheckReviewPolicy decisions
 // without a database. It mirrors the logic in CheckReviewPolicy after the DB calls.
 type policyInput struct {
-	policy      ApprovalPolicy
-	approvedBy  map[string]bool // unique approvers
-	humanFlags  map[string]bool // email → is human (true) or agent (false)
-	userRoles   map[string]string // email → org role
+	policy     ApprovalPolicy
+	approvedBy map[string]bool   // unique approvers
+	humanFlags map[string]bool   // email → is human (true) or agent (false)
+	userRoles  map[string]string // email → org role
 }
 
 func evaluatePolicy(in policyInput) *PolicyStatus {
@@ -444,27 +444,27 @@ func TestEvaluatePolicy_RequiredUsers(t *testing.T) {
 
 func TestEvaluatePolicy_AutoMerge(t *testing.T) {
 	tests := []struct {
-		name         string
-		autoMerge    bool
-		met          bool
+		name          string
+		autoMerge     bool
+		met           bool
 		wantAutoMerge bool
 	}{
 		{
-			name:         "auto merge enabled and met",
-			autoMerge:    true,
-			met:          true,
+			name:          "auto merge enabled and met",
+			autoMerge:     true,
+			met:           true,
 			wantAutoMerge: true,
 		},
 		{
-			name:         "auto merge enabled but not met",
-			autoMerge:    true,
-			met:          false,
+			name:          "auto merge enabled but not met",
+			autoMerge:     true,
+			met:           false,
 			wantAutoMerge: false,
 		},
 		{
-			name:         "auto merge disabled even if met",
-			autoMerge:    false,
-			met:          true,
+			name:          "auto merge disabled even if met",
+			autoMerge:     false,
+			met:           true,
 			wantAutoMerge: false,
 		},
 	}

--- a/internal/isms/db/assets.go
+++ b/internal/isms/db/assets.go
@@ -109,7 +109,9 @@ const assetSelectCols = `id, organization_id, identifier, name, COALESCE(descrip
 		COALESCE(notes, ''),
 		created_at, updated_at`
 
-func scanAsset(scanner interface{ Scan(dest ...interface{}) error }, a *Asset) error {
+func scanAsset(scanner interface {
+	Scan(dest ...interface{}) error
+}, a *Asset) error {
 	return scanner.Scan(&a.ID, &a.OrganizationID, &a.Identifier, &a.Name, &a.Description,
 		&a.AssetType, &a.Status, &a.Owner, &a.PrimaryLocation,
 		&a.Confidentiality, &a.Integrity, &a.Availability,

--- a/internal/isms/db/changelog.go
+++ b/internal/isms/db/changelog.go
@@ -9,18 +9,18 @@ import (
 
 // ChangelogEntry represents a single field-level change in the entity changelog.
 type ChangelogEntry struct {
-	ID             int64     `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	EntityType     string    `json:"entity_type"`
-	EntityID       int64     `json:"entity_id"`
-	Action         string    `json:"action"`
-	Field          string    `json:"field,omitempty"`
-	OldValue       *string   `json:"old_value,omitempty"`
-	NewValue       *string   `json:"new_value,omitempty"`
-	ChangedBy      string    `json:"changed_by"`
-	APIKeyID       *int      `json:"api_key_id,omitempty"`
-	Reason         string `json:"reason,omitempty"`
-	CreatedAt      Epoch  `json:"created_at"`
+	ID             int64   `json:"id"`
+	OrganizationID int     `json:"organization_id"`
+	EntityType     string  `json:"entity_type"`
+	EntityID       int64   `json:"entity_id"`
+	Action         string  `json:"action"`
+	Field          string  `json:"field,omitempty"`
+	OldValue       *string `json:"old_value,omitempty"`
+	NewValue       *string `json:"new_value,omitempty"`
+	ChangedBy      string  `json:"changed_by"`
+	APIKeyID       *int    `json:"api_key_id,omitempty"`
+	Reason         string  `json:"reason,omitempty"`
+	CreatedAt      Epoch   `json:"created_at"`
 }
 
 // LogChange inserts a single changelog entry.

--- a/internal/isms/db/checkins.go
+++ b/internal/isms/db/checkins.go
@@ -25,9 +25,9 @@ func (c *Checkin) ToChangeMap() map[string]string {
 
 // Checkin is a time-series measurement for an objective.
 type Checkin struct {
-	ID             int64      `json:"id"`
-	OrganizationID int        `json:"organization_id"`
-	ObjectiveID    int64      `json:"objective_id"`
+	ID             int64    `json:"id"`
+	OrganizationID int      `json:"organization_id"`
+	ObjectiveID    int64    `json:"objective_id"`
 	OccurredAt     Epoch    `json:"occurred_at"`
 	RecordedAt     Epoch    `json:"recorded_at"`
 	CreatedBy      string   `json:"created_by,omitempty"`

--- a/internal/isms/db/evidence.go
+++ b/internal/isms/db/evidence.go
@@ -6,13 +6,13 @@ import (
 
 // Evidence is an S3-backed file attachment on a checkin.
 type Evidence struct {
-	ID             int64     `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	CheckinID      int64     `json:"checkin_id"`
-	Title          string    `json:"title"`
-	ObjectKey      string    `json:"object_key"`
-	ContentType    string    `json:"content_type"`
-	SizeBytes      *int64    `json:"size_bytes,omitempty"`
+	ID             int64  `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	CheckinID      int64  `json:"checkin_id"`
+	Title          string `json:"title"`
+	ObjectKey      string `json:"object_key"`
+	ContentType    string `json:"content_type"`
+	SizeBytes      *int64 `json:"size_bytes,omitempty"`
 	SHA256         string `json:"sha256,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`
 }

--- a/internal/isms/db/implementation.go
+++ b/internal/isms/db/implementation.go
@@ -7,12 +7,12 @@ import (
 
 // ImplementationStatus tracks the implementation state of an ISMS item.
 type ImplementationStatus struct {
-	ID             int        `json:"id"`
-	OrganizationID int        `json:"organization_id"`
-	ItemID         string     `json:"item_id"`
-	ItemType       string     `json:"item_type"`
-	Status         string     `json:"status"`
-	Owner          string     `json:"owner,omitempty"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	ItemID         string `json:"item_id"`
+	ItemType       string `json:"item_type"`
+	Status         string `json:"status"`
+	Owner          string `json:"owner,omitempty"`
 	TargetDate     *Epoch `json:"target_date,omitempty"`
 	Notes          string `json:"notes,omitempty"`
 	UpdatedAt      Epoch  `json:"updated_at"`

--- a/internal/isms/db/legal.go
+++ b/internal/isms/db/legal.go
@@ -59,7 +59,7 @@ type LegalRequirement struct {
 	TreatmentPlan     string `json:"treatment_plan,omitempty"`
 	TargetLikelihood  *int   `json:"target_likelihood,omitempty"`
 	TargetImpact      *int   `json:"target_impact,omitempty"`
-	Completion int `json:"completion"`
+	Completion        int    `json:"completion"`
 	// Assessment lifecycle: see entity_readings table for the canonical assessment log
 	CreatedAt Epoch `json:"created_at"`
 	UpdatedAt Epoch `json:"updated_at"`
@@ -131,7 +131,9 @@ const legalSelectCols = `id, identifier, organization_id, title, COALESCE(descri
 	target_likelihood, target_impact, COALESCE(completion, 0),
 	created_at, updated_at`
 
-func scanLegal(scanner interface{ Scan(dest ...interface{}) error }, lr *LegalRequirement) error {
+func scanLegal(scanner interface {
+	Scan(dest ...interface{}) error
+}, lr *LegalRequirement) error {
 	return scanner.Scan(
 		&lr.ID, &lr.Identifier, &lr.OrganizationID, &lr.Title, &lr.Description,
 		&lr.Jurisdiction, &lr.Category, &lr.Reference, &lr.URL,

--- a/internal/isms/db/notifications.go
+++ b/internal/isms/db/notifications.go
@@ -7,14 +7,14 @@ import (
 
 // Notification represents an inbox item for a user.
 type Notification struct {
-	ID             int       `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	RecipientID    int       `json:"recipient_id"`
-	Title          string    `json:"title"`
-	Body           string    `json:"body,omitempty"`
-	Link           string    `json:"link,omitempty"`
-	Read           bool  `json:"read"`
-	CreatedAt      Epoch `json:"created_at"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	RecipientID    int    `json:"recipient_id"`
+	Title          string `json:"title"`
+	Body           string `json:"body,omitempty"`
+	Link           string `json:"link,omitempty"`
+	Read           bool   `json:"read"`
+	CreatedAt      Epoch  `json:"created_at"`
 }
 
 func (d *DB) CreateNotification(ctx context.Context, orgID int, n *Notification) error {

--- a/internal/isms/db/objectives.go
+++ b/internal/isms/db/objectives.go
@@ -25,11 +25,11 @@ type ObjectiveListParams struct {
 }
 
 var objectiveSortable = map[string]string{
-	"title":     "title",
-	"display":   "display_id",
-	"status":    "status",
-	"created":   "created_at",
-	"updated":   "updated_at",
+	"title":   "title",
+	"display": "display_id",
+	"status":  "status",
+	"created": "created_at",
+	"updated": "updated_at",
 }
 
 const objectiveSelectCols = `id, organization_id, program_id, display_id, seq_number,
@@ -41,28 +41,28 @@ const objectiveSelectCols = `id, organization_id, program_id, display_id, seq_nu
 
 // Objective is a measurable ISMS objective within a program.
 type Objective struct {
-	ID                int64      `json:"id"`
-	OrganizationID    int        `json:"organization_id"`
-	ProgramID         int64      `json:"program_id"`
-	DisplayID         string     `json:"display_id"`
-	SeqNumber         int        `json:"seq_number"`
-	Title             string     `json:"title"`
-	Description       string     `json:"description,omitempty"`
-	Owner             string     `json:"owner,omitempty"`
-	Source            string     `json:"source,omitempty"`
-	MeasurementMethod string     `json:"measurement_method,omitempty"`
-	TargetValue       *float64   `json:"target_value,omitempty"`
-	TargetOperator    string     `json:"target_operator"`
-	Unit              string     `json:"unit,omitempty"`
-	WindowSeconds     *int       `json:"window_seconds,omitempty"`
-	GraceSeconds      int        `json:"grace_seconds"`
-	CheckinCycle      int        `json:"checkin_cycle"`
-	Status            string     `json:"status"`
-	StartedAt         *Epoch `json:"started_at,omitempty"`
-	ArchivedAt        *Epoch `json:"archived_at,omitempty"`
-	Notes             string `json:"notes,omitempty"`
-	CreatedAt         Epoch  `json:"created_at"`
-	UpdatedAt         Epoch  `json:"updated_at"`
+	ID                int64    `json:"id"`
+	OrganizationID    int      `json:"organization_id"`
+	ProgramID         int64    `json:"program_id"`
+	DisplayID         string   `json:"display_id"`
+	SeqNumber         int      `json:"seq_number"`
+	Title             string   `json:"title"`
+	Description       string   `json:"description,omitempty"`
+	Owner             string   `json:"owner,omitempty"`
+	Source            string   `json:"source,omitempty"`
+	MeasurementMethod string   `json:"measurement_method,omitempty"`
+	TargetValue       *float64 `json:"target_value,omitempty"`
+	TargetOperator    string   `json:"target_operator"`
+	Unit              string   `json:"unit,omitempty"`
+	WindowSeconds     *int     `json:"window_seconds,omitempty"`
+	GraceSeconds      int      `json:"grace_seconds"`
+	CheckinCycle      int      `json:"checkin_cycle"`
+	Status            string   `json:"status"`
+	StartedAt         *Epoch   `json:"started_at,omitempty"`
+	ArchivedAt        *Epoch   `json:"archived_at,omitempty"`
+	Notes             string   `json:"notes,omitempty"`
+	CreatedAt         Epoch    `json:"created_at"`
+	UpdatedAt         Epoch    `json:"updated_at"`
 }
 
 func (d *DB) CreateObjective(ctx context.Context, orgID int, o *Objective) error {

--- a/internal/isms/db/oidc.go
+++ b/internal/isms/db/oidc.go
@@ -14,18 +14,18 @@ import (
 
 // OIDCProvider represents an OIDC/OAuth2 identity provider configured for an organization.
 type OIDCProvider struct {
-	ID             int       `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	ProviderName   string    `json:"provider_name"`
-	DisplayName    string    `json:"display_name"`
-	ClientID       string    `json:"client_id"`
-	ClientSecret   string    `json:"client_secret,omitempty"`
-	DiscoveryURL   string    `json:"discovery_url"`
-	Scopes         string    `json:"scopes"`
-	AutoAddMembers bool      `json:"auto_add_members"`
-	DefaultRole    string    `json:"default_role"`
-	Enabled        bool  `json:"enabled"`
-	CreatedAt      Epoch `json:"created_at"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	ProviderName   string `json:"provider_name"`
+	DisplayName    string `json:"display_name"`
+	ClientID       string `json:"client_id"`
+	ClientSecret   string `json:"client_secret,omitempty"`
+	DiscoveryURL   string `json:"discovery_url"`
+	Scopes         string `json:"scopes"`
+	AutoAddMembers bool   `json:"auto_add_members"`
+	DefaultRole    string `json:"default_role"`
+	Enabled        bool   `json:"enabled"`
+	CreatedAt      Epoch  `json:"created_at"`
 }
 
 // EncryptSecret encrypts plaintext using AES-GCM with a key derived from ISMS_SECRET.

--- a/internal/isms/db/overdue.go
+++ b/internal/isms/db/overdue.go
@@ -7,23 +7,23 @@ import (
 
 // OverdueItem represents something that needs review attention.
 type OverdueItem struct {
-	EntityType string `json:"entity_type"` // risk, supplier, system, legal, policy
-	EntityID   string `json:"entity_id"`   // identifier (RISK-1, SUPPLIER-1, etc.)
-	Title      string `json:"title"`
-	Owner      string `json:"owner,omitempty"`
-	NextReview *Epoch `json:"next_review"`
-	DaysLate   int    `json:"days_late"`
+	EntityType  string `json:"entity_type"` // risk, supplier, system, legal, policy
+	EntityID    string `json:"entity_id"`   // identifier (RISK-1, SUPPLIER-1, etc.)
+	Title       string `json:"title"`
+	Owner       string `json:"owner,omitempty"`
+	NextReview  *Epoch `json:"next_review"`
+	DaysLate    int    `json:"days_late"`
 	Criticality string `json:"criticality,omitempty"` // risk level or criticality
 }
 
 // OverdueSummary is the aggregate overdue status across all entity types.
 type OverdueSummary struct {
-	Risks       []OverdueItem `json:"risks"`
-	Suppliers   []OverdueItem `json:"suppliers"`
-	Systems     []OverdueItem `json:"systems"`
-	Legal       []OverdueItem `json:"legal"`
-	Tasks       []OverdueItem `json:"tasks"`
-	TotalCount  int           `json:"total_count"`
+	Risks      []OverdueItem `json:"risks"`
+	Suppliers  []OverdueItem `json:"suppliers"`
+	Systems    []OverdueItem `json:"systems"`
+	Legal      []OverdueItem `json:"legal"`
+	Tasks      []OverdueItem `json:"tasks"`
+	TotalCount int           `json:"total_count"`
 }
 
 // GetOverdueSummary returns all overdue review items across entity types.
@@ -280,12 +280,12 @@ func (d *DB) OverdueObjectiveCheckins(ctx context.Context, orgID int) ([]Overdue
 		daysLate := int(now.Sub(nextDue).Hours() / 24)
 		due := Epoch{Time: nextDue}
 		items = append(items, OverdueItem{
-			EntityType:  "objective",
-			EntityID:    displayID,
-			Title:       title,
-			Owner:       owner,
-			NextReview:  &due,
-			DaysLate:    daysLate,
+			EntityType: "objective",
+			EntityID:   displayID,
+			Title:      title,
+			Owner:      owner,
+			NextReview: &due,
+			DaysLate:   daysLate,
 		})
 	}
 	return items, nil
@@ -393,13 +393,13 @@ func (d *DB) CreateOverdueReviewTasks(ctx context.Context, orgID int, createdBy 
 			assignee = createdBy
 		}
 		task := Task{
-			Title:    p.title,
-			TaskType: p.taskType,
-			Assignee: assignee,
+			Title:     p.title,
+			TaskType:  p.taskType,
+			Assignee:  assignee,
 			CreatedBy: createdBy,
-			Status:   "open",
-			Priority: p.priority,
-			DueDate:  p.dueDate,
+			Status:    "open",
+			Priority:  p.priority,
+			DueDate:   p.dueDate,
 		}
 		if err := d.CreateTask(ctx, orgID, &task); err != nil {
 			continue

--- a/internal/isms/db/postgres.go
+++ b/internal/isms/db/postgres.go
@@ -264,21 +264,21 @@ func (d *DB) MigrateFS(ctx context.Context, fsys fs.FS, dir string) error {
 // --- Reviews ---
 
 type Review struct {
-	ID             int       `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	DocumentID     string    `json:"document_id"`
-	DocumentType   string    `json:"document_type"`
-	Title          string    `json:"title"`
-	Version        string    `json:"version"`
-	CommitHash     string    `json:"commit_hash,omitempty"`
-	SentHead       string    `json:"sent_head,omitempty"`
-	MergeCommit    string    `json:"merge_commit,omitempty"`
-	Round          int       `json:"round"`
-	RequestedBy    string    `json:"requested_by"`
-	Message        string    `json:"message"`
-	Status         string    `json:"status"`
-	CreatedAt      Epoch `json:"created_at"`
-	UpdatedAt      Epoch `json:"updated_at"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	DocumentID     string `json:"document_id"`
+	DocumentType   string `json:"document_type"`
+	Title          string `json:"title"`
+	Version        string `json:"version"`
+	CommitHash     string `json:"commit_hash,omitempty"`
+	SentHead       string `json:"sent_head,omitempty"`
+	MergeCommit    string `json:"merge_commit,omitempty"`
+	Round          int    `json:"round"`
+	RequestedBy    string `json:"requested_by"`
+	Message        string `json:"message"`
+	Status         string `json:"status"`
+	CreatedAt      Epoch  `json:"created_at"`
+	UpdatedAt      Epoch  `json:"updated_at"`
 	// Computed fields for API
 	CommentCount int `json:"comment_count,omitempty"`
 	OpenComments int `json:"open_comments,omitempty"`
@@ -349,8 +349,10 @@ func (d *DB) ListReviews(ctx context.Context, orgID int, status string, limit in
 
 // ReviewListParams specifies filtering, sorting, and pagination for reviews.
 // Phase is a meta-filter that maps to a set of statuses:
-//   "open"   → open / changes_requested / approved
-//   "closed" → merged / closed
+//
+//	"open"   → open / changes_requested / approved
+//	"closed" → merged / closed
+//
 // Use Status for an exact single-status match instead.
 type ReviewListParams struct {
 	Page   int
@@ -621,18 +623,18 @@ func (d *DB) GetOpenReviewForDocument(ctx context.Context, orgID int, documentID
 // --- Comments ---
 
 type Comment struct {
-	ID             int        `json:"id"`
-	OrganizationID int        `json:"organization_id"`
-	ReviewID       *int       `json:"review_id,omitempty"`
-	DocumentID     string     `json:"document_id"`
-	Author         string     `json:"author"`
-	Body           string     `json:"body"`
-	Section        string     `json:"section,omitempty"`
-	ParagraphIndex *int       `json:"paragraph_index,omitempty"`
-	ParagraphHash  string     `json:"paragraph_hash,omitempty"`
-	Quote          string     `json:"quote,omitempty"`
-	ParentID       *int       `json:"parent_id,omitempty"`
-	Status         string     `json:"status"`
+	ID                   int     `json:"id"`
+	OrganizationID       int     `json:"organization_id"`
+	ReviewID             *int    `json:"review_id,omitempty"`
+	DocumentID           string  `json:"document_id"`
+	Author               string  `json:"author"`
+	Body                 string  `json:"body"`
+	Section              string  `json:"section,omitempty"`
+	ParagraphIndex       *int    `json:"paragraph_index,omitempty"`
+	ParagraphHash        string  `json:"paragraph_hash,omitempty"`
+	Quote                string  `json:"quote,omitempty"`
+	ParentID             *int    `json:"parent_id,omitempty"`
+	Status               string  `json:"status"`
 	ResolvedBy           string  `json:"resolved_by,omitempty"`
 	ResolvedAt           *Epoch  `json:"resolved_at,omitempty"`
 	SuggestionBody       *string `json:"suggestion_body,omitempty"`
@@ -804,14 +806,14 @@ func (d *DB) AllOpenComments(ctx context.Context, orgID int) ([]Comment, error) 
 // --- Approvals ---
 
 type Approval struct {
-	ID             int       `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	ReviewID       *int      `json:"review_id,omitempty"`
-	DocumentID     string    `json:"document_id"`
-	Version        string    `json:"version"`
-	Round          int       `json:"round"`
-	Decision       string    `json:"decision"` // approved, changes_requested
-	ApprovedBy     string    `json:"approved_by"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	ReviewID       *int   `json:"review_id,omitempty"`
+	DocumentID     string `json:"document_id"`
+	Version        string `json:"version"`
+	Round          int    `json:"round"`
+	Decision       string `json:"decision"` // approved, changes_requested
+	ApprovedBy     string `json:"approved_by"`
 	Comment        string `json:"comment,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`
 }
@@ -851,12 +853,12 @@ func (d *DB) ApprovalsForDocument(ctx context.Context, orgID int, documentID str
 // --- Activity ---
 
 type Activity struct {
-	ID             int       `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	DocumentID     string    `json:"document_id,omitempty"`
-	ReviewID       *int      `json:"review_id,omitempty"`
-	Actor          string    `json:"actor"`
-	Action         string    `json:"action"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	DocumentID     string `json:"document_id,omitempty"`
+	ReviewID       *int   `json:"review_id,omitempty"`
+	Actor          string `json:"actor"`
+	Action         string `json:"action"`
 	Detail         string `json:"detail,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`
 }

--- a/internal/isms/db/programs.go
+++ b/internal/isms/db/programs.go
@@ -6,13 +6,13 @@ import (
 
 // Program groups related objectives under a keyed programme.
 type Program struct {
-	ID             int64     `json:"id"`
-	Identifier     string    `json:"identifier"`
-	OrganizationID int       `json:"organization_id"`
-	Key            string    `json:"key"`
-	Title          string    `json:"title"`
-	Description    string    `json:"description,omitempty"`
-	Notes          string    `json:"notes,omitempty"`
+	ID             int64  `json:"id"`
+	Identifier     string `json:"identifier"`
+	OrganizationID int    `json:"organization_id"`
+	Key            string `json:"key"`
+	Title          string `json:"title"`
+	Description    string `json:"description,omitempty"`
+	Notes          string `json:"notes,omitempty"`
 	Owner          string `json:"owner,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`
 	UpdatedAt      Epoch  `json:"updated_at"`

--- a/internal/isms/db/references.go
+++ b/internal/isms/db/references.go
@@ -6,13 +6,13 @@ import (
 
 // EntityReference represents a cross-reference link between two entities.
 type EntityReference struct {
-	ID             int64     `json:"id"`
-	OrganizationID int       `json:"-"`
-	SourceType     string    `json:"source_type"`
-	SourceID       string    `json:"source_id"`
-	TargetType     string    `json:"target_type"`
-	TargetID       string    `json:"target_id"`
-	Title          string    `json:"title,omitempty"` // resolved display name (populated by API, not stored)
+	ID             int64  `json:"id"`
+	OrganizationID int    `json:"-"`
+	SourceType     string `json:"source_type"`
+	SourceID       string `json:"source_id"`
+	TargetType     string `json:"target_type"`
+	TargetID       string `json:"target_id"`
+	Title          string `json:"title,omitempty"` // resolved display name (populated by API, not stored)
 	CreatedBy      string `json:"created_by,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`
 }

--- a/internal/isms/db/review_assignments.go
+++ b/internal/isms/db/review_assignments.go
@@ -6,10 +6,10 @@ import (
 
 // ReviewAssignment tracks who needs to review a given review request.
 type ReviewAssignment struct {
-	ID             int        `json:"id"`
-	OrganizationID int        `json:"organization_id"`
-	ReviewID       int        `json:"review_id"`
-	Reviewer       string     `json:"reviewer"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	ReviewID       int    `json:"review_id"`
+	Reviewer       string `json:"reviewer"`
 	Status         string `json:"status"`
 	ReviewedAt     *Epoch `json:"reviewed_at,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`

--- a/internal/isms/db/risks.go
+++ b/internal/isms/db/risks.go
@@ -30,14 +30,14 @@ var riskSortable = map[string]string{
 
 // Risk represents a single risk entry in the register.
 type Risk struct {
-	ID              int64    `json:"id"`
-	OrganizationID  int      `json:"organization_id"`
-	Identifier      string   `json:"identifier"` // RISK-001
-	Title           string   `json:"title"`
-	Description     string   `json:"description,omitempty"`
-	RiskType        string   `json:"risk_type"`
-	Origin          string   `json:"origin"`
-	Category string `json:"category,omitempty"`
+	ID             int64  `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	Identifier     string `json:"identifier"` // RISK-001
+	Title          string `json:"title"`
+	Description    string `json:"description,omitempty"`
+	RiskType       string `json:"risk_type"`
+	Origin         string `json:"origin"`
+	Category       string `json:"category,omitempty"`
 	// PotentialConsequences was a column; now lives in description (## Potential consequences)
 
 	// Current/residual assessment (nil = not assessed)
@@ -288,7 +288,9 @@ const riskSelectCols = `id, organization_id, identifier, title, COALESCE(descrip
 		COALESCE((SELECT email FROM users WHERE id = risks.owner_id), ''), status, last_review, next_review,
 		COALESCE(notes, ''), created_at, updated_at`
 
-func scanRisk(scanner interface{ Scan(dest ...interface{}) error }, r *Risk) error {
+func scanRisk(scanner interface {
+	Scan(dest ...interface{}) error
+}, r *Risk) error {
 	return scanner.Scan(&r.ID, &r.OrganizationID, &r.Identifier, &r.Title, &r.Description,
 		&r.RiskType, &r.Origin, &r.Category,
 		&r.CurrentLikelihood, &r.CurrentImpact, &r.CurrentScore, &r.CurrentLevel,

--- a/internal/isms/db/settings.go
+++ b/internal/isms/db/settings.go
@@ -16,10 +16,10 @@ type Setting struct {
 
 // OrgSetting is a per-org setting value.
 type OrgSetting struct {
-	Key         string  `json:"key"`
-	Value       string  `json:"value"`
-	Description string  `json:"description"`
-	Category    string  `json:"category"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
 }
 
 // ListSettings returns all known settings.

--- a/internal/isms/db/suggestions.go
+++ b/internal/isms/db/suggestions.go
@@ -9,26 +9,26 @@ import (
 
 // Suggestion represents a proposed change to an operational entity.
 type Suggestion struct {
-	ID                int64            `json:"id"`
-	OrganizationID    int              `json:"organization_id"`
-	EntityType        string           `json:"entity_type"`
-	EntityID          string           `json:"entity_id,omitempty"`
-	SuggestionType    string           `json:"suggestion_type"`
-	Title             string           `json:"title"`
-	Payload           json.RawMessage  `json:"payload"`
-	Rationale         string           `json:"rationale,omitempty"`
-	SourceRefs        json.RawMessage  `json:"source_refs,omitempty"`
-	EntityUpdatedAt   *Epoch           `json:"entity_updated_at,omitempty"`
-	Status            string           `json:"status"`
-	SuggestedBy       string           `json:"suggested_by"`
-	SuggestedByType   string           `json:"suggested_by_type"`
-	ReviewedBy        string           `json:"reviewed_by,omitempty"`
-	ReviewedAt        *Epoch           `json:"reviewed_at,omitempty"`
-	AppliedAt         *Epoch           `json:"applied_at,omitempty"`
-	AppliedEntityID   string           `json:"applied_entity_id,omitempty"`
-	RejectReason      string           `json:"reject_reason,omitempty"`
-	CreatedAt         Epoch            `json:"created_at"`
-	UpdatedAt         Epoch            `json:"updated_at"`
+	ID              int64           `json:"id"`
+	OrganizationID  int             `json:"organization_id"`
+	EntityType      string          `json:"entity_type"`
+	EntityID        string          `json:"entity_id,omitempty"`
+	SuggestionType  string          `json:"suggestion_type"`
+	Title           string          `json:"title"`
+	Payload         json.RawMessage `json:"payload"`
+	Rationale       string          `json:"rationale,omitempty"`
+	SourceRefs      json.RawMessage `json:"source_refs,omitempty"`
+	EntityUpdatedAt *Epoch          `json:"entity_updated_at,omitempty"`
+	Status          string          `json:"status"`
+	SuggestedBy     string          `json:"suggested_by"`
+	SuggestedByType string          `json:"suggested_by_type"`
+	ReviewedBy      string          `json:"reviewed_by,omitempty"`
+	ReviewedAt      *Epoch          `json:"reviewed_at,omitempty"`
+	AppliedAt       *Epoch          `json:"applied_at,omitempty"`
+	AppliedEntityID string          `json:"applied_entity_id,omitempty"`
+	RejectReason    string          `json:"reject_reason,omitempty"`
+	CreatedAt       Epoch           `json:"created_at"`
+	UpdatedAt       Epoch           `json:"updated_at"`
 }
 
 const suggestionSelectCols = `
@@ -40,7 +40,9 @@ const suggestionSelectCols = `
 	COALESCE(applied_entity_id, ''), COALESCE(reject_reason, ''),
 	created_at, updated_at`
 
-func scanSuggestion(scanner interface{ Scan(dest ...interface{}) error }, s *Suggestion) error {
+func scanSuggestion(scanner interface {
+	Scan(dest ...interface{}) error
+}, s *Suggestion) error {
 	return scanner.Scan(
 		&s.ID, &s.OrganizationID, &s.EntityType, &s.EntityID,
 		&s.SuggestionType, &s.Title, &s.Payload, &s.Rationale,

--- a/internal/isms/db/suppliers.go
+++ b/internal/isms/db/suppliers.go
@@ -114,7 +114,9 @@ const supplierSelectCols = `id, organization_id, identifier, name, supplier_type
 		last_review, next_review,
 		COALESCE(notes, ''), created_at, updated_at`
 
-func scanSupplier(scanner interface{ Scan(dest ...interface{}) error }, s *Supplier) error {
+func scanSupplier(scanner interface {
+	Scan(dest ...interface{}) error
+}, s *Supplier) error {
 	return scanner.Scan(&s.ID, &s.OrganizationID, &s.Identifier, &s.Name, &s.SupplierType, &s.Criticality,
 		&s.DataAccess,
 		&s.Contact, &s.ContractRef,

--- a/internal/isms/db/systems.go
+++ b/internal/isms/db/systems.go
@@ -153,7 +153,9 @@ const systemSelectCols = `id, organization_id, identifier, name, COALESCE(descri
 		COALESCE((SELECT email FROM users WHERE id = systems.owner_id), ''),
 		COALESCE(notes, ''), created_at, updated_at`
 
-func scanSystem(scanner interface{ Scan(dest ...interface{}) error }, sys *System) error {
+func scanSystem(scanner interface {
+	Scan(dest ...interface{}) error
+}, sys *System) error {
 	return scanner.Scan(&sys.ID, &sys.OrganizationID, &sys.Identifier, &sys.Name, &sys.Description,
 		&sys.SupplierID, &sys.Department,
 		&sys.Classification, &sys.Criticality, &sys.Status,

--- a/internal/isms/db/tokens.go
+++ b/internal/isms/db/tokens.go
@@ -16,9 +16,9 @@ type APIKey struct {
 	ID             int    `json:"id"`
 	Name           string `json:"name"`
 	UserID         int    `json:"user_id"`
-	UserEmail      string `json:"user_email"`  // from users table
+	UserEmail      string `json:"user_email"`                // from users table
 	OrganizationID *int   `json:"organization_id,omitempty"` // NULL = all orgs, set = org-scoped
-	Permissions    string `json:"permissions"` // read, write, read-write
+	Permissions    string `json:"permissions"`               // read, write, read-write
 	CreatedAt      Epoch  `json:"created_at"`
 	RevokedAt      *Epoch `json:"revoked_at,omitempty"`
 	LastUsedAt     *Epoch `json:"last_used_at,omitempty"`

--- a/internal/isms/db/users.go
+++ b/internal/isms/db/users.go
@@ -12,17 +12,17 @@ import (
 
 // User represents an ISMS platform user.
 type User struct {
-	ID            int        `json:"id"`
-	Email         string     `json:"email"`
-	Name          string     `json:"name"`
-	PasswordHash  *string    `json:"-"`                    // bcrypt, nil = external auth only
-	OTPSecret     *string    `json:"-"`                    // TOTP base32 secret, nil = OTP not enabled
-	OTPVerified   bool       `json:"otp_verified"`         // true after first successful OTP
-	EmailVerified bool       `json:"email_verified"`       // true after verification or CF login
-	IsAgent       bool   `json:"is_agent"`
-	Active        bool   `json:"active"`
-	CreatedAt     Epoch  `json:"created_at"`
-	LastSeen      *Epoch `json:"last_seen,omitempty"`
+	ID            int     `json:"id"`
+	Email         string  `json:"email"`
+	Name          string  `json:"name"`
+	PasswordHash  *string `json:"-"`              // bcrypt, nil = external auth only
+	OTPSecret     *string `json:"-"`              // TOTP base32 secret, nil = OTP not enabled
+	OTPVerified   bool    `json:"otp_verified"`   // true after first successful OTP
+	EmailVerified bool    `json:"email_verified"` // true after verification or CF login
+	IsAgent       bool    `json:"is_agent"`
+	Active        bool    `json:"active"`
+	CreatedAt     Epoch   `json:"created_at"`
+	LastSeen      *Epoch  `json:"last_seen,omitempty"`
 }
 
 // UserWithRole is a User plus their role within a specific organization.
@@ -33,21 +33,21 @@ type UserWithRole struct {
 
 // Organization represents a tenant / customer org.
 type Organization struct {
-	ID        int       `json:"-"`                          // never exposed externally
-	UUID     string    `json:"uuid"`                       // public identifier
-	Name     string    `json:"name"`
-	Slug     string    `json:"slug"`                       // URL-friendly (e.g. "unidoc")
-	RepoPath string    `json:"repo_path,omitempty"`        // git repo path on server
-	Domain   *string `json:"domain,omitempty"`           // custom domain
-	CreatedAt Epoch  `json:"created_at"`
-	UpdatedAt Epoch  `json:"updated_at"`
+	ID        int     `json:"-"`    // never exposed externally
+	UUID      string  `json:"uuid"` // public identifier
+	Name      string  `json:"name"`
+	Slug      string  `json:"slug"`                // URL-friendly (e.g. "unidoc")
+	RepoPath  string  `json:"repo_path,omitempty"` // git repo path on server
+	Domain    *string `json:"domain,omitempty"`    // custom domain
+	CreatedAt Epoch   `json:"created_at"`
+	UpdatedAt Epoch   `json:"updated_at"`
 }
 
 // OrgMember represents a user's membership and role within an organization.
 type OrgMember struct {
-	ID             int       `json:"id"`
-	OrganizationID int       `json:"organization_id"`
-	UserID         int       `json:"user_id"`
+	ID             int    `json:"id"`
+	OrganizationID int    `json:"organization_id"`
+	UserID         int    `json:"user_id"`
 	Role           string `json:"role"`
 	CreatedAt      Epoch  `json:"created_at"`
 }

--- a/internal/isms/db/webauthn.go
+++ b/internal/isms/db/webauthn.go
@@ -6,16 +6,16 @@ import (
 
 // WebAuthnCredential represents a WebAuthn/FIDO2 passkey credential for a user.
 type WebAuthnCredential struct {
-	ID              int        `json:"id"`
-	UserID          int        `json:"user_id"`
-	CredentialID    []byte     `json:"-"`
-	PublicKey       []byte     `json:"-"`
-	AttestationType string     `json:"attestation_type"`
-	Transport       []string   `json:"transport"`
-	SignCount       int        `json:"sign_count"`
-	Name            string `json:"name"`
-	CreatedAt       Epoch  `json:"created_at"`
-	LastUsedAt      *Epoch `json:"last_used_at,omitempty"`
+	ID              int      `json:"id"`
+	UserID          int      `json:"user_id"`
+	CredentialID    []byte   `json:"-"`
+	PublicKey       []byte   `json:"-"`
+	AttestationType string   `json:"attestation_type"`
+	Transport       []string `json:"transport"`
+	SignCount       int      `json:"sign_count"`
+	Name            string   `json:"name"`
+	CreatedAt       Epoch    `json:"created_at"`
+	LastUsedAt      *Epoch   `json:"last_used_at,omitempty"`
 }
 
 // CreateWebAuthnCredential stores a new WebAuthn credential.

--- a/internal/isms/mcp/server.go
+++ b/internal/isms/mcp/server.go
@@ -819,8 +819,8 @@ func handleRequest(client *apiClient, req *jsonRPCRequest) *jsonRPCResponse {
 			ID:      req.ID,
 			Result: map[string]interface{}{
 				"protocolVersion": "2024-11-05",
-				"capabilities":   map[string]interface{}{"tools": map[string]interface{}{}},
-				"serverInfo":     map[string]interface{}{"name": "isms-mcp", "version": "1.0.0"},
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "isms-mcp", "version": "1.0.0"},
 			},
 		}
 	case "notifications/initialized":

--- a/internal/isms/model/document.go
+++ b/internal/isms/model/document.go
@@ -4,23 +4,22 @@ package model
 // Not all fields apply to all document types — which fields are used
 // depends on the template and document folder, not on hardcoded types.
 type DocumentFrontmatter struct {
-	DocumentID     string         `yaml:"document_id" json:"document_id"`
-	Title          string         `yaml:"title" json:"title"`
-	Type           string         `yaml:"type,omitempty" json:"type,omitempty"`                 // control, policy, procedure, clause, record, guideline — empty = document
-	Version        string         `yaml:"version,omitempty" json:"version,omitempty"`
-	Status         string         `yaml:"status" json:"status"`                                 // draft, in_review, approved, retired
-	Author         string         `yaml:"author,omitempty" json:"author,omitempty"`
-	Owner          string         `yaml:"owner,omitempty" json:"owner,omitempty"` // responsible for periodic review
-	Reviewer       string         `yaml:"reviewer,omitempty" json:"reviewer,omitempty"`
-	ApprovedBy     string         `yaml:"approved_by,omitempty" json:"approved_by,omitempty"`
-	ApprovedDate   string         `yaml:"approved_date,omitempty" json:"approved_date,omitempty"`
-	EffectiveDate  string         `yaml:"effective_date,omitempty" json:"effective_date,omitempty"`
-	NextReview     string         `yaml:"next_review,omitempty" json:"next_review,omitempty"`
-	ReviewCycle    int            `yaml:"review_cycle,omitempty" json:"review_cycle,omitempty"` // months
-	Classification string         `yaml:"classification,omitempty" json:"classification,omitempty"`
+	DocumentID     string           `yaml:"document_id" json:"document_id"`
+	Title          string           `yaml:"title" json:"title"`
+	Type           string           `yaml:"type,omitempty" json:"type,omitempty"` // control, policy, procedure, clause, record, guideline — empty = document
+	Version        string           `yaml:"version,omitempty" json:"version,omitempty"`
+	Status         string           `yaml:"status" json:"status"` // draft, in_review, approved, retired
+	Author         string           `yaml:"author,omitempty" json:"author,omitempty"`
+	Owner          string           `yaml:"owner,omitempty" json:"owner,omitempty"` // responsible for periodic review
+	Reviewer       string           `yaml:"reviewer,omitempty" json:"reviewer,omitempty"`
+	ApprovedBy     string           `yaml:"approved_by,omitempty" json:"approved_by,omitempty"`
+	ApprovedDate   string           `yaml:"approved_date,omitempty" json:"approved_date,omitempty"`
+	EffectiveDate  string           `yaml:"effective_date,omitempty" json:"effective_date,omitempty"`
+	NextReview     string           `yaml:"next_review,omitempty" json:"next_review,omitempty"`
+	ReviewCycle    int              `yaml:"review_cycle,omitempty" json:"review_cycle,omitempty"` // months
+	Classification string           `yaml:"classification,omitempty" json:"classification,omitempty"`
 	Changelog      []DocumentChange `yaml:"changelog,omitempty" json:"changelog,omitempty"`
 }
-
 
 // DocumentChange is a version history entry in the document changelog.
 type DocumentChange struct {
@@ -33,4 +32,3 @@ type DocumentChange struct {
 
 // DocumentStatuses lists the valid document statuses.
 var DocumentStatuses = []string{"draft", "in_review", "approved", "retired"}
-

--- a/internal/isms/notify/notify.go
+++ b/internal/isms/notify/notify.go
@@ -46,9 +46,9 @@ type Event struct {
 	Actor    string
 	Action   string
 	Detail   string
-	Body     string // comment/task body (truncated)
-	Link     string // relative URL path, e.g. /documents/ISO27001-4.1
-	BaseURL  string // e.g. https://isms.unidoc.io
+	Body     string      // comment/task body (truncated)
+	Link     string      // relative URL path, e.g. /documents/ISO27001-4.1
+	BaseURL  string      // e.g. https://isms.unidoc.io
 	Channels OrgChannels // per-org credentials
 }
 

--- a/internal/isms/store/document.go
+++ b/internal/isms/store/document.go
@@ -8,15 +8,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	"isms.sh/internal/isms/model"
 	"gopkg.in/yaml.v3"
+	"isms.sh/internal/isms/model"
 )
 
 // DocumentFile represents a policy markdown file with parsed frontmatter.
 type DocumentFile struct {
-	Path        string                  `json:"path"`
+	Path        string                    `json:"path"`
 	Frontmatter model.DocumentFrontmatter `json:"frontmatter"`
-	Body        string                  `json:"body"` // markdown body after frontmatter
+	Body        string                    `json:"body"` // markdown body after frontmatter
 }
 
 // LoadDocument reads a document file and parses its frontmatter.

--- a/internal/isms/store/git.go
+++ b/internal/isms/store/git.go
@@ -86,10 +86,15 @@ type dirEntry struct {
 	isDir bool
 }
 
-func (d dirEntry) Name() string               { return d.name }
-func (d dirEntry) IsDir() bool                 { return d.isDir }
-func (d dirEntry) Type() fs.FileMode           { if d.isDir { return fs.ModeDir }; return 0 }
-func (d dirEntry) Info() (fs.FileInfo, error)   { return nil, fmt.Errorf("not supported") }
+func (d dirEntry) Name() string { return d.name }
+func (d dirEntry) IsDir() bool  { return d.isDir }
+func (d dirEntry) Type() fs.FileMode {
+	if d.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (d dirEntry) Info() (fs.FileInfo, error) { return nil, fmt.Errorf("not supported") }
 
 // readDir lists entries in a directory from the git tree or filesystem.
 func (s *Store) readDir(path string) ([]fs.DirEntry, error) {
@@ -415,7 +420,7 @@ func (s *Store) ResetToCommit(hash string) error {
 
 // ChangedFile describes a file changed in a recent commit.
 type ChangedFile struct {
-	Path       string `json:"path"`        // relative to documents/
+	Path       string `json:"path"` // relative to documents/
 	DocumentID string `json:"document_id"`
 	Title      string `json:"title"`
 	Folder     string `json:"folder"`
@@ -1292,7 +1297,9 @@ func (s *Store) commitFileUnlocked(filePath string, content []byte, authorName, 
 }
 
 // storeBlob creates a blob object in the repo.
-func storeBlob(storer interface{ SetEncodedObject(plumbing.EncodedObject) (plumbing.Hash, error) }, content []byte) (plumbing.Hash, error) {
+func storeBlob(storer interface {
+	SetEncodedObject(plumbing.EncodedObject) (plumbing.Hash, error)
+}, content []byte) (plumbing.Hash, error) {
 	obj := &plumbing.MemoryObject{}
 	obj.SetType(plumbing.BlobObject)
 	obj.SetSize(int64(len(content)))

--- a/internal/isms/store/yaml.go
+++ b/internal/isms/store/yaml.go
@@ -25,7 +25,7 @@ type Store struct {
 	root    string          // root directory of the ISMS repo
 	repo    *git.Repository // nil = filesystem mode, non-nil = bare repo mode
 	mu      sync.Mutex      // protects concurrent git write operations
-	signing *SigningConfig   // SSH signing config (nil = unsigned commits)
+	signing *SigningConfig  // SSH signing config (nil = unsigned commits)
 
 	// Document ID index cache (invalidated on HEAD change)
 	docIndexMu   sync.Mutex
@@ -166,4 +166,3 @@ func (s *Store) writeYAML(path string, data interface{}) error {
 	}
 	return os.WriteFile(path, out, 0o644)
 }
-

--- a/internal/isms/tui/tui.go
+++ b/internal/isms/tui/tui.go
@@ -20,7 +20,7 @@ type mode int
 
 const (
 	modeList   mode = iota // two-pane: list on left, preview on right
-	modeReader              // full-screen rendered document
+	modeReader             // full-screen rendered document
 )
 
 // item is a row in the document list — either a folder header or a document.


### PR DESCRIPTION
Closes #83.

The last 0.6.2 item, deliberately held until #91–#94 merged because a whole-repo reformat conflicts with every open PR.

**What changed**
- `gofmt -w .` across the tree — mostly import ordering (e.g. `golang.org/...` before `isms.sh/...` within a group) and whitespace. No logic changes.
- **CI gate** (`tests.yml`, go-unit job): a `gofmt` step fails the build on any unformatted file, so this churn can't creep back.
- **`just fmt`** (`Justfile`): `gofmt -w .` to fix the tree locally; the gate's failure message points here.

**Verification**
- `gofmt -l .` clean after the reformat.
- `go build ./...` and `go vet ./...` green; `go test ./internal/...` green (verified from the dev container).

Big diff but mechanical — reviewing the two hand-authored files (`tests.yml`, `Justfile`) is the substantive part; the rest is pure `gofmt` output.