### PR TITLE
feat(review): per-cell word-level table diffs (#6, slice 1/2)

### DIFF
--- a/tests/test_e2e_review_diff.py
+++ b/tests/test_e2e_review_diff.py
@@ -104,9 +104,92 @@ def test_review_table_diff_renders_per_cell(pw_browser, table_review):
         _assert_per_cell_table_diff(page)
         page.screenshot(path="docs/screenshots/test_review_table_diff_split.png")
 
-        # 2. Unified view does too.
+        # 2. Unified view does too — and its stats count CELLS, not raw lines
+        #    (a md→HTML table must not read "+1 added -5 removed" for a 2-cell edit).
         page.locator("button:has-text('Unified')").first.click()
         _assert_per_cell_table_diff(page)
+        assert page.locator("text=2 added").count() >= 1, "unified stats should count 2 changed cells"
+        assert page.locator("text=5 removed").count() == 0, "stats must not use raw line counts for a table edit"
         page.screenshot(path="docs/screenshots/test_review_table_diff_unified.png")
+    finally:
+        ctx.close()
+
+
+# A second table that gets deleted outright in the same revision — this is what
+# broke the old sequential-counter pairing (the deletion shifted the index so the
+# changed table diffed against the wrong old table). #99 review must-fix.
+OLD_BODY_2 = """# Team Roster
+
+| Name | Role |
+|---|---|
+| Alice | Lead |
+| Bob | Dev |
+
+# Interested Parties
+
+| Party | Requirement |
+|---|---|
+| Customers | Confidentiality |
+| Suppliers | Security expectations |"""
+
+# Reviewer deletes the Team Roster table entirely and changes ONE cell in the
+# Interested Parties table (Customers requirement).
+NEW_BODY_2 = (
+    "# Interested Parties\n\n"
+    "<table><tbody>"
+    "<tr><th><p>Party</p></th><th><p>Requirement</p></th></tr>"
+    "<tr><td><p>Customers</p></td><td><p>Confidentiality and integrity</p></td></tr>"
+    "<tr><td><p>Suppliers</p></td><td><p>Security expectations</p></td></tr>"
+    "</tbody></table>"
+)
+
+
+@pytest.fixture(scope="module")
+def table_review_with_deletion(tokens):
+    """Approved baseline with TWO tables; reviewer deletes the first and changes
+    one cell in the second."""
+    t = tokens["admin"]
+    r1t = api("post", "/auth/login",
+              json={"email": R1[0], "password": R1[1], "organization": ORG},
+              expect_status=200).json()["token"]
+    doc_id = f"e2e-tabledel-{uuid.uuid4().hex[:8]}"
+    api("post", "/documents", t, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "E2E Table Delete", "content": OLD_BODY_2,
+    }, expect_status=[200, 201])
+    rid0 = api("post", f"/documents/{doc_id}/reviews", t,
+               json={"reviewers": [R1[0]], "message": "baseline"},
+               expect_status=[200, 201]).json()["review_id"]
+    api("post", f"/reviews/{rid0}/approve", r1t,
+        json={"decision": "approved", "comment": "ok"}, expect_status=200)
+    api("post", f"/reviews/{rid0}/merge", t, json={}, expect_status=200)
+    rid = api("post", f"/documents/{doc_id}/reviews", t,
+              json={"reviewers": [R1[0]], "message": "Delete + edit"},
+              expect_status=[200, 201]).json()["review_id"]
+    api("put", f"/reviews/{rid}/content", r1t, json={"content": NEW_BODY_2}, expect_status=200)
+    yield rid
+    api("put", f"/reviews/{rid}/status", t, json={"status": "closed"})
+
+
+def test_review_table_diff_pairs_correctly_after_deletion(pw_browser, table_review_with_deletion):
+    ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = ctx.new_page()
+    try:
+        do_login(page, ADMIN[0], ADMIN[1], then_goto=f"reviews/{table_review_with_deletion}")
+        page.locator("button:has-text('Changes')").first.click()
+        page.wait_for_load_state("networkidle")
+        page.locator(".doc-prose table").first.wait_for(state="visible", timeout=10000)
+
+        # The Interested Parties change must be paired against the RIGHT old table
+        # despite the Team Roster deletion: exactly one changed cell, the real edit.
+        # (The old bug paired it against Team Roster → 0 cell-changes, Alice/Bob
+        # rows wrongly appended as deletions.)
+        page.locator("td.tc-cell-change").first.wait_for(state="visible", timeout=8000)
+        assert page.locator("td.tc-cell-change").count() == 1, \
+            f"expected exactly 1 changed cell, got {page.locator('td.tc-cell-change').count()}"
+        assert page.locator(".tc-cell-change .tc-word-ins", has_text="and integrity").count() >= 1, \
+            "the real word-level edit must be shown"
+        assert page.locator("td.tc-cell-change", has_text="Alice").count() == 0, \
+            "deleted-table rows must not be mis-paired into the changed table"
     finally:
         ctx.close()

