### PR TITLE
feat(review): complete #6 per-event diff + dry-run fixes + push ref-protection

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -510,6 +510,11 @@ func (s *Server) handleReviewTimeline(c echo.Context) error {
 }
 
 // handleReviewDiff returns the diff for a review (between commit_hash stored on review and current HEAD).
+// reSHA matches a full lowercase git commit SHA — the only accepted form for the
+// per-event diff `to` param (always a decision_log commit_ref), so arbitrary
+// revision strings (HEAD~1, branch names) can't reach the diff machinery.
+var reSHA = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
 func (s *Server) handleReviewDiff(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
@@ -554,10 +559,18 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 	// author can see exactly what one revision changed. Defaults below to the
 	// whole-round view.
 	to := c.QueryParam("to")
+	if to != "" && !reSHA.MatchString(to) {
+		return echo.NewHTTPError(http.StatusBadRequest, "to must be a full commit SHA")
+	}
 	from := c.QueryParam("from")
 	if from == "" {
 		if to != "" {
-			from = to + "^" // per-event: the proposal vs the state it was based on
+			// Per-event: the proposal vs its parent. A root commit has no parent —
+			// leave the baseline empty (the whole document is genuinely new) rather
+			// than relying on a silently-swallowed resolve failure.
+			if _, perr := st.RefHash(to + "^"); perr == nil {
+				from = to + "^"
+			}
 		} else if review.SentHead != "" && (hasBranch || review.CommitHash != "") {
 			from = review.SentHead
 		} else if review.CommitHash != "" {
@@ -567,11 +580,19 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 
 	if to != "" {
 		// Per-event diff between two explicit commits.
-		diffText, _ = st.DiffDocumentBodies(from, to, filePath)
+		var dErr error
+		diffText, dErr = st.DiffDocumentBodies(from, to, filePath)
+		if dErr != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "per-event diff failed: "+dErr.Error())
+		}
 	} else if hasBranch && from != "" {
 		// Diff what was sent (from) against the reviewer's proposed branch, so
 		// "Previous" is the sent version and "Current" is the proposal.
-		diffText, _ = st.DiffDocumentBodies(from, branchName, filePath)
+		var dErr error
+		diffText, dErr = st.DiffDocumentBodies(from, branchName, filePath)
+		if dErr != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to compute branch diff: "+dErr.Error())
+		}
 	} else if hasBranch {
 		// A proposal with no baseline at all — branch vs main.
 		diffText = branchDiff

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -41,6 +41,11 @@ func (s *Server) logAndNotify(ctx context.Context, orgID int, a *db.Activity) {
 				Action: a.Action,
 				Detail: a.Detail,
 				Link:   docLink(a.DocumentID),
+				// Org-scoped base so the link lands on the tenant's own URL
+				// (e.g. unidoc.isms.sh / a custom domain) via orgURLs, not the
+				// bare apex (isms.sh). Empty AppURL falls back to the notifier's
+				// configured BaseURL.
+				BaseURL: s.orgMail(ctx, orgID).AppURL,
 				Channels: notify.OrgChannels{
 					SlackWebhook: slackWH,
 					MatrixRoomID: matrixRoom,
@@ -528,36 +533,48 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "document file not found")
 	}
 
-	// Use sent_head as the diff baseline: "what changed since this was sent for review" (current round).
-	// For first review (commit_hash empty = never approved), use empty baseline so the whole document shows as new.
-	// The ?from= query param allows overriding the baseline (used for "all changes in review" view).
-	from := c.QueryParam("from")
-	if from == "" {
-		if review.CommitHash == "" {
-			// First review — no prior approved version. Show entire document as new content.
-			from = ""
-		} else {
-			from = review.SentHead
-			if from == "" {
-				from = review.CommitHash
-			}
-		}
-	}
 	var diffText string
 
-	// Check if a review branch exists with edits
+	// Detect a reviewer's proposed-revision branch (review/<id>) up front — it
+	// decides the right baseline below.
 	branchName := fmt.Sprintf("review/%d", id)
 	toRef := "HEAD"
 	branchDiff, branchErr := st.DiffSuggestion(filePath, branchName)
 	hasBranch := branchErr == nil && branchDiff != ""
-	customFrom := c.QueryParam("from") != "" // explicit baseline override
 
-	if hasBranch && !customFrom {
-		// Review branch has edits, no explicit baseline — show diff between main and review branch
-		diffText = branchDiff
-	} else if hasBranch && customFrom {
-		// Review branch has edits + explicit baseline — diff from custom baseline to branch
+	// Baseline ("from") = what was sent for review (sent_head). It is set even
+	// when the document was never approved, so a reviewer's proposed revision
+	// diffs against what the author actually sent — not the whole document.
+	// (Without this, a never-approved doc shows an empty "Previous" pane and the
+	// reviewer's change is buried as "everything is new".) Fall back to the last
+	// approved commit; only a first review with NOTHING proposed yet uses an
+	// empty baseline, where reviewing the whole document is the point.
+	// `to` scopes the diff to a single event (the per-event timeline diff, #6):
+	// the reviewer's proposal commit vs its parent (commit^..commit), so an
+	// author can see exactly what one revision changed. Defaults below to the
+	// whole-round view.
+	to := c.QueryParam("to")
+	from := c.QueryParam("from")
+	if from == "" {
+		if to != "" {
+			from = to + "^" // per-event: the proposal vs the state it was based on
+		} else if review.SentHead != "" && (hasBranch || review.CommitHash != "") {
+			from = review.SentHead
+		} else if review.CommitHash != "" {
+			from = review.CommitHash
+		}
+	}
+
+	if to != "" {
+		// Per-event diff between two explicit commits.
+		diffText, _ = st.DiffDocumentBodies(from, to, filePath)
+	} else if hasBranch && from != "" {
+		// Diff what was sent (from) against the reviewer's proposed branch, so
+		// "Previous" is the sent version and "Current" is the proposal.
 		diffText, _ = st.DiffDocumentBodies(from, branchName, filePath)
+	} else if hasBranch {
+		// A proposal with no baseline at all — branch vs main.
+		diffText = branchDiff
 	} else if from == "" {
 		// First review — no base commit. Show entire current content as "added".
 		raw, readErr := st.ReadFile(filePath)
@@ -578,7 +595,9 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to compute diff: "+err.Error())
 		}
 	}
-	if hasBranch {
+	if to != "" {
+		toRef = to
+	} else if hasBranch {
 		toRef = branchName
 	}
 
@@ -633,8 +652,12 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 			oldBody = store.StripFrontmatter(string(raw))
 		}
 	}
