### PR TITLE
feat(auth): Cloudflare Access web session + JIT provisioning (#98)

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -188,6 +188,7 @@ All configuration is via environment variables. See `contrib/unidoc.env` for the
 |----------|-------------|
 | `CLOUDFLARE_TEAM_DOMAIN` | Cloudflare Access team domain (e.g. `mycompany.cloudflareaccess.com`). Enables CF Zero Trust authentication. |
 | `ISMS_CF_AUDIENCE` | CF Access Application Audience (AUD) tag. **Set this when using CF Access** — without it, any CF Access JWT from any application is accepted. |
+| `ISMS_CF_AUTO_PROVISION` | Set to `1`/`true` to create the **user record** automatically on their first Cloudflare Access login (JIT). Off by default. The user is created with no org membership — an admin (or the CLI) then adds them to the right organization and role. **Only safe when your CF Access policy is the source of truth for who may reach ISMS** — see the warning below. |
 | `ISMS_USER_SIGNUP` | Set to `1` to enable self-registration. Off by default. |
 | `ISMS_SKIP_EMAIL_VERIFY` | Set to `1` to skip email verification on signup (users are active immediately). For dev/eval only. |
 
@@ -582,6 +583,26 @@ Disable with `ISMS_RATE_LIMIT=0`. The default is 20 requests per minute per IP.
 ### CF Access warning: "ISMS_CF_AUDIENCE not set"
 
 When `CLOUDFLARE_TEAM_DOMAIN` is set but `ISMS_CF_AUDIENCE` is not, the server logs a warning on startup. Without the audience check, any CF Access JWT from any application on your team domain is accepted. Set `ISMS_CF_AUDIENCE` to the Application Audience (AUD) tag from your CF Access dashboard.
+
+### Cloudflare Access as web login (Zero Trust SSO)
+
+With `CLOUDFLARE_TEAM_DOMAIN` + `ISMS_CF_AUDIENCE` set and ISMS published behind a CF Access application, a user who has already passed CF Access (e.g. via Entra at the CF layer) is logged into the **web app** automatically — no separate ISMS login. On load the SPA calls `GET /api/v1/auth/cf-session`; behind CF Access the proxy adds the identity headers, the server **validates the Access JWT** (not just the email header), resolves the user, and mints an ISMS session. The same CF identity also authenticates the API, CLI, and git.
+
+By default the user must already exist in ISMS and be a member of the org. To skip the manual "create the user" step, enable JIT provisioning:
+
+```
+ISMS_CF_AUTO_PROVISION=1
+```
+
+With this on, the first CF Access login **creates the user record** (no org, no role). They can authenticate, but can't load an org's data until an **admin adds them to the right organization** — Admin → Members, or:
+
+```
+isms server org add-member --org acme --email user@acme.com --role reader
+```
+
+There is intentionally **no default org/role**: which org someone belongs to, and at what role, is a deliberate decision, not an env-var guess.
+
+**Security tradeoff — read before enabling JIT.** Auto-provisioning is safe **only when your CF Access policy is the source of truth for who may reach ISMS.** If a route is left unprotected, or a CF Access token leaks, an unintended user could create an account. Mitigations: it's opt-in (default off); a provisioned user has **no org access at all** until an admin grants it (so a stray account can see nothing); and the Access JWT is always cryptographically verified — a missing/invalid token never provisions.
 
 ### Git repo not found for organization
 

--- a/internal/isms/api/api_cf.go
+++ b/internal/isms/api/api_cf.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -10,6 +11,11 @@ import (
 	"github.com/labstack/echo/v4"
 	"isms.sh/internal/isms/db"
 )
+
+// errProvisionFailed distinguishes a failed JIT user creation (DB error → 500)
+// from a genuine "user not found / provisioning off" (401), so an operator
+// debugging a broken DB doesn't chase a misleading 401 down the CF JWT path.
+var errProvisionFailed = errors.New("auto-provision failed")
 
 // cfProvisionConfig controls just-in-time user provisioning on Cloudflare Access
 // login. Off by default — opt in via ISMS_CF_AUTO_PROVISION. Safe ONLY when the
@@ -54,7 +60,7 @@ func resolveCFUser(ctx context.Context, d *db.DB, email, name string, pc cfProvi
 		u.Name = deriveNameFromEmail(email)
 	}
 	if err := d.UpsertUser(ctx, u); err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("%w: %v", errProvisionFailed, err)
 	}
 	return u, true, nil
 }
