### PR TITLE
feat(review): @-mention members in review comments → notification (#4, slice 1)

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -81,7 +81,7 @@ var mentionRe = regexp.MustCompile(`@([a-zA-Z0-9._-]+)`)
 // @-mentioned in a review comment (#4), excluding the comment's author. Matching
 // is case-insensitive against the member's email local-part or name-slug.
 func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, actor, body string) {
-	matches := mentionRe.FindAllStringSubmatch(body, -1)
+	matches := mentionRe.FindAllStringSubmatchIndex(body, -1)
 	if len(matches) == 0 {
 		return
 	}
@@ -89,26 +89,38 @@ func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, 
 	if err != nil {
 		return
 	}
-	byHandle := map[string]string{} // handle → email
+	// Keep email local-parts and name-slugs in SEPARATE maps. One member's email
+	// local-part can equal another member's name-slug ("alicesmith@…" vs "Alice
+	// Smith"); merging both into one map would let whichever sorts later silently
+	// overwrite the other and mis-route the mention. Local-parts are unique
+	// (emails are), so prefer them and only fall back to a name-slug on a miss.
+	byLocal := map[string]string{}
+	bySlug := map[string]string{}
 	for _, u := range users {
 		local := u.Email
 		if at := strings.IndexByte(local, '@'); at > 0 {
 			local = local[:at]
 		}
-		byHandle[strings.ToLower(local)] = u.Email
+		byLocal[strings.ToLower(local)] = u.Email
 		if slug := strings.ToLower(strings.ReplaceAll(u.Name, " ", "")); slug != "" {
-			byHandle[slug] = u.Email
+			bySlug[slug] = u.Email
 		}
 	}
-	snippet := body
-	if len(snippet) > 200 {
-		snippet = snippet[:200] + "…"
-	}
+	snippet := truncateStr(body, 200)
 	title := fmt.Sprintf("%s mentioned you in a review comment", actor)
 	link := fmt.Sprintf("/reviews/%d", reviewID)
 	notified := map[string]bool{}
 	for _, m := range matches {
-		email, ok := byHandle[strings.ToLower(m[1])]
+		// Skip "@scope/pkg" tokens (e.g. @babel/core): a '/' right after the
+		// handle marks a package path or URL segment, not a mention.
+		if end := m[3]; end < len(body) && body[end] == '/' {
+			continue
+		}
+		handle := strings.ToLower(body[m[2]:m[3]])
+		email, ok := byLocal[handle]
+		if !ok {
+			email, ok = bySlug[handle]
+		}
 		if !ok || email == actor || notified[email] {
 			continue // unknown handle, self-mention, or already notified
 		}
@@ -834,8 +846,12 @@ func (s *Server) handleAddReviewComment(c echo.Context) error {
 		Detail:     detail,
 	})
 
-	// Notify anyone @-mentioned in the comment (#4).
-	s.notifyReviewMentions(ctx, orgID, id, actor, req.Body)
+	// Notify anyone @-mentioned in the comment or its suggested replacement (#4).
+	mentionText := req.Body
+	if req.SuggestionBody != nil && *req.SuggestionBody != "" {
+		mentionText += "\n" + *req.SuggestionBody
+	}
+	s.notifyReviewMentions(ctx, orgID, id, actor, mentionText)
 
 	return c.JSON(http.StatusCreated, comment)
 }

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -73,6 +73,50 @@ func docLink(docID string) string {
 	}
 }
 
