### PR TITLE
fix(url): honour subdomainRouting in orgURLs + OIDC redirect (#108)

### DIFF
--- a/internal/isms/api/api_oidc.go
+++ b/internal/isms/api/api_oidc.go
@@ -311,7 +311,7 @@ func (s *Server) handleOIDCCallback(c echo.Context) error {
 	// hop to https://<slug>.isms.sh/. Otherwise stay on the apex with #token=...
 	// and let the SPA route via /:org-prefixed paths.
 	baseURL := strings.TrimRight(os.Getenv("ISMS_BASE_URL"), "/")
-	redirectURL := orgTokenRedirectURL(baseURL, org.Slug, token, role)
+	redirectURL := orgTokenRedirectURL(baseURL, org.Slug, token, role, s.subdomainRouting)
 	return c.Redirect(http.StatusFound, redirectURL)
 }
 
@@ -319,7 +319,7 @@ func (s *Server) handleOIDCCallback(c echo.Context) error {
 // Prefers a subdomain hop (https://<slug>.<apex>/#token=...) when the base URL
 // has a hostname that can host subdomains; falls back to path-based routing
 // (<base>/<slug>/#token=...) for single-label / localhost hosts.
-func orgTokenRedirectURL(baseURL, slug, token, role string) string {
+func orgTokenRedirectURL(baseURL, slug, token, role string, subdomainRouting bool) string {
 	// Parse the base URL — extract scheme and host so we can splice in the slug.
 	// Cheap parse: assume baseURL like "https://isms.sh" or "http://localhost:9090".
 	const sep = "://"
@@ -337,9 +337,10 @@ func orgTokenRedirectURL(baseURL, slug, token, role string) string {
 		host = hostAndPort[:c]
 		port = hostAndPort[c:] // includes ':'
 	}
-	// Can this host serve subdomains? Need at least 2 dot-separated parts and
-	// not localhost / IP literal.
-	canSubdomain := strings.Contains(host, ".") &&
+	// Subdomain hop only when the deployment routes by subdomain; otherwise stay
+	// path-based so the redirect matches how requests are actually routed.
+	canSubdomain := subdomainRouting &&
+		strings.Contains(host, ".") &&
 		!strings.HasPrefix(host, "localhost") &&
 		!isIPLiteral(host)
 	if canSubdomain {

--- a/internal/isms/api/api_oidc.go
+++ b/internal/isms/api/api_oidc.go
@@ -311,43 +311,40 @@ func (s *Server) handleOIDCCallback(c echo.Context) error {
 	// hop to https://<slug>.isms.sh/. Otherwise stay on the apex with #token=...
 	// and let the SPA route via /:org-prefixed paths.
 	baseURL := strings.TrimRight(os.Getenv("ISMS_BASE_URL"), "/")
-	redirectURL := orgTokenRedirectURL(baseURL, org.Slug, token, role, s.subdomainRouting)
+	redirectURL := orgTokenRedirectURL(baseURL, org.Slug, org.Domain, token, role, s.subdomainRouting)
 	return c.Redirect(http.StatusFound, redirectURL)
 }
 
 // orgTokenRedirectURL builds the post-OIDC-login redirect for a given org.
-// Prefers a subdomain hop (https://<slug>.<apex>/#token=...) when the base URL
-// has a hostname that can host subdomains; falls back to path-based routing
-// (<base>/<slug>/#token=...) for single-label / localhost hosts.
-func orgTokenRedirectURL(baseURL, slug, token, role string, subdomainRouting bool) string {
-	// Parse the base URL — extract scheme and host so we can splice in the slug.
-	// Cheap parse: assume baseURL like "https://isms.sh" or "http://localhost:9090".
-	const sep = "://"
-	i := strings.Index(baseURL, sep)
-	if i < 0 {
+// Precedence mirrors orgURLs (server.go): a configured custom domain wins, then
+// a subdomain hop (https://<slug>.<apex>/login#token=...) when the deployment
+// routes by subdomain, otherwise path-based routing (<base>/<slug>/login#...).
+// Sharing resolveSubdomainHost keeps this decision identical to orgURLs, so the
+// login redirect always lands on the same host the org's other links use.
+func orgTokenRedirectURL(baseURL, slug string, domain *string, token, role string, subdomainRouting bool) string {
+	// Custom domain wins — an org with its own domain (e.g. audit.sts.is) must
+	// land its OIDC login there, not on the apex subdomain/path.
+	if domain != nil && *domain != "" {
+		d := *domain
+		if !strings.Contains(d, "://") {
+			scheme := "https"
+			if strings.HasPrefix(baseURL, "http://") {
+				scheme = "http"
+			}
+			d = scheme + "://" + d
+		}
+		d = strings.TrimRight(d, "/")
+		return fmt.Sprintf("%s/login#token=%s&role=%s", d, token, role)
+	}
+	scheme, host, port, canSubdomain := resolveSubdomainHost(baseURL, subdomainRouting)
+	if scheme == "" {
 		// Malformed base — fall back to apex with fragment, SPA will route from there.
 		return fmt.Sprintf("%s/#token=%s&role=%s", baseURL, token, role)
 	}
-	scheme := baseURL[:i]
-	hostAndPort := baseURL[i+len(sep):]
-	// Split host:port
-	host := hostAndPort
-	port := ""
-	if c := strings.LastIndex(hostAndPort, ":"); c > 0 {
-		host = hostAndPort[:c]
-		port = hostAndPort[c:] // includes ':'
-	}
-	// Subdomain hop only when the deployment routes by subdomain; otherwise stay
-	// path-based so the redirect matches how requests are actually routed.
-	canSubdomain := subdomainRouting &&
-		strings.Contains(host, ".") &&
-		!strings.HasPrefix(host, "localhost") &&
-		!isIPLiteral(host)
 	if canSubdomain {
-		// www.isms.sh → isms.sh
+		// www.isms.sh → isms.sh. Land on /login — Login.vue's onMounted handler
+		// parses the token fragment, sets the session, and routes to /overview.
 		apex := strings.TrimPrefix(host, "www.")
-		// Land on /login — Login.vue's onMounted handler parses the token
-		// fragment, sets the session, and routes onward to /overview.
 		return fmt.Sprintf("%s://%s.%s%s/login#token=%s&role=%s", scheme, slug, apex, port, token, role)
 	}
 	// Path-based fallback (e.g. localhost dev): https://localhost:9090/<slug>/login#token=...

--- a/internal/isms/api/orgurls_test.go
+++ b/internal/isms/api/orgurls_test.go
@@ -10,61 +10,78 @@ func ptr(s string) *string { return &s }
 
 // orgURLs must build links into the tenant's own space — never a flat shared
 // base — matching the SPA router: org-scoped pages carry the slug/subdomain,
-// public pages (verify-email, login) are never mounted under /:org.
+// public pages (verify-email, login) are never mounted under /:org. Subdomain
+// URLs are used ONLY when subdomainRouting is enabled — otherwise links stay
+// path-based, matching how requests are actually routed.
 func TestOrgURLs(t *testing.T) {
 	cases := []struct {
-		name       string
-		base       string
-		org        *db.Organization
-		wantApp    string
-		wantPublic string
+		name             string
+		base             string
+		org              *db.Organization
+		subdomainRouting bool
+		wantApp          string
+		wantPublic       string
 	}{
 		{
-			name:       "subdomain host: org becomes the subdomain for both",
-			base:       "https://isms.sh",
-			org:        &db.Organization{Slug: "sts"},
-			wantApp:    "https://sts.isms.sh",
-			wantPublic: "https://sts.isms.sh",
+			name:             "subdomain routing on: org becomes the subdomain for both",
+			base:             "https://isms.sh",
+			org:              &db.Organization{Slug: "sts"},
+			subdomainRouting: true,
+			wantApp:          "https://sts.isms.sh",
+			wantPublic:       "https://sts.isms.sh",
 		},
 		{
-			name:       "path-based host: app carries the slug, public does not",
-			base:       "http://localhost:9090",
-			org:        &db.Organization{Slug: "sts"},
-			wantApp:    "http://localhost:9090/sts",
-			wantPublic: "http://localhost:9090",
+			name:             "subdomain routing OFF: a real domain stays path-based (single-tenant box)",
+			base:             "https://isms.stsplatform.com",
+			org:              &db.Organization{Slug: "sts"},
+			subdomainRouting: false,
+			wantApp:          "https://isms.stsplatform.com/sts",
+			wantPublic:       "https://isms.stsplatform.com",
 		},
 		{
-			name:       "custom domain wins for both app and public",
-			base:       "https://isms.sh",
-			org:        &db.Organization{Slug: "sts", Domain: ptr("audit.sts.is")},
-			wantApp:    "https://audit.sts.is",
-			wantPublic: "https://audit.sts.is",
+			name:             "path-based host stays path-based regardless",
+			base:             "http://localhost:9090",
+			org:              &db.Organization{Slug: "sts"},
+			subdomainRouting: true,
+			wantApp:          "http://localhost:9090/sts",
+			wantPublic:       "http://localhost:9090",
 		},
 		{
-			name:       "custom domain with explicit scheme is preserved",
-			base:       "https://isms.sh",
-			org:        &db.Organization{Slug: "sts", Domain: ptr("https://audit.sts.is/")},
-			wantApp:    "https://audit.sts.is",
-			wantPublic: "https://audit.sts.is",
+			name:             "custom domain wins for both, independent of routing mode",
+			base:             "https://isms.sh",
+			org:              &db.Organization{Slug: "sts", Domain: ptr("audit.sts.is")},
+			subdomainRouting: false,
+			wantApp:          "https://audit.sts.is",
+			wantPublic:       "https://audit.sts.is",
 		},
 		{
-			name:       "www is stripped from the apex",
-			base:       "https://www.isms.sh",
-			org:        &db.Organization{Slug: "sts"},
-			wantApp:    "https://sts.isms.sh",
-			wantPublic: "https://sts.isms.sh",
+			name:             "custom domain with explicit scheme is preserved",
+			base:             "https://isms.sh",
+			org:              &db.Organization{Slug: "sts", Domain: ptr("https://audit.sts.is/")},
+			subdomainRouting: true,
+			wantApp:          "https://audit.sts.is",
+			wantPublic:       "https://audit.sts.is",
 		},
 		{
-			name:       "port is preserved on the subdomain",
-			base:       "https://isms.sh:8443",
-			org:        &db.Organization{Slug: "sts"},
-			wantApp:    "https://sts.isms.sh:8443",
-			wantPublic: "https://sts.isms.sh:8443",
+			name:             "www is stripped from the apex (subdomain routing on)",
+			base:             "https://www.isms.sh",
+			org:              &db.Organization{Slug: "sts"},
+			subdomainRouting: true,
+			wantApp:          "https://sts.isms.sh",
+			wantPublic:       "https://sts.isms.sh",
+		},
+		{
+			name:             "port is preserved on the subdomain (subdomain routing on)",
+			base:             "https://isms.sh:8443",
+			org:              &db.Organization{Slug: "sts"},
+			subdomainRouting: true,
+			wantApp:          "https://sts.isms.sh:8443",
+			wantPublic:       "https://sts.isms.sh:8443",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			app, public := orgURLs(tc.base, tc.org)
+			app, public := orgURLs(tc.base, tc.org, tc.subdomainRouting)
 			if app != tc.wantApp {
 				t.Errorf("app = %q, want %q", app, tc.wantApp)
 			}

--- a/internal/isms/api/orgurls_test.go
+++ b/internal/isms/api/orgurls_test.go
@@ -91,3 +91,66 @@ func TestOrgURLs(t *testing.T) {
 		})
 	}
 }
+
+// orgTokenRedirectURL (post-OIDC login redirect) must make the SAME host
+// decision as orgURLs — custom domain > subdomain (only when routing on) > path
+// — so a user logging in via OIDC lands on the same host their notification/
+// email links point to. It carried the identical subdomainRouting gate as
+// orgURLs but had no test; this locks the precedence in CI, including the
+// custom-domain case that was previously ignored (#108 review).
+func TestOrgTokenRedirectURL(t *testing.T) {
+	cases := []struct {
+		name             string
+		base             string
+		slug             string
+		domain           *string
+		subdomainRouting bool
+		want             string
+	}{
+		{
+			name:             "subdomain routing on: hop to the tenant subdomain",
+			base:             "https://isms.sh",
+			slug:             "sts",
+			subdomainRouting: true,
+			want:             "https://sts.isms.sh/login#token=TOK&role=reader",
+		},
+		{
+			name:             "subdomain routing OFF on a real domain: stay path-based",
+			base:             "https://isms.stsplatform.com",
+			slug:             "sts",
+			subdomainRouting: false,
+			want:             "https://isms.stsplatform.com/sts/login#token=TOK&role=reader",
+		},
+		{
+			name:             "localhost stays path-based regardless of routing flag",
+			base:             "http://localhost:9090",
+			slug:             "sts",
+			subdomainRouting: true,
+			want:             "http://localhost:9090/sts/login#token=TOK&role=reader",
+		},
+		{
+			name:             "custom domain wins regardless of routing mode",
+			base:             "https://isms.sh",
+			slug:             "sts",
+			domain:           ptr("audit.sts.is"),
+			subdomainRouting: true,
+			want:             "https://audit.sts.is/login#token=TOK&role=reader",
+		},
+		{
+			name:             "custom domain with explicit scheme is preserved",
+			base:             "https://isms.sh",
+			slug:             "sts",
+			domain:           ptr("https://audit.sts.is/"),
+			subdomainRouting: false,
+			want:             "https://audit.sts.is/login#token=TOK&role=reader",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orgTokenRedirectURL(tc.base, tc.slug, tc.domain, "TOK", "reader", tc.subdomainRouting)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -125,32 +125,45 @@ func orgURLs(baseURL string, org *db.Organization, subdomainRouting bool) (app, 
 		d = strings.TrimRight(d, "/")
 		return d, d
 	}
-	const sep = "://"
-	i := strings.Index(baseURL, sep)
-	if i < 0 {
+	scheme, host, port, canSubdomain := resolveSubdomainHost(baseURL, subdomainRouting)
+	if scheme == "" {
+		// Malformed base URL (no "://") — return it unchanged for both.
 		return baseURL, baseURL
 	}
-	scheme := baseURL[:i]
-	hostAndPort := baseURL[i+len(sep):]
-	host := hostAndPort
-	port := ""
-	if c := strings.LastIndex(hostAndPort, ":"); c > 0 {
-		host = hostAndPort[:c]
-		port = hostAndPort[c:] // includes ':'
-	}
-	// Only emit subdomain URLs when the deployment actually routes by subdomain.
-	// Otherwise (path-based, incl. a single-tenant box on a real domain) links
-	// must stay path-based — never guess subdomain from the host shape alone.
-	canSubdomain := subdomainRouting &&
-		strings.Contains(host, ".") &&
-		!strings.HasPrefix(host, "localhost") &&
-		!isIPLiteral(host)
 	if canSubdomain {
 		apex := strings.TrimPrefix(host, "www.")
 		sub := fmt.Sprintf("%s://%s.%s%s", scheme, org.Slug, apex, port)
 		return sub, sub
 	}
 	return baseURL + "/" + org.Slug, baseURL
+}
+
+// resolveSubdomainHost parses a "scheme://host:port" base URL and reports
+// whether this deployment can serve a tenant on a wildcard subdomain of it.
+// It is the single source of truth for the subdomain-vs-path decision shared by
+// orgURLs and orgTokenRedirectURL — each previously computed it independently,
+// which let the same "ignore subdomainRouting" bug ship in two copies (#108).
+// A zero scheme ("") signals a malformed base URL (no "://").
+func resolveSubdomainHost(baseURL string, subdomainRouting bool) (scheme, host, port string, canSubdomain bool) {
+	const sep = "://"
+	i := strings.Index(baseURL, sep)
+	if i < 0 {
+		return "", "", "", false
+	}
+	scheme = baseURL[:i]
+	hostAndPort := baseURL[i+len(sep):]
+	host = hostAndPort
+	if c := strings.LastIndex(hostAndPort, ":"); c > 0 {
+		host = hostAndPort[:c]
+		port = hostAndPort[c:] // includes ':'
+	}
+	// Only route by subdomain when the deployment actually does — never guess
+	// from the host shape alone (a real domain with routing off stays path-based).
+	canSubdomain = subdomainRouting &&
+		strings.Contains(host, ".") &&
+		!strings.HasPrefix(host, "localhost") &&
+		!isIPLiteral(host)
+	return scheme, host, port, canSubdomain
 }
 
 func (s *Server) storeForOrg(ctx context.Context, orgID int) (*store.Store, error) {

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -98,7 +98,7 @@ func (s *Server) orgMail(ctx context.Context, orgID int) orgMailCtx {
 	if color, err := s.db.GetOrgSetting(ctx, orgID, "branding_color"); err == nil {
 		m.Branding.Color = color
 	}
-	m.AppURL, m.PublicURL = orgURLs(raw, org)
+	m.AppURL, m.PublicURL = orgURLs(raw, org, s.subdomainRouting)
 	return m
 }
 
@@ -108,10 +108,11 @@ func (s *Server) orgMail(ctx context.Context, orgID int) orgMailCtx {
 //   - subdomain host: https://<slug>.<apex> for both (the org IS the host)
 //   - path-based:     <base>/<slug> for app pages, <base> for public pages
 //
-// The subdomain-vs-path decision uses the same heuristic as the post-OIDC
-// redirect (orgTokenRedirectURL): a dotted, non-localhost, non-IP host can serve
-// per-org subdomains.
-func orgURLs(baseURL string, org *db.Organization) (app, public string) {
+// Subdomain URLs are used only when subdomainRouting is enabled (the deployment
+// actually serves tenants on wildcard subdomains); otherwise links stay
+// path-based, so the generated URL always matches how requests are routed —
+// never inferred from the host shape alone.
+func orgURLs(baseURL string, org *db.Organization, subdomainRouting bool) (app, public string) {
 	if org.Domain != nil && *org.Domain != "" {
 		d := *org.Domain
 		if !strings.Contains(d, "://") {
@@ -137,7 +138,11 @@ func orgURLs(baseURL string, org *db.Organization) (app, public string) {
 		host = hostAndPort[:c]
 		port = hostAndPort[c:] // includes ':'
 	}
-	canSubdomain := strings.Contains(host, ".") &&
+	// Only emit subdomain URLs when the deployment actually routes by subdomain.
+	// Otherwise (path-based, incl. a single-tenant box on a real domain) links
+	// must stay path-based — never guess subdomain from the host shape alone.
+	canSubdomain := subdomainRouting &&
+		strings.Contains(host, ".") &&
 		!strings.HasPrefix(host, "localhost") &&
 		!isIPLiteral(host)
 	if canSubdomain {


### PR DESCRIPTION
Closes #108.

**Bug.** `orgURLs` (notification/email links) and `orgTokenRedirectURL` (post-OIDC redirect) decided subdomain-vs-path from the **host shape** (dotted, non-localhost, non-IP → subdomain) and never read `ISMS_SUBDOMAIN_ROUTING`. On a path-based single-tenant box on a real domain (`isms.stsplatform.com`, routing off) they generated subdomain links like `https://sts.isms.stsplatform.com` — which don't resolve (no wildcard). Surfaced by the STS migration; affects Slack/email links (#104/#16).

**Fix.** Both functions now gate the subdomain branch on `subdomainRouting`, so a generated URL always matches how requests are actually routed — the config is the single source of truth, not a guess from the hostname. Custom-domain and path-based behaviour unchanged.

**Test.** `orgurls_test.go` gains a routing-off case (real domain → path-based). go build + vet + `TestOrgURLs` green; gofmt clean. Backend-only, no DB migration.