@@ -95,6 +101,10 @@ func (s *Server) handleCFSession(c echo.Context) error {
 	ctx := c.Request().Context()
 	user, created, err := resolveCFUser(ctx, s.db, email, claims.Name, s.cfProvision)
 	if err != nil {
+		if errors.Is(err, errProvisionFailed) {
+			log.Printf("[cf-access] auto-provision failed for %s: %v", email, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "auto-provision failed")
+		}
 		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
 	}
 	if created {

--- a/internal/isms/api/api_cf.go
+++ b/internal/isms/api/api_cf.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"isms.sh/internal/isms/db"
+)
+
+// cfProvisionConfig controls just-in-time user provisioning on Cloudflare Access
+// login. Off by default — opt in via ISMS_CF_AUTO_PROVISION. Safe ONLY when the
+// CF Access policy is the source of truth for who may reach the app (#98).
+//
+// JIT creates the user row ONLY. Organization membership and role stay an
+// explicit admin/CLI action — there is intentionally no "default org": which
+// org a person belongs to, and at what role, is a governance decision, not
+// something to guess from an env var.
+type cfProvisionConfig struct {
+	Enabled bool
+}
+
+// deriveNameFromEmail produces a fallback display name when the CF JWT carries
+// no name claim (e.g. "ari.bjarna" from "ari.bjarna@acme.com").
+func deriveNameFromEmail(email string) string {
+	if at := strings.IndexByte(email, '@'); at > 0 {
+		return email[:at]
+	}
+	return email
+}
+
+// resolveCFUser returns the ISMS user for a Cloudflare-Access-authenticated
+// email. When the user doesn't exist and auto-provisioning is enabled, it
+// creates the user row (active) — and nothing else. Org membership and role are
+// granted separately by an admin (Admin → Members) or the CLI; until then the
+// user has no org and can authenticate but not load an org's data.
+//
+// Shared by the auth middleware (API/CLI/git) and the cf-session handler (web)
+// so both behave identically. Returns (user, created, error); created is true on
+// JIT provisioning.
+func resolveCFUser(ctx context.Context, d *db.DB, email, name string, pc cfProvisionConfig) (*db.User, bool, error) {
+	if u, err := d.GetUserByEmail(ctx, email); err == nil {
+		return u, false, nil
+	}
+	if !pc.Enabled {
+		return nil, false, fmt.Errorf("user not found")
+	}
+
+	u := &db.User{Email: email, Name: name, Active: true}
+	if u.Name == "" {
+		u.Name = deriveNameFromEmail(email)
+	}
+	if err := d.UpsertUser(ctx, u); err != nil {
+		return nil, false, err
+	}
+	return u, true, nil
+}
+
+// handleCFSession mints an ISMS session token for a user already authenticated
+// by Cloudflare Access (#98). The SPA calls this on load when it has no local
+// token: behind CF Access the proxy adds identity headers, we validate the JWT
+// (not just the email header — never trust the header alone), resolve/provision
+// the user, and return a session like a password login. Public route; only
+// succeeds when CF Access is configured and the JWT validates.
+func (s *Server) handleCFSession(c echo.Context) error {
+	if s.cfKeyCache == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Cloudflare Access is not configured")
+	}
+
+	jwt := c.Request().Header.Get("Cf-Access-Jwt-Assertion")
+	if jwt == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "no Cloudflare Access token")
+	}
+	claims, err := s.cfKeyCache.VerifyJWT(jwt)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("invalid Cloudflare Access token: %v", err))
+	}
+
+	email := claims.Email
+	if hdr := c.Request().Header.Get("Cf-Access-Authenticated-User-Email"); hdr != "" {
+		if email != "" && !strings.EqualFold(email, hdr) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
+		}
+		if email == "" {
+			email = hdr
+		}
+	}
+	if email == "" {
+		return echo.NewHTTPError(http.StatusUnauthorized, "no email in Cloudflare Access identity")
+	}
+
+	ctx := c.Request().Context()
+	user, created, err := resolveCFUser(ctx, s.db, email, claims.Name, s.cfProvision)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+	}
+	if created {
+		log.Printf("[cf-access] auto-provisioned user %s", email)
+	}
+
+	// Resolve org + role — mirror handleLogin: subdomain/domain context first,
+	// then auto-select when the user belongs to exactly one org.
+	var orgID int
+	var orgName, orgSlug string
+	if slug, ok := c.Get("org_slug").(string); ok && slug != "" {
+		org, oerr := s.db.GetOrganizationBySlug(ctx, slug)
+		if oerr != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "organization not found")
+		}
+		if _, merr := s.db.GetOrgMember(ctx, org.ID, user.ID); merr != nil {
+			// JIT-provisioned but not yet a member — an admin must add them.
+			return echo.NewHTTPError(http.StatusForbidden, "no access to this organization yet — ask an admin to add you")
+		}
+		orgID, orgName, orgSlug = org.ID, org.Name, org.Slug
+	} else {
+		orgs, _ := s.db.ListUserOrgs(ctx, user.ID)
+		switch {
+		case len(orgs) == 1:
+			orgID, orgName, orgSlug = orgs[0].ID, orgs[0].Name, orgs[0].Slug
+		case len(orgs) == 0:
+			// Don't mint an org-less session here: it would persist a stale
+			// token so that adding the user to an org later wouldn't take
+			// effect on refresh (the CF probe only runs when there's no token).
+			// 403 instead → after an admin adds them, the next load re-probes
+			// and resolves the org cleanly.
+			return echo.NewHTTPError(http.StatusForbidden, "no organization yet — ask an admin to add you")
+			// len(orgs) > 1: leave orgID 0 → the SPA shows the org picker.
+		}
+	}
+
+	role := "reader"
+	if orgID > 0 {
+		if r, rerr := s.db.GetUserRole(ctx, orgID, user.ID); rerr == nil && r != "" {
+			role = r
+		}
+	}
+
+	token, err := s.createSessionJWT(user, orgID, role, orgSlug, orgName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "creating session token")
+	}
+
+	return c.JSON(http.StatusOK, loginResponse{
+		Token:            token,
+		Email:            user.Email,
+		Name:             user.Name,
+		Role:             role,
+		OrganizationID:   orgID,
+		OrganizationName: orgName,
+		OrganizationSlug: orgSlug,
+	})
+}