+// mentionRe matches @handle tokens in a comment body. A handle is a member's
+// email local-part (maria@… → @maria) or their name with spaces removed.
+var mentionRe = regexp.MustCompile(`@([a-zA-Z0-9._-]+)`)
+
+// notifyReviewMentions creates an in-app notification for each org member
+// @-mentioned in a review comment (#4), excluding the comment's author. Matching
+// is case-insensitive against the member's email local-part or name-slug.
+func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, actor, body string) {
+	matches := mentionRe.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return
+	}
+	users, err := s.db.ListOrgUsers(ctx, orgID)
+	if err != nil {
+		return
+	}
+	byHandle := map[string]string{} // handle → email
+	for _, u := range users {
+		local := u.Email
+		if at := strings.IndexByte(local, '@'); at > 0 {
+			local = local[:at]
+		}
+		byHandle[strings.ToLower(local)] = u.Email
+		if slug := strings.ToLower(strings.ReplaceAll(u.Name, " ", "")); slug != "" {
+			byHandle[slug] = u.Email
+		}
+	}
+	snippet := body
+	if len(snippet) > 200 {
+		snippet = snippet[:200] + "…"
+	}
+	title := fmt.Sprintf("%s mentioned you in a review comment", actor)
+	link := fmt.Sprintf("/reviews/%d", reviewID)
+	notified := map[string]bool{}
+	for _, m := range matches {
+		email, ok := byHandle[strings.ToLower(m[1])]
+		if !ok || email == actor || notified[email] {
+			continue // unknown handle, self-mention, or already notified
+		}
+		notified[email] = true
+		_ = s.db.CreateNotificationByEmail(ctx, orgID, email, title, snippet, link)
+	}
+}
+
 // getUserEmail extracts the authenticated user email from context or headers.
 func getUserEmail(c echo.Context) string {
 	// Set by token auth middleware
@@ -789,6 +833,9 @@ func (s *Server) handleAddReviewComment(c echo.Context) error {
 		Action:     action,
 		Detail:     detail,
 	})
+
+	// Notify anyone @-mentioned in the comment (#4).
+	s.notifyReviewMentions(ctx, orgID, id, actor, req.Body)
 
 	return c.JSON(http.StatusCreated, comment)
 }

--- a/internal/isms/db/notifications.go
+++ b/internal/isms/db/notifications.go
@@ -56,7 +56,9 @@ func (d *DB) ListNotifications(ctx context.Context, orgID int, userID int, unrea
 	}
 	defer rows.Close()
 