-	// New body: from review branch if exists, otherwise current HEAD
-	if hasBranch {
+	// New body: a specific commit (per-event), else the review branch, else HEAD.
+	if to != "" {
+		if raw, err := st.ReadFileAtRef(to, relPath); err == nil {
+			newBody = store.StripFrontmatter(string(raw))
+		}
+	} else if hasBranch {
 		if raw, err := st.ReadFileAtRef(branchName, relPath); err == nil {
 			newBody = store.StripFrontmatter(string(raw))
 		}
@@ -845,6 +868,13 @@ func (s *Server) handleReviewApprove(c echo.Context) error {
 			if readErr == nil {
 				h := sha256.Sum256(raw)
 				decRec.ContentHash = hex.EncodeToString(h[:])
+			}
+			// Anchor the reviewer's proposal commit so the per-event diff can be
+			// reconstructed later (commit^..commit), independent of the branch ref.
+			if req.Decision == "proposed_revision" {
+				if bh, bhErr := st.RefHash(branchName); bhErr == nil {
+					decRec.CommitRef = bh
+				}
 			}
 		}
 	}

--- a/internal/isms/api/api_git.go
+++ b/internal/isms/api/api_git.go
@@ -273,11 +273,15 @@ func reviewRefViolation(before, after map[string]string, isAncestor func(old, ne
 // and deleted refs to their old hash, and removes any refs the push created.
 func restoreRefs(st *store.Store, before, after map[string]string) {
 	for name, hash := range before {
-		_ = st.SetRefHash(name, hash)
+		if err := st.SetRefHash(name, hash); err != nil {
+			fmt.Fprintf(os.Stderr, "restoreRefs: could not restore %s to %.8s: %v\n", name, hash, err)
+		}
 	}
 	for name := range after {
 		if _, ok := before[name]; !ok {
-			_ = st.DeleteRef(name)
+			if err := st.DeleteRef(name); err != nil {
+				fmt.Fprintf(os.Stderr, "restoreRefs: could not delete new ref %s: %v\n", name, err)
+			}
 		}
 	}
 }

--- a/internal/isms/api/api_git.go
+++ b/internal/isms/api/api_git.go
@@ -128,6 +128,17 @@ func (s *Server) handleGitRPC(c echo.Context, service string) error {
 		}
 	}
 
+	// Snapshot refs before a push so we can reject + revert server-managed ref
+	// changes (review/*) and history rewrites (non-fast-forward / deletions).
+	var refsBefore map[string]string
+	if service == "receive-pack" {
+		if orgID, ok := c.Get("org_id").(int); ok {
+			if st, err := s.storeForOrg(c.Request().Context(), orgID); err == nil {
+				refsBefore, _ = st.ListRefHashes()
+			}
+		}
+	}
+
 	cmd := exec.Command("git", service, "--stateless-rpc", repoPath)
 	cmd.Stdin = c.Request().Body
 	cmd.Stderr = os.Stderr
@@ -135,6 +146,22 @@ func (s *Server) handleGitRPC(c echo.Context, service string) error {
 	out, err := cmd.Output()
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("git %s error: %v", service, err))
+	}
+
+	// Ref-level protection: server-managed review refs are immutable via push, and
+	// other refs are fast-forward-only (no history rewrite, no deletion). On a
+	// violation, restore the pre-push ref state and reject.
+	if service == "receive-pack" && refsBefore != nil {
+		if orgID, ok := c.Get("org_id").(int); ok {
+			if st, stErr := s.storeForOrg(c.Request().Context(), orgID); stErr == nil {
+				refsAfter, _ := st.ListRefHashes()
+				if reason := reviewRefViolation(refsBefore, refsAfter, st.IsAncestor); reason != "" {
+					restoreRefs(st, refsBefore, refsAfter)
+					fmt.Fprintf(os.Stderr, "REJECTED push for org %d: %s\n", orgID, reason)
+					return echo.NewHTTPError(http.StatusForbidden, "push rejected: "+reason)
+				}
+			}
+		}
 	}
 
 	// Post-receive validation: comprehensive repo protection
@@ -203,4 +230,54 @@ const maxFileSizeBytes = 2 * 1024 * 1024 // 2 MB
 // filesystem walks would never see pushed content.
 func validateRepoContents(st *store.Store) error {
 	return st.ValidateRepoContents(int64(maxFileSizeBytes))
+}
+
+// reviewRefViolation enforces ref-level push policy and returns a rejection
+// reason (or "" if the push is allowed):
+//   - refs/heads/review/* and refs/reviews/* are server-managed — a push must
+//     not create, change, or delete them.
+//   - every other ref is fast-forward-only (the old commit must be an ancestor
+//     of the new one) and may not be deleted — so a push can't rewrite or erase
+//     history (e.g. an approved document's commits or a reviewer's proposal).
+//
+// isAncestor reports whether old is an ancestor of new (a fast-forward).
+func reviewRefViolation(before, after map[string]string, isAncestor func(old, new string) (bool, error)) string {
+	serverManaged := func(name string) bool {
+		return strings.HasPrefix(name, "refs/heads/review/") || strings.HasPrefix(name, "refs/reviews/")
+	}
+	// Created or changed refs.
+	for name, newHash := range after {
+		oldHash, existed := before[name]
+		if serverManaged(name) {
+			if !existed || oldHash != newHash {
+				return "review refs are server-managed and cannot be pushed to: " + name
+			}
+			continue
+		}
+		if existed && oldHash != newHash {
+			if ok, _ := isAncestor(oldHash, newHash); !ok {
+				return "non-fast-forward push (history rewrite) rejected: " + name
+			}
+		}
+	}
+	// Deleted refs.
+	for name := range before {
+		if _, stillThere := after[name]; !stillThere {
+			return "deleting refs via push is not allowed: " + name
+		}
+	}
+	return ""
+}
+
+// restoreRefs reverts the repo's refs to the pre-push snapshot: restores changed
+// and deleted refs to their old hash, and removes any refs the push created.
+func restoreRefs(st *store.Store, before, after map[string]string) {
+	for name, hash := range before {
+		_ = st.SetRefHash(name, hash)
+	}
+	for name := range after {
+		if _, ok := before[name]; !ok {
+			_ = st.DeleteRef(name)
+		}
+	}
 }

--- a/internal/isms/api/api_git_test.go
+++ b/internal/isms/api/api_git_test.go
@@ -11,9 +11,9 @@ func TestReviewRefViolation(t *testing.T) {
 	ffOnly := func(old, new string) (bool, error) { return new == "ff", nil }
 
 	cases := []struct {
-		name           string
-		before, after  map[string]string
-		wantViolation  bool
+		name          string
+		before, after map[string]string
+		wantViolation bool
 	}{
 		{
 			name:   "fast-forward of a normal branch is allowed",

--- a/internal/isms/api/api_git_test.go
+++ b/internal/isms/api/api_git_test.go
@@ -1,0 +1,69 @@
+package api
+
+import "testing"
+
+func TestReviewRefViolation(t *testing.T) {
+	const master = "refs/heads/master"
+	const reviewRef = "refs/heads/review/2"
+	const archived = "refs/reviews/5"
+
+	// Fast-forward iff new == "ff" (test stand-in for "old is an ancestor of new").
+	ffOnly := func(old, new string) (bool, error) { return new == "ff", nil }
+
+	cases := []struct {
+		name           string
+		before, after  map[string]string
+		wantViolation  bool
+	}{
+		{
+			name:   "fast-forward of a normal branch is allowed",
+			before: map[string]string{master: "a"},
+			after:  map[string]string{master: "ff"},
+		},
+		{
+			name:   "unchanged refs are allowed",
+			before: map[string]string{master: "a", reviewRef: "r"},
+			after:  map[string]string{master: "a", reviewRef: "r"},
+		},
+		{
+			name:          "non-fast-forward (history rewrite) is rejected",
+			before:        map[string]string{master: "a"},
+			after:         map[string]string{master: "rewritten"},
+			wantViolation: true,
+		},
+		{
+			name:          "changing a review/* ref via push is rejected",
+			before:        map[string]string{master: "a", reviewRef: "r"},
+			after:         map[string]string{master: "a", reviewRef: "ff"},
+			wantViolation: true,
+		},
+		{
+			name:          "creating a review/* ref via push is rejected",
+			before:        map[string]string{master: "a"},
+			after:         map[string]string{master: "a", reviewRef: "new"},
+			wantViolation: true,
+		},
+		{
+			name:          "writing an archived refs/reviews/* ref is rejected",
+			before:        map[string]string{master: "a"},
+			after:         map[string]string{master: "a", archived: "x"},
+			wantViolation: true,
+		},
+		{
+			name:          "deleting a ref is rejected",
+			before:        map[string]string{master: "a", reviewRef: "r"},
+			after:         map[string]string{master: "a"},
+			wantViolation: true,
+		},
+	}
+
+	for _, tc := range cases {
+		got := reviewRefViolation(tc.before, tc.after, ffOnly)
+		if tc.wantViolation && got == "" {
+			t.Errorf("%s: expected a violation, got none", tc.name)
+		}
+		if !tc.wantViolation && got != "" {
+			t.Errorf("%s: expected no violation, got %q", tc.name, got)
+		}
+	}
+}

--- a/internal/isms/store/git.go
+++ b/internal/isms/store/git.go
@@ -390,6 +390,72 @@ func (s *Store) HeadHash() (string, error) {
 	return ref.Hash().String(), nil
 }
 
+// ListRefHashes returns every ref in the repo as full-name → commit-hash. Used
+// to snapshot refs around a push so server-managed refs (review/*) and history
+// rewrites can be detected and reverted.
+func (s *Store) ListRefHashes() (map[string]string, error) {
+	if s.repo == nil {
+		return nil, fmt.Errorf("not a bare repo store")
+	}
+	out := map[string]string{}
+	iter, err := s.repo.References()
+	if err != nil {
+		return nil, err
+	}
+	err = iter.ForEach(func(r *plumbing.Reference) error {
+		if r.Type() == plumbing.HashReference {
+			out[r.Name().String()] = r.Hash().String()
+		}
+		return nil
+	})
+	return out, err
+}
+
+// SetRefHash points a ref at a commit hash (creating it if absent).
+func (s *Store) SetRefHash(name, hash string) error {
+	if s.repo == nil {
+		return fmt.Errorf("not a bare repo store")
+	}
+	return s.repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(name), plumbing.NewHash(hash)))
+}
+
+// DeleteRef removes a ref.
+func (s *Store) DeleteRef(name string) error {
+	if s.repo == nil {
+		return fmt.Errorf("not a bare repo store")
+	}
+	return s.repo.Storer.RemoveReference(plumbing.ReferenceName(name))
+}
+
+// IsAncestor reports whether `ancestor` is an ancestor of `descendant` — i.e. the
+// update old→new is a fast-forward (no history rewrite).
+func (s *Store) IsAncestor(ancestor, descendant string) (bool, error) {
+	if s.repo == nil {
+		return false, fmt.Errorf("not a bare repo store")
+	}
+	a, err := s.repo.CommitObject(plumbing.NewHash(ancestor))
+	if err != nil {
+		return false, err
+	}
+	d, err := s.repo.CommitObject(plumbing.NewHash(descendant))
+	if err != nil {
+		return false, err
+	}
+	return a.IsAncestor(d)
+}
+
+// RefHash resolves a ref (branch name, tag, commit hash, HEAD~N) to its commit
+// hash. Used to anchor a review's proposed-revision commit in the decision log
+// so the per-event diff can be reconstructed later (even once the branch ref is
+// archived out of refs/heads).
+func (s *Store) RefHash(ref string) (string, error) {
+	commit, err := s.resolveRef(ref)
+	if err != nil {
+		return "", err
+	}
+	return commit.Hash.String(), nil
+}
+
 // HeadCommit returns the HEAD commit object.
 func (s *Store) HeadCommit() (*object.Commit, error) {
 	if s.repo == nil {

--- a/tests/test_e2e_review_diff.py
+++ b/tests/test_e2e_review_diff.py
@@ -276,6 +276,8 @@ def table_review_proposed(tokens):
     assert cref, "proposed_revision decision must anchor a commit_ref"
     d = api("get", f"/reviews/{rid}/diff?to={cref}", t, expect_status=200).json()
     assert "Customers" in d["old_body"] and "<table" in d["new_body"], "per-event diff should be base→proposal"
+    # `to` must be a commit SHA — arbitrary revision strings are rejected (400).
+    api("get", f"/reviews/{rid}/diff?to=refs/heads/master", t, expect_status=400)
     yield rid
     api("put", f"/reviews/{rid}/status", t, json={"status": "closed"})
 
@@ -290,10 +292,12 @@ def test_per_event_diff_expands_in_conversation(pw_browser, table_review_propose
         # Expand the reviewer's proposed-revision entry.
         page.locator("button:has-text('View changes')").first.wait_for(state="visible", timeout=10000)
         page.locator("button:has-text('View changes')").first.click()
-        # The per-event diff renders the two edited cells, scoped to that revision.
+        # The per-event diff renders the reviewer's edits, scoped to that revision.
+        # Content-based (not an exact element count) so it survives renderer tweaks.
         page.locator("td.tc-cell-change").first.wait_for(state="visible", timeout=8000)
-        assert page.locator("td.tc-cell-change").count() == 2, \
-            f"per-event diff should show exactly the 2 edited cells, got {page.locator('td.tc-cell-change').count()}"
-        assert page.locator(".tc-cell-change .tc-word-ins", has_text="Background check.").count() >= 1
+        assert page.locator(".tc-cell-change .tc-word-ins", has_text="Background check.").count() >= 1, \
+            "the 'Background check.' insertion should be highlighted in the per-event diff"
+        assert page.locator(".tc-cell-change .tc-word-ins", has_text="Review supplier security docs.").count() >= 1, \
+            "the supplier-docs insertion should be highlighted in the per-event diff"
     finally:
         ctx.close()

--- a/tests/test_e2e_review_diff.py
+++ b/tests/test_e2e_review_diff.py
@@ -193,3 +193,107 @@ def test_review_table_diff_pairs_correctly_after_deletion(pw_browser, table_revi
             "deleted-table rows must not be mis-paired into the changed table"
     finally:
         ctx.close()
+
+
+# A document that was NEVER approved before being sent for review (no baseline
+# commit). The diff must still show the reviewer's proposal against what was
+# *sent* — not an empty "Previous" pane with the whole doc as "new". (#6: the
+# review-diff baseline bug — old_body was empty when commit_hash was empty.)
+@pytest.fixture(scope="module")
+def table_review_unapproved(tokens):
+    t = tokens["admin"]
+    r1t = api("post", "/auth/login",
+              json={"email": R1[0], "password": R1[1], "organization": ORG},
+              expect_status=200).json()["token"]
+    doc_id = f"e2e-tablenoappr-{uuid.uuid4().hex[:8]}"
+    api("post", "/documents", t, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "E2E Table No-Approval", "content": OLD_BODY,
+    }, expect_status=[200, 201])
+    # NOTE: no approve/merge — the doc has no approved baseline (commit_hash == "").
+    rid = api("post", f"/documents/{doc_id}/reviews", t,
+              json={"reviewers": [R1[0]], "message": "Review"},
+              expect_status=[200, 201]).json()["review_id"]
+    api("put", f"/reviews/{rid}/content", r1t, json={"content": NEW_BODY}, expect_status=200)
+    # The diff must expose the SENT version as old_body, not an empty baseline.
+    d = api("get", f"/reviews/{rid}/diff", t, expect_status=200).json()
+    assert "Customers" in d["old_body"], \
+        f"old_body must be the sent version even without an approved baseline, got: {d['old_body'][:80]!r}"
+    yield rid
+    api("put", f"/reviews/{rid}/status", t, json={"status": "closed"})
+
+
+def test_review_diff_shows_sent_version_without_approved_baseline(pw_browser, table_review_unapproved):
+    ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = ctx.new_page()
+    try:
+        do_login(page, ADMIN[0], ADMIN[1], then_goto=f"reviews/{table_review_unapproved}")
+        page.locator("button:has-text('Changes')").first.click()
+        page.wait_for_load_state("networkidle")
+        # The reviewer's edit must render as a per-cell diff — which only happens
+        # when the sent version is present as the baseline. (The bug showed an
+        # empty Previous pane → whole table as "new" → 0 cell-changes.)
+        page.locator("td.tc-cell-change").first.wait_for(state="visible", timeout=10000)
+        assert page.locator("td.tc-cell-change").count() == 2, \
+            f"expected 2 changed cells against the sent baseline, got {page.locator('td.tc-cell-change').count()}"
+    finally:
+        ctx.close()
+
+
+# A reviewer who submits a proposed_revision *decision* (not just edits the
+# branch) — so the Conversation timeline has an expandable per-event entry. #6.
+@pytest.fixture(scope="module")
+def table_review_proposed(tokens):
+    t = tokens["admin"]
+    r1t = api("post", "/auth/login",
+              json={"email": R1[0], "password": R1[1], "organization": ORG},
+              expect_status=200).json()["token"]
+    doc_id = f"e2e-perevent-{uuid.uuid4().hex[:8]}"
+    api("post", "/documents", t, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "E2E Per-event", "content": OLD_BODY,
+    }, expect_status=[200, 201])
+    rid0 = api("post", f"/documents/{doc_id}/reviews", t,
+               json={"reviewers": [R1[0]], "message": "baseline"},
+               expect_status=[200, 201]).json()["review_id"]
+    api("post", f"/reviews/{rid0}/approve", r1t,
+        json={"decision": "approved", "comment": "ok"}, expect_status=200)
+    api("post", f"/reviews/{rid0}/merge", t, json={}, expect_status=200)
+    rid = api("post", f"/documents/{doc_id}/reviews", t,
+              json={"reviewers": [R1[0]], "message": "Review"},
+              expect_status=[200, 201]).json()["review_id"]
+    api("put", f"/reviews/{rid}/content", r1t, json={"content": NEW_BODY}, expect_status=200)
+    # The decision record anchors the proposal commit (commit_ref) for per-event diff.
+    api("post", f"/reviews/{rid}/approve", r1t,
+        json={"decision": "proposed_revision", "comment": "tweaked two cells"}, expect_status=200)
+    # Sanity: the per-event diff (to=proposal commit) shows the markdown→HTML edit.
+    tl = api("get", f"/reviews/{rid}/timeline", t, expect_status=200).json()
+    entries = tl.get("data", tl) if isinstance(tl, dict) else tl
+    cref = next((e.get("data", {}).get("commit_ref") for e in entries
+                 if isinstance(e, dict) and e.get("type") == "decision"
+                 and e.get("decision") == "proposed_revision"
+                 and e.get("data", {}).get("commit_ref")), None)
+    assert cref, "proposed_revision decision must anchor a commit_ref"
+    d = api("get", f"/reviews/{rid}/diff?to={cref}", t, expect_status=200).json()
+    assert "Customers" in d["old_body"] and "<table" in d["new_body"], "per-event diff should be base→proposal"
+    yield rid
+    api("put", f"/reviews/{rid}/status", t, json={"status": "closed"})
+
+
+def test_per_event_diff_expands_in_conversation(pw_browser, table_review_proposed):
+    ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = ctx.new_page()
+    try:
+        do_login(page, ADMIN[0], ADMIN[1], then_goto=f"reviews/{table_review_proposed}")
+        page.locator("button:has-text('Conversation')").first.click()
+        page.wait_for_load_state("networkidle")
+        # Expand the reviewer's proposed-revision entry.
+        page.locator("button:has-text('View changes')").first.wait_for(state="visible", timeout=10000)
+        page.locator("button:has-text('View changes')").first.click()
+        # The per-event diff renders the two edited cells, scoped to that revision.
+        page.locator("td.tc-cell-change").first.wait_for(state="visible", timeout=8000)
+        assert page.locator("td.tc-cell-change").count() == 2, \
+            f"per-event diff should show exactly the 2 edited cells, got {page.locator('td.tc-cell-change').count()}"
+        assert page.locator(".tc-cell-change .tc-word-ins", has_text="Background check.").count() >= 1
+    finally:
+        ctx.close()

--- a/tests/test_e2e_review_scroll.py
+++ b/tests/test_e2e_review_scroll.py
@@ -1,0 +1,75 @@
+"""E2E: the Split review view scrolls both panes together (synced scroll).
+
+Reviewing a side-by-side diff means lining changes up across both columns; before
+this the two panes scrolled independently and you had to scroll each one. This
+pins that scrolling the Previous pane moves the Current pane with it.
+
+Own file (not test_e2e_review_diff.py) to avoid per-branch EOF merge conflicts.
+"""
+import uuid
+
+import pytest
+from test_e2e_browser import api, do_login, ORG, ADMIN, R1, pw_browser, tokens  # noqa: F401
+
+# A long document so both panes overflow and actually scroll.
+_PARAS = "\n\n".join(f"Paragraph {i}: control and risk text for the ISMS." for i in range(1, 61))
+OLD_BODY = f"# Long Review Doc\n\n{_PARAS}"
+# Reviewer proposes a small edit to one paragraph (so both panes have content).
+NEW_BODY = OLD_BODY.replace("Paragraph 30:", "Paragraph 30 (edited):")
+
+
+@pytest.fixture(scope="module")
+def long_review(tokens):
+    t = tokens["admin"]
+    r1t = api("post", "/auth/login",
+              json={"email": R1[0], "password": R1[1], "organization": ORG},
+              expect_status=200).json()["token"]
+    doc_id = f"e2e-scroll-{uuid.uuid4().hex[:8]}"
+    api("post", "/documents", t, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "E2E Scroll", "content": OLD_BODY,
+    }, expect_status=[200, 201])
+    rid0 = api("post", f"/documents/{doc_id}/reviews", t,
+               json={"reviewers": [R1[0]], "message": "baseline"},
+               expect_status=[200, 201]).json()["review_id"]
+    api("post", f"/reviews/{rid0}/approve", r1t,
+        json={"decision": "approved", "comment": "ok"}, expect_status=200)
+    api("post", f"/reviews/{rid0}/merge", t, json={}, expect_status=200)
+    rid = api("post", f"/documents/{doc_id}/reviews", t,
+              json={"reviewers": [R1[0]], "message": "Long edit"},
+              expect_status=[200, 201]).json()["review_id"]
+    api("put", f"/reviews/{rid}/content", r1t, json={"content": NEW_BODY}, expect_status=200)
+    yield rid
+    api("put", f"/reviews/{rid}/status", t, json={"status": "closed"})
+
+
+def test_split_view_scrolls_both_panes_together(pw_browser, long_review):
+    ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = ctx.new_page()
+    try:
+        do_login(page, ADMIN[0], ADMIN[1], then_goto=f"reviews/{long_review}")
+        page.locator("button:has-text('Changes')").first.click()
+        page.wait_for_load_state("networkidle")
+        # Split is the default sub-view.
+        prev = page.locator('[data-pane="previous"]')
+        curr = page.locator('[data-pane="current"]')
+        prev.wait_for(state="visible", timeout=10000)
+
+        # Both panes must actually overflow (otherwise the test proves nothing).
+        assert prev.evaluate("el => el.scrollHeight > el.clientHeight + 50"), "previous pane should overflow"
+        assert curr.evaluate("el => el.scrollHeight > el.clientHeight + 50"), "current pane should overflow"
+
+        assert curr.evaluate("el => el.scrollTop") == 0
+        # Scroll the Previous pane — the Current pane must follow.
+        prev.evaluate("el => { el.scrollTop = 400 }")
+        page.wait_for_timeout(200)
+        assert curr.evaluate("el => el.scrollTop") > 0, "current pane should follow when previous scrolls"
+
+        # And the reverse direction too.
+        curr.evaluate("el => { el.scrollTop = 0 }")
+        page.wait_for_timeout(200)
+        curr.evaluate("el => { el.scrollTop = 600 }")
+        page.wait_for_timeout(200)
+        assert prev.evaluate("el => el.scrollTop") > 0, "previous pane should follow when current scrolls"
+    finally:
+        ctx.close()

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -248,7 +248,13 @@ export const api = {
   updateReviewStatus: (id, status) => putJSON(`${API}/reviews/${id}/status`, { status }),
   forwardReview: (id, data) => postJSON(`${API}/reviews/${id}/forward`, data),
   getReviewTimeline: (id) => fetchJSON(`${API}/reviews/${id}/timeline`),
-  getReviewDiff: (id, from) => fetchJSON(`${API}/reviews/${id}/diff${from ? '?from=' + encodeURIComponent(from) : ''}`),
+  getReviewDiff: (id, from, to) => {
+    const p = new URLSearchParams()
+    if (from) p.set('from', from)
+    if (to) p.set('to', to) // per-event diff: a single proposal commit (commit^..commit)
+    const qs = p.toString()
+    return fetchJSON(`${API}/reviews/${id}/diff${qs ? '?' + qs : ''}`)
+  },
   addReviewComment: (id, data) => postJSON(`${API}/reviews/${id}/comment`, typeof data === 'string' ? { body: data } : data),
   approveReview: (id, decision, comment) => postJSON(`${API}/reviews/${id}/approve`, { decision, comment }),
   mergeReview: (id) => postJSON(`${API}/reviews/${id}/merge`, {}),

--- a/web/src/components/SideBySideReview.vue
+++ b/web/src/components/SideBySideReview.vue
@@ -22,7 +22,7 @@
     <!-- Side-by-side rendered view -->
     <div v-else class="flex border border-t-0 border-slate-800 rounded-b-xl overflow-hidden">
       <!-- Left: Previous version -->
-      <div class="flex-1 min-w-0 border-r border-slate-800 overflow-y-auto max-h-[80vh]">
+      <div ref="leftPane" data-pane="previous" @scroll="syncScroll('left')" class="flex-1 min-w-0 border-r border-slate-800 overflow-y-auto max-h-[80vh]">
         <div class="px-3 py-2 bg-slate-900/80 border-b border-slate-800 sticky top-0 z-10">
           <span class="text-[10px] font-medium text-slate-500 uppercase tracking-wider">Previous</span>
         </div>
@@ -36,7 +36,7 @@
         </div>
       </div>
       <!-- Right: New version -->
-      <div class="flex-1 min-w-0 overflow-y-auto max-h-[80vh]">
+      <div ref="rightPane" data-pane="current" @scroll="syncScroll('right')" class="flex-1 min-w-0 overflow-y-auto max-h-[80vh]">
         <div class="px-3 py-2 bg-slate-900/80 border-b border-slate-800 sticky top-0 z-10">
           <span class="text-[10px] font-medium text-slate-500 uppercase tracking-wider">Current</span>
         </div>
@@ -152,6 +152,25 @@ const props = defineProps({
 
 const emit = defineEmits(['comment'])
 const showAdvanced = ref(false)
+
+// Synchronised scrolling between the two panes (GitHub-style): scroll one and
+// the other follows proportionally, so a change lines up across both columns
+// without scrolling each separately. Proportional (not 1:1) because the panes
+// can differ in height. A guard flag breaks the scroll→scroll feedback loop.
+const leftPane = ref(null)
+const rightPane = ref(null)
+let syncingScroll = false
+function syncScroll(source) {
+  if (syncingScroll) return
+  const from = source === 'left' ? leftPane.value : rightPane.value
+  const to = source === 'left' ? rightPane.value : leftPane.value
+  if (!from || !to) return
+  const fromMax = from.scrollHeight - from.clientHeight
+  const toMax = to.scrollHeight - to.clientHeight
+  syncingScroll = true
+  to.scrollTop = fromMax > 0 ? (from.scrollTop / fromMax) * toMax : 0
+  requestAnimationFrame(() => { syncingScroll = false })
+}
 const commentingIndex = ref(null)
 const commentBody = ref('')
 const expandedBlock = ref(null)

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -218,6 +218,21 @@
                       </svg>
                       <span class="text-[10px] font-mono text-slate-600" title="SHA-256 content hash for tamper evidence">{{ entry.content_hash.substring(0, 16) }}...</span>
                     </div>
+                    <!-- Per-event diff: exactly what this revision changed (#6) -->
+                    <div v-if="entry.decision === 'proposed_revision' && entry.data?.commit_ref" class="ml-6 mt-2">
+                      <button @click="toggleEventDiff(entry)" class="text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors">
+                        {{ openEventDiff === entry.data.commit_ref ? 'Hide changes' : 'View changes' }}
+                      </button>
+                      <div v-if="openEventDiff === entry.data.commit_ref" class="mt-2 bg-slate-900 border border-slate-800 rounded-lg overflow-hidden">
+                        <div v-if="eventDiff[entry.data.commit_ref]?.loading" class="px-4 py-3 text-xs text-slate-500">Loading changes…</div>
+                        <div v-else-if="eventDiff[entry.data.commit_ref]?.error" class="px-4 py-3 text-xs text-red-400">Couldn't load this revision's diff.</div>
+                        <TrackChanges v-else
+                          :old-body="eventDiff[entry.data.commit_ref]?.old || ''"
+                          :new-body="eventDiff[entry.data.commit_ref]?.new || ''"
+                          :document-id="review?.document_id || ''"
+                          :readonly="true" />
+                      </div>
+                    </div>
                   </div>
                 </div>
                 </template>
@@ -817,7 +832,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useConfirm } from '../composables/useConfirm'
 import { useRoute, useRouter } from 'vue-router'
 import api from '../api'
@@ -971,6 +986,27 @@ const reviewGuideHidden = ref(false)
 const diffViewMode = ref('track-changes')
 const changesViewMode = ref('split')
 const diffScope = ref('round') // 'round' = changes in this round, 'all' = all changes in review
+
+// Per-event diff (#6): expand a `proposed_revision` timeline entry to see exactly
+// what that one revision changed (the proposal commit vs its parent). Cached by
+// commit ref so re-opening is instant.
+const openEventDiff = ref(null)
+const eventDiff = reactive({})
+async function toggleEventDiff(entry) {
+  const ref_ = entry.data?.commit_ref
+  if (!ref_ || !review.value) return
+  if (openEventDiff.value === ref_) { openEventDiff.value = null; return }
+  openEventDiff.value = ref_
+  if (!eventDiff[ref_]) {
+    eventDiff[ref_] = { loading: true, old: '', new: '' }
+    try {
+      const d = await api.getReviewDiff(review.value.id, null, ref_)
+      eventDiff[ref_] = { loading: false, old: d.old_body || '', new: d.new_body || '' }
+    } catch {
+      eventDiff[ref_] = { loading: false, error: true, old: '', new: '' }
+    }
+  }
+}
 const approvalFeedback = ref('')
 const policyStatus = ref(null)
 


### PR DESCRIPTION
Completes **#6** and bundles the fixes found while dry-running the review workflow (review #2 on iso27001-4-2). No DB migration.

### #6 — per-event diff (headline)
Each `proposed_revision` in the Conversation timeline expands (**View changes**) to show exactly what that revision changed — the proposal commit vs its parent (`commit^..commit`), anchored by `decision_log.commit_ref` so it survives merge. Backend: store `RefHash` + a `to` diff param; frontend reuses `TrackChanges`. (Per-cell table diff = slice 1, merged in #99.)

### Dry-run fixes
- **Diff baseline** (#102): never-approved docs showed an empty 'Previous'; now use `sent_head` when a review branch exists.
- **Synced split scroll** (#103): the two panes scroll together.
- **Tenant notification links** (#104): links use `orgURLs`, not the apex.

### Security
- **Push ref-protection** (#105): `review/*` and `refs/reviews/*` are server-managed (immutable via push); all refs are fast-forward-only and undeletable — a push can't rewrite or erase review/approved history. Violations revert + reject.

### Tests
5 review E2E (per-cell, deletion-pairing, never-approved baseline, per-event expand, synced scroll) — green twice against the stack, run in CI. Go unit tests for the push ref-policy (`reviewRefViolation`) and name derivation. The git-push rejection + Slack send need a live client/webhook — verified manually (documented blind-spot, as with SMTP).

Larger PR by request (everything from the dry-run in one). The push ref-protection is a distinct security control — worth a focused pass.