--- a/internal/isms/api/api_cf_test.go
+++ b/internal/isms/api/api_cf_test.go
@@ -1,0 +1,17 @@
+package api
+
+import "testing"
+
+func TestDeriveNameFromEmail(t *testing.T) {
+	cases := map[string]string{
+		"ari.bjarna@acme.com": "ari.bjarna",
+		"jon@example.org":     "jon",
+		"weird-no-at":         "weird-no-at",
+		"@leading":            "@leading", // no local part — fall back to the raw input
+	}
+	for in, want := range cases {
+		if got := deriveNameFromEmail(in); got != want {
+			t.Errorf("deriveNameFromEmail(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/isms/api/middleware.go
+++ b/internal/isms/api/middleware.go
@@ -26,21 +26,23 @@ import (
 
 // AuthConfig configures the authentication middleware.
 type AuthConfig struct {
-	CloudflareTeamDomain string // e.g. "mycompany.cloudflareaccess.com"
-	CloudflareAudience   string // CF Access Application Audience (AUD) tag — set via ISMS_CF_AUDIENCE
-	DB                   *db.DB // for API token lookups
-	Secret               string // for validating JWT session tokens
+	CloudflareTeamDomain string            // e.g. "mycompany.cloudflareaccess.com"
+	CloudflareAudience   string            // CF Access Application Audience (AUD) tag — set via ISMS_CF_AUDIENCE
+	DB                   *db.DB            // for API token lookups
+	Secret               string            // for validating JWT session tokens
+	KeyCache             *cfKeyCache       // shared CF JWKS cache (also used by the cf-session handler)
+	Provision            cfProvisionConfig // JIT user provisioning on first CF Access login
 }
 
 // AuthMiddleware validates authentication on all API routes.
 // Two auth methods: Bearer token or Cloudflare Zero Trust. No exceptions.
 func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
-	var keyCache *cfKeyCache
-	if cfg.CloudflareTeamDomain != "" {
+	keyCache := cfg.KeyCache
+	if keyCache == nil && cfg.CloudflareTeamDomain != "" {
 		keyCache = newCFKeyCache(cfg.CloudflareTeamDomain, cfg.CloudflareAudience)
-		if cfg.CloudflareAudience == "" {
-			log.Println("WARNING: ISMS_CF_AUDIENCE not set — Cloudflare Access JWT audience validation is disabled. Any CF Access JWT from any application will be accepted. Set ISMS_CF_AUDIENCE to the Application Audience (AUD) tag from your CF Access dashboard.")
-		}
+	}
+	if keyCache != nil && cfg.CloudflareAudience == "" {
+		log.Println("WARNING: ISMS_CF_AUDIENCE not set — Cloudflare Access JWT audience validation is disabled. Any CF Access JWT from any application will be accepted. Set ISMS_CF_AUDIENCE to the Application Audience (AUD) tag from your CF Access dashboard.")
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -55,7 +57,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if path == "/healthz" ||
 				path == "/docs" || path == "/api/openapi.yaml" ||
 				path == "/api/v1/auth/login" || path == "/api/v1/auth/signup" || path == "/api/v1/auth/verify-email" ||
-				path == "/api/v1/auth/forgot-password" ||
+				path == "/api/v1/auth/forgot-password" || path == "/api/v1/auth/cf-session" ||
 				path == "/api/v1/auth/passkey/login/begin" || path == "/api/v1/auth/passkey/login/complete" ||
 				path == "/api/v1/auth/oidc/providers" || path == "/api/v1/auth/oidc/authorize" || path == "/api/v1/auth/oidc/callback" {
 				return next(c)
@@ -230,6 +232,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				return echo.NewHTTPError(http.StatusUnauthorized, "API key required. Use: isms server api-key create")
 			}
 
+			cfName := ""
 			{
 				jwt := c.Request().Header.Get("Cf-Access-Jwt-Assertion")
 				if jwt == "" {
@@ -242,14 +245,18 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				if claims.Email != "" && claims.Email != email {
 					return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
 				}
+				cfName = claims.Name
 			}
 
-			// Resolve user and org for CF-authenticated users
+			// Resolve (or, when enabled, JIT-provision) the CF-authenticated user.
 			c.Set("user_email", email)
 			ctx := c.Request().Context()
-			user, err := cfg.DB.GetUserByEmail(ctx, email)
+			user, created, err := resolveCFUser(ctx, cfg.DB, email, cfName, cfg.Provision)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+			}
+			if created {
+				log.Printf("[cf-access] auto-provisioned user %s", email)
 			}
 
 			// If OrgResolverMiddleware already resolved the org (subdomain/domain/path),
@@ -377,6 +384,7 @@ func (s *Server) RoleMiddleware() echo.MiddlewareFunc {
 
 type cfClaims struct {
 	Email string          `json:"email"`
+	Name  string          `json:"name,omitempty"` // present when CF Access passes identity claims
 	Exp   int64           `json:"exp"`
 	Iat   int64           `json:"iat"`
 	Iss   string          `json:"iss"`

--- a/internal/isms/api/middleware.go
+++ b/internal/isms/api/middleware.go
@@ -242,7 +242,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				if err != nil {
 					return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("invalid token: %v", err))
 				}
-				if claims.Email != "" && claims.Email != email {
+				if claims.Email != "" && !strings.EqualFold(claims.Email, email) {
 					return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
 				}
 				cfName = claims.Name
@@ -253,6 +253,9 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			ctx := c.Request().Context()
 			user, created, err := resolveCFUser(ctx, cfg.DB, email, cfName, cfg.Provision)
 			if err != nil {
+				if errors.Is(err, errProvisionFailed) {
+					return echo.NewHTTPError(http.StatusInternalServerError, "auto-provision failed")
+				}
 				return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
 			}
 			if created {

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -61,6 +61,11 @@ type Server struct {
 
 	// In-memory search index per org — avoids 10+ DB queries per keystroke.
 	searchIndex *SearchIndex
+
+	// Cloudflare Access: shared JWKS cache + JIT provisioning config, used by
+	// both the auth middleware and the cf-session web-login handler.
+	cfKeyCache  *cfKeyCache
+	cfProvision cfProvisionConfig
 }
 
 // storeForOrg returns (or creates and caches) a store for the given organization.
@@ -349,11 +354,21 @@ func NewWithFS(addr, webDir string, database *db.DB, embeddedFS fs.FS) *Server {
 	// Authentication + role enforcement
 	teamDomain := os.Getenv("CLOUDFLARE_TEAM_DOMAIN") // e.g. mycompany.cloudflareaccess.com
 	cfAudience := os.Getenv("ISMS_CF_AUDIENCE")       // CF Access Application Audience (AUD) tag
+	if teamDomain != "" {
+		srv.cfKeyCache = newCFKeyCache(teamDomain, cfAudience)
+	}
+	// JIT provisioning on first CF Access login (opt-in, default off). See #98.
+	// Creates the user row only — org membership/role is an explicit admin/CLI step.
+	srv.cfProvision = cfProvisionConfig{
+		Enabled: os.Getenv("ISMS_CF_AUTO_PROVISION") == "true" || os.Getenv("ISMS_CF_AUTO_PROVISION") == "1",
+	}
 	srv.echo.Use(AuthMiddleware(AuthConfig{
 		CloudflareTeamDomain: teamDomain,
 		CloudflareAudience:   cfAudience,
 		DB:                   database,
 		Secret:               srv.secret,
+		KeyCache:             srv.cfKeyCache,
+		Provision:            srv.cfProvision,
 	}))
 	srv.echo.Use(srv.RoleMiddleware())
 	// Tenant isolation model (defense in depth):
@@ -427,6 +442,7 @@ func (s *Server) routes() {
 	// the individual handlers (handleLogin, handlePasskeyLoginComplete).
 	authLimit := AuthRateLimitMiddleware(s.db)
 	api.POST("/auth/login", s.handleLogin, authLimit)
+	api.GET("/auth/cf-session", s.handleCFSession, authLimit) // Cloudflare Access → web session (#98)
 	api.POST("/auth/signup", s.handleSignup, authLimit)
 	api.POST("/auth/verify-email", s.handleVerifyEmail, authLimit)
 	api.POST("/auth/forgot-password", s.handleForgotPassword, authLimit)

--- a/tests/test_cf_session.py
+++ b/tests/test_cf_session.py
@@ -1,0 +1,22 @@
+"""Cloudflare Access → web session endpoint (#98).
+
+The test stack has no Cloudflare Access configured, so this pins the *safe
+default*: the endpoint is a public route (reachable without a token) and refuses
+to mint a session when CF Access isn't configured — it never falls open.
+
+Coverage gap: the happy path (valid Cf-Access-Jwt-Assertion → JIT-provision +
+session) and the JWT-validation branches require a live Cloudflare Access tunnel
+(the JWKS are fetched from the team domain and the JWT is signed by Cloudflare's
+private key), which CI can't provide — same limitation as the SMTP paths (#16/
+#42). Those are verified manually against a real CF Access deployment. The pure
+resolve helper's name derivation is unit-tested in api_cf_test.go.
+"""
+import requests
+
+
+def test_cf_session_is_public_and_fails_safe(api_url):
+    # No auth header at all — the route must be reachable (public), and with no
+    # Cloudflare Access configured it must refuse rather than mint a session.
+    r = requests.get(f"{api_url}/auth/cf-session")
+    assert r.status_code == 401, f"expected 401 when CF Access is unconfigured: {r.status_code} {r.text}"
+    assert "cloudflare access" in r.text.lower(), f"unexpected body: {r.text}"

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -182,6 +182,19 @@ export const api = {
   // Config
   getConfig: () => fetchJSON(`${API}/config`),
 
+  // Cloudflare Access SSO: when behind CF Access, the proxy adds identity
+  // headers and the server mints a session. Returns the login payload, or null
+  // when not behind CF Access / not provisioned (a probe — never throws/redirects).
+  cfSession: async () => {
+    try {
+      const res = await safeFetch(`${API}/auth/cf-session`, { headers: getHeaders() })
+      if (!res.ok) return null
+      return await res.json()
+    } catch {
+      return null
+    }
+  },
+
   // Users
   getMe: () => fetchJSON(`${API}/me`),
   getMyOrgs: () => fetchJSON(`${API}/me/organizations`),

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import { getApiToken, clearApiToken } from './api'
+import { getApiToken, setApiToken, clearApiToken } from './api'
 import api from './api'
 import Login from './views/Login.vue'
 import Signup from './views/Signup.vue'
@@ -102,6 +102,9 @@ const router = createRouter({
 
 // Navigation guard: check auth before each route
 let sessionValidated = false
+// Probe Cloudflare Access SSO at most once per load — if we're not behind CF
+// Access it 401s, and we shouldn't pay that latency on every navigation.
+let cfTried = false
 
 router.beforeEach(async (to, from) => {
   // A tenant subdomain (e.g. verkis.commandvector.net) IS the org context —
@@ -124,7 +127,20 @@ router.beforeEach(async (to, from) => {
   }
 
   if (!getApiToken()) {
-    return { path: '/login', query: to.fullPath !== '/' ? { redirect: to.fullPath } : undefined }
+    // No local token — but if we're behind Cloudflare Access, the server can
+    // mint a session from the CF identity (no ISMS login needed). Try once.
+    if (!cfTried) {
+      cfTried = true
+      const cf = await api.cfSession()
+      if (cf?.token) {
+        setApiToken(cf.token)
+        if (cf.email) localStorage.setItem('isms_user_email', cf.email)
+        if (cf.name) localStorage.setItem('isms_user_name', cf.name)
+      }
+    }
+    if (!getApiToken()) {
+      return { path: '/login', query: to.fullPath !== '/' ? { redirect: to.fullPath } : undefined }
+    }
   }
 
   if (!sessionValidated) {


### PR DESCRIPTION
Closes #98.

**Problem.** CF Access authenticated the API/CLI/git layer, but the web SPA gated on a local token and bounced to /login — so passing CF Access (Entra at the CF layer) did **not** log you into the web app, and nothing minted an ISMS session from a CF identity. No ISMS-side OIDC wanted: the org IdP is already wired through CF Zero Trust.

**Change.**
- `GET /auth/cf-session` — validates the `Cf-Access-Jwt-Assertion` (reusing the JWKS cache; **not** just the email header), resolves/(JIT-)provisions the user, resolves org+role, mints a session like a password login. Public route; fails safe (401) when CF Access isn't configured.
- The auth middleware shares the same resolve-or-provision helper, so API/CLI/git JIT-provision too.
- The SPA probes `/auth/cf-session` once when it has no token, before redirecting to /login.

**JIT is deliberately minimal** (per discussion): `ISMS_CF_AUTO_PROVISION=1` creates the **user row only** — no default org/role. Which org someone joins, and at what role, stays an explicit `isms server org add-member` / Admin decision, not an env-var guess. A provisioned user with no org gets a 403 from cf-session (rather than a stale org-less token), so `add-member` + refresh logs them in cleanly.

**Security.** Access JWT always cryptographically verified; JIT opt-in (default off); a provisioned user sees nothing until an admin grants org access.

**Tests.** `api_cf_test.go` (name derivation, CI go-unit); `tests/test_cf_session.py` (public route + fails-safe 401, CI integration); full suite green (664). The CF-JWT happy path needs a live CF Access tunnel (JWKS + Cloudflare-signed JWT), so it's verified manually against the real deployment — documented gap, same class as the SMTP paths. **No DB migration.** Operator guide updated.