--- a/tests/test_e2e_review_diff.py
+++ b/tests/test_e2e_review_diff.py
@@ -1,0 +1,112 @@
+"""E2E: the review diff renders table edits per-cell, not as a wholesale replace (#6).
+
+Reproduces the real reported case (María on clause 4.2): a reviewer proposes a
+revision that the WYSIWYG editor stores as an HTML table (a markdown pipe table
+becomes HTML on the first edit), changing only two cells. The diff must highlight
+just those two cells — in BOTH the default Split view and the Unified view — and
+must NOT show the markdown→HTML conversion as a change.
+
+Kept in its own file (not the test_e2e_browser monolith) to avoid per-branch
+EOF merge conflicts as review-UI work continues.
+"""
+import uuid
+
+import pytest
+from test_e2e_browser import api, do_login, ORG, ADMIN, R1, pw_browser, tokens  # noqa: F401
+
+# Baseline sent for review: a clean markdown pipe table.
+OLD_BODY = """# Interested Parties
+
+| Party | Requirement | How addressed |
+|---|---|---|
+| Customers | Confidentiality and integrity | Certification programme |
+| Employees | Clear responsibilities and training | Awareness programme |
+| Suppliers | Defined security expectations | Supplier register |"""
+
+# The reviewer's proposal: the WYSIWYG editor stores the table as HTML, and only
+# two requirement cells gained a prepended phrase (Customers row is untouched).
+NEW_BODY = (
+    "# Interested Parties\n\n"
+    "<table><tbody>"
+    "<tr><th><p>Party</p></th><th><p>Requirement</p></th><th><p>How addressed</p></th></tr>"
+    "<tr><td><p>Customers</p></td><td><p>Confidentiality and integrity</p></td><td><p>Certification programme</p></td></tr>"
+    "<tr><td><p>Employees</p></td><td><p>Background check. Clear responsibilities and training</p></td><td><p>Awareness programme</p></td></tr>"
+    "<tr><td><p>Suppliers</p></td><td><p>Review supplier security docs. Defined security expectations</p></td><td><p>Supplier register</p></td></tr>"
+    "</tbody></table>"
+)
+
+
+@pytest.fixture(scope="module")
+def table_review(tokens):
+    """Mirror the real case: an APPROVED doc (so there's a baseline to diff
+    against), then a new review where the reviewer proposes an HTML-table
+    revision that changes two cells. Returns the review id."""
+    t = tokens["admin"]
+    r1t = api("post", "/auth/login",
+              json={"email": R1[0], "password": R1[1], "organization": ORG},
+              expect_status=200).json()["token"]
+    doc_id = f"e2e-tablediff-{uuid.uuid4().hex[:8]}"
+    api("post", "/documents", t, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "E2E Table Diff", "content": OLD_BODY,
+    }, expect_status=[200, 201])
+
+    # Establish an approved baseline (the markdown table) — a real, live doc.
+    rid0 = api("post", f"/documents/{doc_id}/reviews", t,
+               json={"reviewers": [R1[0]], "message": "baseline"},
+               expect_status=[200, 201]).json()["review_id"]
+    api("post", f"/reviews/{rid0}/approve", r1t,
+        json={"decision": "approved", "comment": "ok"}, expect_status=200)
+    api("post", f"/reviews/{rid0}/merge", t, json={}, expect_status=200)
+
+    # New review: the assigned reviewer proposes the HTML-table revision.
+    rid = api("post", f"/documents/{doc_id}/reviews", t,
+              json={"reviewers": [R1[0]], "message": "Table diff E2E"},
+              expect_status=[200, 201]).json()["review_id"]
+    api("put", f"/reviews/{rid}/content", r1t, json={"content": NEW_BODY}, expect_status=200)
+
+    # Sanity: the diff endpoint exposes the old (markdown) + new (HTML) bodies.
+    d = api("get", f"/reviews/{rid}/diff", t, expect_status=200).json()
+    assert d["has_branch"] is True, "review branch should exist after a proposal"
+    assert "Customers" in d["old_body"], f"old_body should hold the approved markdown table, got: {d['old_body'][:120]!r}"
+    assert "<table" in d["new_body"], "new_body should hold the proposed HTML table"
+    yield rid
+    api("put", f"/reviews/{rid}/status", t, json={"status": "closed"})
+
+
+def _assert_per_cell_table_diff(page):
+    # Renders as a real table (not escaped tag soup).
+    page.locator(".doc-prose table").first.wait_for(state="visible", timeout=10000)
+    # Exactly the two edited cells are highlighted — NOT the whole table.
+    page.locator("td.tc-cell-change").first.wait_for(state="visible", timeout=8000)
+    n = page.locator("td.tc-cell-change").count()
+    assert n == 2, f"expected exactly 2 changed cells, got {n}"
+    # The added phrases show as word-level insertions inside those cells.
+    assert page.locator(".tc-cell-change .tc-word-ins", has_text="Background check.").count() >= 1, \
+        "the 'Background check.' insertion should be highlighted"
+    assert page.locator(".tc-cell-change .tc-word-ins", has_text="Review supplier security docs.").count() >= 1, \
+        "the supplier-docs insertion should be highlighted"
+    # An unchanged cell (Customers row) must not be flagged as changed.
+    assert page.locator("td.tc-cell-change", has_text="Certification programme").count() == 0, \
+        "unchanged cells must not be highlighted"
+
+
+def test_review_table_diff_renders_per_cell(pw_browser, table_review):
+    ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = ctx.new_page()
+    try:
+        do_login(page, ADMIN[0], ADMIN[1], then_goto=f"reviews/{table_review}")
+        # Open the Changes tab (default), Split view is the default sub-view.
+        page.locator("button:has-text('Changes')").first.click()
+        page.wait_for_load_state("networkidle")
+
+        # 1. Default (Split) view renders the edit per-cell.
+        _assert_per_cell_table_diff(page)
+        page.screenshot(path="docs/screenshots/test_review_table_diff_split.png")
+
+        # 2. Unified view does too.
+        page.locator("button:has-text('Unified')").first.click()
+        _assert_per_cell_table_diff(page)
+        page.screenshot(path="docs/screenshots/test_review_table_diff_unified.png")
+    finally:
+        ctx.close()