-	var notifications []Notification
+	// Initialise (not a nil slice) so an empty result serialises as JSON [] not
+	// null — frontend/tests can iterate the result without a null guard.
+	notifications := []Notification{}
 	for rows.Next() {
 		var n Notification
 		if err := rows.Scan(&n.ID, &n.OrganizationID, &n.RecipientID, &n.Title, &n.Body, &n.Link, &n.Read, &n.CreatedAt); err != nil {

--- a/tests/test_review_mentions.py
+++ b/tests/test_review_mentions.py
@@ -1,0 +1,63 @@
+"""Regression for #4: @-mentioning an org member in a review comment notifies them.
+
+The commenter writes "@handle …" (handle = the member's email local-part). The
+mentioned member gets an in-app notification linking to the review. Handles that
+don't match a member, and self-mentions, produce no notification.
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL, READER_EMAIL
+
+
+def _notifications(api_url, headers):
+    r = requests.get(f"{api_url}/notifications", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    return body.get("data", body) if isinstance(body, dict) else body
+
+
+def test_review_comment_mention_notifies_the_member(api_url, admin_headers, reader_headers):
+    suffix = uuid.uuid4().hex[:8]
+    doc_id = f"mention-{suffix}"
+    r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "Mention test", "content": "# Mention test\n\nbody",
+    })
+    assert r.status_code in (200, 201), r.text
+
+    rid = requests.post(f"{api_url}/documents/{doc_id}/reviews", headers=admin_headers,
+                        json={"reviewers": [READER_EMAIL], "message": "review"}).json()["review_id"]
+
+    handle = READER_EMAIL.split("@")[0]  # "testreviewer"
+    c = requests.post(f"{api_url}/reviews/{rid}/comment", headers=admin_headers,
+                      json={"body": f"@{handle} please take a look"})
+    assert c.status_code in (200, 201), c.text
+
+    # The mentioned reader has a notification linking to this review.
+    items = _notifications(api_url, reader_headers)
+    assert any("mentioned you" in (n.get("title", "")) and f"/reviews/{rid}" in (n.get("link") or "")
+               for n in items), f"reader should have a mention notification for review {rid}"
+
+
+def test_unknown_handle_and_self_mention_produce_no_notification(api_url, admin_headers):
+    suffix = uuid.uuid4().hex[:8]
+    doc_id = f"mention-none-{suffix}"
+    r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "Mention none", "content": "# x\n\nbody",
+    })
+    assert r.status_code in (200, 201), r.text
+    rid = requests.post(f"{api_url}/documents/{doc_id}/reviews", headers=admin_headers,
+                        json={"reviewers": [READER_EMAIL], "message": "review"}).json()["review_id"]
+
+    admin_handle = ADMIN_EMAIL.split("@")[0]
+    # Unknown handle + a self-mention by the admin author — neither should notify anyone.
+    c = requests.post(f"{api_url}/reviews/{rid}/comment", headers=admin_headers,
+                      json={"body": f"@nobody-{suffix} and @{admin_handle} (me) — no pings"})
+    assert c.status_code in (200, 201), c.text
+
+    # Admin (the author) must not have self-notified for this review.
+    items = _notifications(api_url, admin_headers)
+    assert not any(f"/reviews/{rid}" in (n.get("link") or "") for n in items), \
+        "author self-mention must not create a notification"

--- a/tests/test_review_mentions.py
+++ b/tests/test_review_mentions.py
@@ -14,7 +14,8 @@ def _notifications(api_url, headers):
     r = requests.get(f"{api_url}/notifications", headers=headers)
     assert r.status_code == 200, r.text
     body = r.json()
-    return body.get("data", body) if isinstance(body, dict) else body
+    items = body.get("data", body) if isinstance(body, dict) else body
+    return items or []  # GET /notifications serialises an empty result as null
 
 
 def test_review_comment_mention_notifies_the_member(api_url, admin_headers, reader_headers):
@@ -61,3 +62,29 @@ def test_unknown_handle_and_self_mention_produce_no_notification(api_url, admin_
     items = _notifications(api_url, admin_headers)
     assert not any(f"/reviews/{rid}" in (n.get("link") or "") for n in items), \
         "author self-mention must not create a notification"
+
+
+def test_scoped_package_token_is_not_a_mention(api_url, admin_headers, reader_headers):
+    """`@handle/...` (e.g. @babel/core) is a package path, not a mention (#4 review)."""
+    suffix = uuid.uuid4().hex[:8]
+    doc_id = f"mention-scope-{suffix}"
+    r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+        "folder": "iso27001", "filename": f"{doc_id}.md",
+        "document_id": doc_id, "title": "Mention scope", "content": "# x\n\nbody",
+    })
+    assert r.status_code in (200, 201), r.text
+    rid = requests.post(f"{api_url}/documents/{doc_id}/reviews", headers=admin_headers,
+                        json={"reviewers": [READER_EMAIL], "message": "review"}).json()["review_id"]
+
+    # The reader's handle followed by "/..." must read as a package path, not a ping.
+    handle = READER_EMAIL.split("@")[0]
+    c = requests.post(f"{api_url}/reviews/{rid}/comment", headers=admin_headers,
+                      json={"body": f"see @{handle}/core for the config, not a mention"})
+    assert c.status_code in (200, 201), c.text
+
+    # The reader is a reviewer, so they legitimately have a review-assignment
+    # notification for this rid — assert only that no *mention* notification exists.
+    items = _notifications(api_url, reader_headers)
+    assert not any("mentioned you" in (n.get("title", "")) and f"/reviews/{rid}" in (n.get("link") or "")
+                   for n in items), \
+        "a @handle/pkg token must not create a mention notification"


### PR DESCRIPTION
Part of #4.

Typing `@handle` in a review comment now notifies that org member. `notifyReviewMentions` parses `@handle` tokens, resolves each against org members (email local-part — `maria@… → @maria` — or name-slug, case-insensitive), and creates an in-app notification linking to the review. Self-mentions and unknown handles are ignored. Surfaces in the existing notification bell.

Uses the existing `notifications` table + `CreateNotificationByEmail` — **no DB migration**.

**Tests:** `tests/test_review_mentions.py` — a mention notifies the member (with the `/reviews/<id>` link); an unknown handle and an author self-mention produce nothing. Green twice against the stack; runs in CI.

**Scope:** slice 1 = review-comment mentions (the notify core; works today by typing `@handle`). Follow-up slices: frontend @autocomplete in the comment box, and mentions in rollback plans / change requests (the rest of #4).