--- a/web/src/components/SideBySideReview.vue
+++ b/web/src/components/SideBySideReview.vue
@@ -138,6 +138,7 @@ import { ref, computed, watch } from 'vue'
 import DOMPurify from 'dompurify'
 import DiffView from './DiffView.vue'
 import { parseMd } from '../composables/useRenderMd'
+import { diffTables, isTableBlock } from '../composables/useTableDiff'
 
 const props = defineProps({
   oldBody: { type: String, default: '' },
@@ -235,13 +236,35 @@ const diff = computed(() => {
   return diffBlocks(oldBlocks.value, newBlocks.value)
 })
 
-const leftBlocks = computed(() =>
-  oldBlocks.value.map((b, i) => ({ ...b, changed: diff.value.oldChanged[i] }))
+// A changed table renders as a single per-cell diff in the Current column
+// (see useTableDiff) instead of a wholesale red-old / green-new block — so a
+// one-cell edit reads as one cell, not a replaced table. The Previous column
+// then shows the old table plainly (the merged diff already marks removals).
+const changedOldTables = computed(() =>
+  oldBlocks.value.filter((b, i) => diff.value.oldChanged[i] && isTableBlock(b.text))
 )
 
-const rightBlocks = computed(() =>
-  newBlocks.value.map((b, i) => ({ ...b, changed: diff.value.newChanged[i] }))
+const leftBlocks = computed(() =>
+  oldBlocks.value.map((b, i) => ({
+    ...b,
+    // Don't strike through a whole old table — its diff is shown on the right.
+    changed: diff.value.oldChanged[i] && !isTableBlock(b.text),
+  }))
 )
+
+const rightBlocks = computed(() => {
+  let tIdx = 0
+  return newBlocks.value.map((b, i) => {
+    const changed = diff.value.newChanged[i]
+    if (changed && isTableBlock(b.text)) {
+      const oldText = changedOldTables.value[tIdx]?.text || ''
+      tIdx++
+      const merged = diffTables(oldText, b.text)
+      if (merged) return { ...b, changed: false, html: merged }
+    }
+    return { ...b, changed }
+  })
+})
 
 const changedCount = computed(() =>
   diff.value.newChanged.filter(c => c).length

--- a/web/src/components/SideBySideReview.vue
+++ b/web/src/components/SideBySideReview.vue
@@ -209,22 +209,34 @@ function diffBlocks(oldBlocks, newBlocks) {
         : Math.max(dp[i - 1][j], dp[i][j - 1])
     }
   }
-  // Backtrack to mark changed blocks
+  // Backtrack into a full edit script, then derive changed flags + del→ins pairs.
   const oldChanged = new Array(m).fill(true)
   const newChanged = new Array(n).fill(true)
+  const ops = []
   let i = m, j = n
-  while (i > 0 && j > 0) {
-    if (oldBlocks[i - 1].text === newBlocks[j - 1].text) {
-      oldChanged[i - 1] = false
-      newChanged[j - 1] = false
-      i--; j--
-    } else if (dp[i - 1][j] > dp[i][j - 1]) {
-      i--
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldBlocks[i - 1].text === newBlocks[j - 1].text) {
+      ops.push({ type: 'eq', oi: i - 1, ni: j - 1 }); i--; j--
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({ type: 'ins', ni: j - 1 }); j--
     } else {
-      j--
+      ops.push({ type: 'del', oi: i - 1 }); i--
     }
   }
-  return { oldChanged, newChanged }
+  ops.reverse()
+  for (const op of ops) {
+    if (op.type === 'eq') { oldChanged[op.oi] = false; newChanged[op.ni] = false }
+  }
+  // A removed block immediately followed by an inserted one is a replacement —
+  // pair them so a changed table is diffed against the RIGHT old table even when
+  // an unrelated pure deletion sits earlier in the document.
+  const pairs = new Map() // newIdx → oldIdx
+  for (let k = 0; k < ops.length - 1; k++) {
+    if (ops[k].type === 'del' && ops[k + 1].type === 'ins') {
+      pairs.set(ops[k + 1].ni, ops[k].oi); k++
+    }
+  }
+  return { oldChanged, newChanged, pairs }
 }
 
 const oldBlocks = computed(() => splitBlocks(props.oldBody))
@@ -240,10 +252,6 @@ const diff = computed(() => {
 // (see useTableDiff) instead of a wholesale red-old / green-new block — so a
 // one-cell edit reads as one cell, not a replaced table. The Previous column
 // then shows the old table plainly (the merged diff already marks removals).
-const changedOldTables = computed(() =>
-  oldBlocks.value.filter((b, i) => diff.value.oldChanged[i] && isTableBlock(b.text))
-)
-
 const leftBlocks = computed(() =>
   oldBlocks.value.map((b, i) => ({
     ...b,
@@ -252,19 +260,21 @@ const leftBlocks = computed(() =>
   }))
 )
 
-const rightBlocks = computed(() => {
-  let tIdx = 0
-  return newBlocks.value.map((b, i) => {
+const rightBlocks = computed(() =>
+  newBlocks.value.map((b, i) => {
     const changed = diff.value.newChanged[i]
     if (changed && isTableBlock(b.text)) {
-      const oldText = changedOldTables.value[tIdx]?.text || ''
-      tIdx++
+      // Pair against the old block this one replaced (del→ins), not a sequential
+      // counter — so an unrelated table deletion can't mis-pair the diff.
+      const oldIdx = diff.value.pairs?.get(i)
+      const oldText = (oldIdx != null && isTableBlock(oldBlocks.value[oldIdx]?.text))
+        ? oldBlocks.value[oldIdx].text : ''
       const merged = diffTables(oldText, b.text)
       if (merged) return { ...b, changed: false, html: merged }
     }
     return { ...b, changed }
   })
-})
+)
 
 const changedCount = computed(() =>
   diff.value.newChanged.filter(c => c).length

--- a/web/src/components/TrackChanges.vue
+++ b/web/src/components/TrackChanges.vue
@@ -302,7 +302,16 @@ const segments = computed(() => {
       // Tables: diff cell-by-cell (handles md→HTML conversion + colors) instead
       // of word-diffing the HTML/tag soup. Falls back to prose word-diff.
       const tableHtml = diffTables(oldT, newT)
-      paired.push({ type: 'change', oldText: oldT, newText: newT, html: tableHtml || wordDiffHtml(oldT, newT), isTable: !!tableHtml })
+      if (tableHtml) {
+        // Count changed cells so the stats header reflects cells, not the raw
+        // line delta (a 2-cell edit must not read "+1 -5" from md→HTML).
+        const tmp = document.createElement('div')
+        tmp.innerHTML = tableHtml
+        const cellCount = tmp.querySelectorAll('td.tc-cell-change, .tc-row-add > td, .tc-row-del > td').length
+        paired.push({ type: 'change', oldText: oldT, newText: newT, html: tableHtml, isTable: true, cellCount })
+      } else {
+        paired.push({ type: 'change', oldText: oldT, newText: newT, html: wordDiffHtml(oldT, newT), isTable: false })
+      }
       i += 2
     } else {
       paired.push(raw[i])
@@ -317,7 +326,12 @@ const stats = computed(() => {
   for (const s of segments.value) {
     if (s.type === 'add') added += s.text.split('\n').length
     else if (s.type === 'remove') removed += s.text.split('\n').length
-    else if (s.type === 'change') { removed += s.oldText.split('\n').length; added += s.newText.split('\n').length }
+    else if (s.type === 'change') {
+      // A table change is measured in changed cells, not the raw line delta —
+      // otherwise a md→HTML table reads "+1 added -5 removed" for a 2-cell edit.
+      if (s.isTable) { added += s.cellCount || 0 }
+      else { removed += s.oldText.split('\n').length; added += s.newText.split('\n').length }
+    }
   }
   return { added, removed }
 })

--- a/web/src/components/TrackChanges.vue
+++ b/web/src/components/TrackChanges.vue
@@ -40,7 +40,7 @@
               :class="{
                 'tc-del': block.type === 'remove',
                 'tc-ins': block.type === 'add',
-                'tc-change': block.type === 'change',
+                'tc-change': block.type === 'change' && !block.isTable,
               }">
               <div class="doc-prose" v-html="block.html"></div>
             </div>
@@ -122,6 +122,8 @@
 import { ref, computed, watch, reactive } from 'vue'
 import DOMPurify from 'dompurify'
 import { parseMd } from '../composables/useRenderMd'
+import { tokenize, diffTokens, diffLines, escapeHtml } from '../composables/useWordDiff'
+import { diffTables } from '../composables/useTableDiff'
 import DiffView from './DiffView.vue'
 import api from '../api'
 
@@ -296,7 +298,11 @@ const segments = computed(() => {
   let i = 0
   while (i < raw.length) {
     if (raw[i].type === 'remove' && i + 1 < raw.length && raw[i + 1].type === 'add') {
-      paired.push({ type: 'change', oldText: raw[i].text, newText: raw[i + 1].text, html: wordDiffHtml(raw[i].text, raw[i + 1].text) })
+      const oldT = raw[i].text, newT = raw[i + 1].text
+      // Tables: diff cell-by-cell (handles md→HTML conversion + colors) instead
+      // of word-diffing the HTML/tag soup. Falls back to prose word-diff.
+      const tableHtml = diffTables(oldT, newT)
+      paired.push({ type: 'change', oldText: oldT, newText: newT, html: tableHtml || wordDiffHtml(oldT, newT), isTable: !!tableHtml })
       i += 2
     } else {
       paired.push(raw[i])
@@ -331,7 +337,7 @@ const finalBlocks = computed(() => {
     if (seg.type === 'change') {
       const lineBlame = newLineIdx < blame.length ? blame[newLineIdx] : null
       newLineIdx += seg.newText.split('\n').length
-      blocks.push({ type: 'change', text: seg.newText, html: seg.html, blame: lineBlame, blameKey: lineBlame ? lineBlame.hash : 'change' })
+      blocks.push({ type: 'change', text: seg.newText, html: seg.html, isTable: seg.isTable, blame: lineBlame, blameKey: lineBlame ? lineBlame.hash : 'change' })
       continue
     }
     // equal or add — split by blame boundaries
@@ -373,34 +379,11 @@ const rawDiff = computed(() => {
 
 function renderMd(text) { return text ? DOMPurify.sanitize(parseMd(text)) : '' }
 
+// Prose word-diff: equal text stays raw so markdown still renders; only the
+// del/ins payloads are escaped. (Table cells use the plain-text path instead.)
 function wordDiffHtml(oldText, newText) {
   const ops = diffTokens(tokenize(oldText), tokenize(newText))
-  const parts = ops.map(op => op.type === 'equal' ? op.text : op.type === 'remove' ? `<del class="tc-word-del">${esc(op.text)}</del>` : `<ins class="tc-word-ins">${esc(op.text)}</ins>`)
+  const parts = ops.map(op => op.type === 'equal' ? op.text : op.type === 'remove' ? `<del class="tc-word-del">${escapeHtml(op.text)}</del>` : `<ins class="tc-word-ins">${escapeHtml(op.text)}</ins>`)
   return DOMPurify.sanitize(parseMd(parts.join('')), { ADD_TAGS: ['del', 'ins'], ADD_ATTR: ['class'] })
-}
-
-function esc(t) { return t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') }
-function tokenize(text) { return text.match(/\S+|\s+/g) || [] }
-
-function diffTokens(oldToks, newToks) {
-  const m = oldToks.length, n = newToks.length
-  const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1))
-  for (let i = 1; i <= m; i++) for (let j = 1; j <= n; j++) dp[i][j] = oldToks[i-1] === newToks[j-1] ? dp[i-1][j-1]+1 : Math.max(dp[i-1][j], dp[i][j-1])
-  const raw = []; let i = m, j = n
-  while (i > 0 || j > 0) { if (i > 0 && j > 0 && oldToks[i-1] === newToks[j-1]) { raw.push({ type: 'equal', text: oldToks[i-1] }); i--; j-- } else if (j > 0 && (i === 0 || dp[i][j-1] >= dp[i-1][j])) { raw.push({ type: 'add', text: newToks[j-1] }); j-- } else { raw.push({ type: 'remove', text: oldToks[i-1] }); i-- } }
-  raw.reverse()
-  const merged = []; for (const op of raw) { if (merged.length > 0 && merged[merged.length-1].type === op.type) merged[merged.length-1].text += op.text; else merged.push({...op}) }
-  return merged
-}
-
-function diffLines(oldArr, newArr) {
-  const m = oldArr.length, n = newArr.length
-  const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1))
-  for (let i = 1; i <= m; i++) for (let j = 1; j <= n; j++) dp[i][j] = oldArr[i-1] === newArr[j-1] ? dp[i-1][j-1]+1 : Math.max(dp[i-1][j], dp[i][j-1])
-  const raw = []; let i = m, j = n
-  while (i > 0 || j > 0) { if (i > 0 && j > 0 && oldArr[i-1] === newArr[j-1]) { raw.push({ type: 'equal', text: oldArr[i-1] }); i--; j-- } else if (j > 0 && (i === 0 || dp[i][j-1] >= dp[i-1][j])) { raw.push({ type: 'add', text: newArr[j-1] }); j-- } else { raw.push({ type: 'remove', text: oldArr[i-1] }); i-- } }
-  raw.reverse()
-  const merged = []; for (const op of raw) { if (merged.length > 0 && merged[merged.length-1].type === op.type) merged[merged.length-1].text += '\n' + op.text; else merged.push({...op}) }
-  return merged
 }
 </script>

--- a/web/src/composables/useTableDiff.js
+++ b/web/src/composables/useTableDiff.js
@@ -1,0 +1,127 @@
+// Structural, cell-level diff for tables in the review diff view (#6).
+//
+// Tables are stored as raw HTML (see useMarkdownConvert `alwaysHtmlTable`) to
+// preserve colors/formatting/complex cells. Diffing that HTML as text — or
+// word-diffing the tag soup — is unreadable: a one-line `<table>…</table>` reads
+// as a wholesale replace. Worse, the first WYSIWYG edit converts a markdown pipe
+// table into HTML, so a single cell tweak looks like the entire table changed.
+//
+// Instead we render both sides to a table DOM (markdown pipe tables are rendered
+// to HTML first, so the md→HTML conversion is NOT shown as a change), match rows
+// by a key column (first cell text, index fallback), and highlight only what
+// actually changed — word-level inside each changed cell — while keeping every
+// unchanged cell's own markup and colors. The output is the NEW table's markup,
+// so styling/colgroup/colors are preserved.
+
+import DOMPurify from 'dompurify'
+import { tokenize, diffTokens, escapeHtml } from './useWordDiff'
+import { parseMd } from './useRenderMd'
+
+const HTML_TABLE_RE = /^\s*<table[\s>]/i
+// A markdown pipe table: a row with a pipe followed by a `|---|` separator line.
+const MD_TABLE_RE = /\|[^\n]*\n\s*\|?[\s:|-]*-{3,}/
+
+export function isHtmlTable(text) {
+  return HTML_TABLE_RE.test(text || '')
+}
+
+// True for either an HTML table or a markdown pipe table — used to detect table
+// blocks before diffing them.
+export function isTableBlock(text) {
+  return isHtmlTable(text) || (text.includes('|') && MD_TABLE_RE.test(text))
+}
+
+// Normalise either an HTML table or a markdown pipe table to a <table> element.
+// Returns null when the text doesn't contain a table.
+function toTableEl(text) {
+  const html = isHtmlTable(text) ? text : parseMd(text)
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  return doc.querySelector('table')
+}
+
+function rowCells(tr) {
+  return Array.from(tr.children).filter(el => el.tagName === 'TD' || el.tagName === 'TH')
+}
+
+function isHeaderRow(tr) {
+  const cells = rowCells(tr)
+  return cells.length > 0 && cells.every(c => c.tagName === 'TH')
+}
+
+function rowKey(tr) {
+  const cells = rowCells(tr)
+  return cells.length ? cells[0].textContent.trim() : ''
+}
+
+function cellWordDiff(oldText, newText) {
+  return diffTokens(tokenize(oldText), tokenize(newText))
+    .map(op => op.type === 'equal' ? escapeHtml(op.text)
+      : op.type === 'remove' ? `<del class="tc-word-del">${escapeHtml(op.text)}</del>`
+        : `<ins class="tc-word-ins">${escapeHtml(op.text)}</ins>`)
+    .join('')
+}
+
+// Diff two tables (each given as HTML or markdown). Returns sanitised HTML for
+// the merged, highlighted table, or null when either side isn't a table — so
+// the caller can fall back to its normal (prose) diff path.
+export function diffTables(oldText, newText) {
+  const oldTable = toTableEl(oldText)
+  const newTable = toTableEl(newText)
+  if (!oldTable || !newTable) return null
+
+  // Index old rows by key (first-cell text); duplicate keys keep insertion order
+  // so identical-key rows still pair up in order. Header rows are matched too.
+  const oldRows = Array.from(oldTable.querySelectorAll('tr'))
+  const oldByKey = new Map()
+  for (const tr of oldRows) {
+    const k = rowKey(tr)
+    if (!oldByKey.has(k)) oldByKey.set(k, [])
+    oldByKey.get(k).push(tr)
+  }
+  const consumed = new Set()
+
+  for (const tr of newTable.querySelectorAll('tr')) {
+    const bucket = oldByKey.get(rowKey(tr))
+    let oldTr = null
+    if (bucket) { for (const cand of bucket) { if (!consumed.has(cand)) { oldTr = cand; consumed.add(cand); break } } }
+
+    if (!oldTr) {
+      // A genuinely new row — but don't flag a header row as "added content".
+      if (!isHeaderRow(tr)) tr.classList.add('tc-row-add')
+      continue
+    }
+
+    // Matched row — diff its cells by position.
+    const newCells = rowCells(tr)
+    const oldCells = rowCells(oldTr)
+    for (let ci = 0; ci < newCells.length; ci++) {
+      const nc = newCells[ci]
+      const oc = oldCells[ci]
+      if (!oc) { nc.classList.add('tc-cell-add'); continue }
+      const oldCellText = oc.textContent.trim()
+      const newCellText = nc.textContent.trim()
+      if (oldCellText !== newCellText) {
+        nc.innerHTML = cellWordDiff(oldCellText, newCellText)
+        nc.classList.add('tc-cell-change')
+      }
+    }
+  }
+
+  // Old rows never matched were removed — append them (skip headers) so the
+  // author still sees what was dropped. (v1: removed rows render at the end.)
+  let removedHtml = ''
+  for (const tr of oldRows) {
+    if (consumed.has(tr) || isHeaderRow(tr)) continue
+    tr.classList.add('tc-row-del')
+    removedHtml += tr.outerHTML
+  }
+  if (removedHtml) {
+    const tbody = newTable.querySelector('tbody') || newTable
+    tbody.insertAdjacentHTML('beforeend', removedHtml)
+  }
+
+  return DOMPurify.sanitize(newTable.outerHTML, {
+    ADD_TAGS: ['del', 'ins', 'colgroup', 'col'],
+    ADD_ATTR: ['class', 'colspan', 'rowspan', 'style'],
+  })
+}

--- a/web/src/composables/useTableDiff.js
+++ b/web/src/composables/useTableDiff.js
@@ -14,7 +14,7 @@
 // so styling/colgroup/colors are preserved.
 
 import DOMPurify from 'dompurify'
-import { tokenize, diffTokens, escapeHtml } from './useWordDiff'
+import { wordDiffPlain } from './useWordDiff'
 import { parseMd } from './useRenderMd'
 
 const HTML_TABLE_RE = /^\s*<table[\s>]/i
@@ -51,14 +51,6 @@ function isHeaderRow(tr) {
 function rowKey(tr) {
   const cells = rowCells(tr)
   return cells.length ? cells[0].textContent.trim() : ''
-}
-
-function cellWordDiff(oldText, newText) {
-  return diffTokens(tokenize(oldText), tokenize(newText))
-    .map(op => op.type === 'equal' ? escapeHtml(op.text)
-      : op.type === 'remove' ? `<del class="tc-word-del">${escapeHtml(op.text)}</del>`
-        : `<ins class="tc-word-ins">${escapeHtml(op.text)}</ins>`)
-    .join('')
 }
 
 // Diff two tables (each given as HTML or markdown). Returns sanitised HTML for
@@ -101,7 +93,7 @@ export function diffTables(oldText, newText) {
       const oldCellText = oc.textContent.trim()
       const newCellText = nc.textContent.trim()
       if (oldCellText !== newCellText) {
-        nc.innerHTML = cellWordDiff(oldCellText, newCellText)
+        nc.innerHTML = wordDiffPlain(oldCellText, newCellText)
         nc.classList.add('tc-cell-change')
       }
     }

--- a/web/src/composables/useWordDiff.js
+++ b/web/src/composables/useWordDiff.js
@@ -12,8 +12,19 @@ export function escapeHtml(t) {
 }
 
 // Token-level LCS → merged runs of equal/add/remove (each run's text concatenated).
+// The DP table is Uint16Array, so an LCS dimension ≥ 65536 would wrap silently
+// and corrupt the backtrack. Far beyond any real review (~500 KB in one cell),
+// but make the failure mode explicit: fall back to a whole remove+add.
+const DP_MAX = 65535
+
 export function diffTokens(oldToks, newToks) {
   const m = oldToks.length, n = newToks.length
+  if (m > DP_MAX || n > DP_MAX) {
+    return [
+      ...(m ? [{ type: 'remove', text: oldToks.join('') }] : []),
+      ...(n ? [{ type: 'add', text: newToks.join('') }] : []),
+    ]
+  }
   const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1))
   for (let i = 1; i <= m; i++) for (let j = 1; j <= n; j++) dp[i][j] = oldToks[i - 1] === newToks[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1])
   const raw = []; let i = m, j = n
@@ -26,6 +37,12 @@ export function diffTokens(oldToks, newToks) {
 // Line-level LCS → merged runs of equal/add/remove (runs joined by newline).
 export function diffLines(oldArr, newArr) {
   const m = oldArr.length, n = newArr.length
+  if (m > DP_MAX || n > DP_MAX) {
+    return [
+      ...(m ? [{ type: 'remove', text: oldArr.join('\n') }] : []),
+      ...(n ? [{ type: 'add', text: newArr.join('\n') }] : []),
+    ]
+  }
   const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1))
   for (let i = 1; i <= m; i++) for (let j = 1; j <= n; j++) dp[i][j] = oldArr[i - 1] === newArr[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1])
   const raw = []; let i = m, j = n

--- a/web/src/composables/useWordDiff.js
+++ b/web/src/composables/useWordDiff.js
@@ -1,0 +1,46 @@
+// Shared LCS diff primitives for the review diff views (TrackChanges + the
+// HTML-table cell differ). Pure functions — no DOM, no Vue — so they can be
+// reused and reasoned about in isolation.
+
+// Split into word + whitespace tokens so word boundaries are preserved.
+export function tokenize(text) {
+  return text.match(/\S+|\s+/g) || []
+}
+
+export function escapeHtml(t) {
+  return t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// Token-level LCS → merged runs of equal/add/remove (each run's text concatenated).
+export function diffTokens(oldToks, newToks) {
+  const m = oldToks.length, n = newToks.length
+  const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1))
+  for (let i = 1; i <= m; i++) for (let j = 1; j <= n; j++) dp[i][j] = oldToks[i - 1] === newToks[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1])
+  const raw = []; let i = m, j = n
+  while (i > 0 || j > 0) { if (i > 0 && j > 0 && oldToks[i - 1] === newToks[j - 1]) { raw.push({ type: 'equal', text: oldToks[i - 1] }); i--; j-- } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) { raw.push({ type: 'add', text: newToks[j - 1] }); j-- } else { raw.push({ type: 'remove', text: oldToks[i - 1] }); i-- } }
+  raw.reverse()
+  const merged = []; for (const op of raw) { if (merged.length > 0 && merged[merged.length - 1].type === op.type) merged[merged.length - 1].text += op.text; else merged.push({ ...op }) }
+  return merged
+}
+
+// Line-level LCS → merged runs of equal/add/remove (runs joined by newline).
+export function diffLines(oldArr, newArr) {
+  const m = oldArr.length, n = newArr.length
+  const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1))
+  for (let i = 1; i <= m; i++) for (let j = 1; j <= n; j++) dp[i][j] = oldArr[i - 1] === newArr[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1])
+  const raw = []; let i = m, j = n
+  while (i > 0 || j > 0) { if (i > 0 && j > 0 && oldArr[i - 1] === newArr[j - 1]) { raw.push({ type: 'equal', text: oldArr[i - 1] }); i--; j-- } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) { raw.push({ type: 'add', text: newArr[j - 1] }); j-- } else { raw.push({ type: 'remove', text: oldArr[i - 1] }); i-- } }
+  raw.reverse()
+  const merged = []; for (const op of raw) { if (merged.length > 0 && merged[merged.length - 1].type === op.type) merged[merged.length - 1].text += '\n' + op.text; else merged.push({ ...op }) }
+  return merged
+}
+
+// Word-level diff of two PLAIN-TEXT strings → escaped HTML with <del>/<ins>
+// spans. Use for content that is not markdown (e.g. a table cell's text).
+export function wordDiffPlain(oldText, newText) {
+  return diffTokens(tokenize(oldText), tokenize(newText))
+    .map(op => op.type === 'equal' ? escapeHtml(op.text)
+      : op.type === 'remove' ? `<del class="tc-word-del">${escapeHtml(op.text)}</del>`
+        : `<ins class="tc-word-ins">${escapeHtml(op.text)}</ins>`)
+    .join('')
+}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -513,6 +513,18 @@
   border-radius: 2px;
 }
 
+/* Table cell-level diff (#6): tint only what changed; unchanged cells keep
+   their own colors. Word-level del/ins inside cells reuse .tc-word-* above. */
+.doc-prose td.tc-cell-change { background: rgba(59, 130, 246, 0.10); }
+.doc-prose td.tc-cell-add,
+.doc-prose .tc-row-add > td { background: rgba(34, 197, 94, 0.12); }
+.doc-prose .tc-row-del > td {
+  background: rgba(239, 68, 68, 0.10);
+  color: #fca5a5;
+  text-decoration: line-through;
+  text-decoration-color: rgba(239, 68, 68, 0.4);
+}
+
 /* ── Print / read mode ── */
 @media print {
   /* Hide chrome: sidebar, toolbars, navigation, buttons */


### PR DESCRIPTION
Part of #6 — the headline for 0.7.0.

**Problem (the real case María hit on clause 4.2):** tables are stored as HTML to keep colors/rich cells, and the WYSIWYG converts a markdown pipe table to HTML on the first edit. The diff views word-diffed that HTML source, so a two-cell edit rendered as a wholesale table replace — unreadable, the actual change buried.

**Fix:** a structural per-cell table diff (`useTableDiff.diffTables`) wired into **both** review diff views (Unified and the default Split). It renders both sides to a table DOM (markdown rendered to HTML first, so the md→HTML conversion is *not* shown as a change), matches rows by a key column, and highlights only the changed cells — word-level inside — keeping every unchanged cell's own colors/markup.

**Verification:** new `tests/test_e2e_review_diff.py` (Playwright, real browser) reproduces the case via API and asserts exactly the two edited cells are highlighted in Split **and** Unified, the conversion isn't shown as a change, and unchanged cells aren't flagged. Green twice against the stack (idempotent); runs in CI. The LCS core is also unit-checked. Shared diff primitives extracted to `useWordDiff.js` (DRY).

**Scope:** this is slice 1/2 — it satisfies the *table cell word-level highlights* criterion. Per-event timeline diff + the diff-scope toggle (the other criteria) land in a focused second PR. Migration-free, frontend-only.

Kept the E2E in its own file (not the test_e2e_browser monolith) to avoid the recurring EOF merge conflicts as review-UI work continues.