### PR TITLE
fix(auth): hide signup UI when self-registration is disabled (#111)

### DIFF
--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -865,10 +865,18 @@ func (s *Server) handleGetConfig(c echo.Context) error {
 		// for demo / dev where wildcard DNS + TLS isn't set up.
 		SubdomainRouting bool   `json:"subdomain_routing"`
 		ApexHost         string `json:"apex_host,omitempty"`
+
+		// Whether self-registration is enabled (ISMS_USER_SIGNUP). The frontend
+		// hides the "Sign up" affordances when this is false — the signup handler
+		// itself is the hard gate (403), this just keeps the UI honest.
+		SignupEnabled bool `json:"signup_enabled"`
 	}
 	resp := configResponse{}
 	resp.SubdomainRouting = s.subdomainRouting
 	resp.ApexHost = s.apexHost
+	if sv := os.Getenv("ISMS_USER_SIGNUP"); sv == "true" || sv == "1" {
+		resp.SignupEnabled = true
+	}
 
 	// Branding from org settings (Postgres)
 	branding := map[string]string{}

--- a/tests/test_signup_config.py
+++ b/tests/test_signup_config.py
@@ -1,0 +1,35 @@
+"""Regression: /config must report signup_enabled, and it must match the gate.
+
+The bug: the login/signup UI hard-coded a "Sign up" link, so a deployment with
+ISMS_USER_SIGNUP unset (self-registration off) still advertised signup even
+though POST /auth/signup returns 403. /config now exposes `signup_enabled` so the
+frontend can hide the affordance. This test pins the flag to the real gate: the
+value /config reports must agree with whether the signup endpoint accepts a
+registration (403 = disabled, anything else = enabled).
+"""
+import uuid
+
+import requests
+
+
+def test_config_signup_enabled_matches_gate(api_url):
+    cfg = requests.get(f"{api_url}/config")
+    assert cfg.status_code == 200, cfg.text
+    body = cfg.json()
+    assert "signup_enabled" in body, "/config must expose signup_enabled"
+    enabled = body["signup_enabled"]
+    assert isinstance(enabled, bool), f"signup_enabled must be a bool, got {enabled!r}"
+
+    # Probe the actual gate with a throwaway registration.
+    email = f"signup-probe-{uuid.uuid4().hex[:8]}@isms-test.local"
+    r = requests.post(f"{api_url}/auth/signup",
+                      json={"email": email, "name": "Probe", "password": "probe-pw-123"})
+
+    if enabled:
+        # Flag says on → the endpoint must NOT be gated off (403).
+        assert r.status_code != 403, \
+            f"signup_enabled=true but /auth/signup returned 403: {r.text}"
+    else:
+        # Flag says off → the endpoint must be gated (403).
+        assert r.status_code == 403, \
+            f"signup_enabled=false but /auth/signup returned {r.status_code}: {r.text}"

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -38,7 +38,7 @@
         Living documents, tracked reviews, and operational cadence in one auditable platform. Pick a framework or bring your own. AI helps with the work. Humans stay in control.
       </p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
-        <router-link to="/signup"
+        <router-link v-if="signupEnabled" to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
           Start in cloud
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"/></svg>
@@ -133,7 +133,8 @@
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
           <h3 class="text-lg font-semibold mb-2">Managed cloud</h3>
           <p class="text-sm text-slate-400 leading-relaxed mb-4">Sign up, pick your framework, start working. We handle infrastructure, backups, and updates. Multi-tenant with row-level data isolation.</p>
-          <router-link to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Start free &rarr;</router-link>
+          <router-link v-if="signupEnabled" to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Start free &rarr;</router-link>
+          <router-link v-else to="/login" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Sign in &rarr;</router-link>
         </div>
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
           <h3 class="text-lg font-semibold mb-2">Self-hosted</h3>
@@ -148,7 +149,7 @@
       <h2 class="text-4xl font-bold mb-4">Your auditor will thank you</h2>
       <p class="text-slate-400 mb-8">Full version history. Immutable approval records. Cryptographically verifiable decisions. Complete audit trail from day one.</p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
-        <router-link to="/signup"
+        <router-link v-if="signupEnabled" to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
           Start in cloud
         </router-link>
@@ -180,6 +181,7 @@ const brandFooter = ref('')
 const logoUrl = ref(null)
 const logoError = ref(false)
 const showPoweredBy = ref(true)
+const signupEnabled = ref(false)
 
 const features = [
   { title: 'Git-native documents', desc: 'Policies are markdown files in a git repo. Every change is a commit with full diff. Branch for review, merge to publish. No proprietary formats, no lock-in.' },
@@ -217,6 +219,7 @@ onMounted(async () => {
     if (cfg.branding?.branding_color) document.documentElement.style.setProperty('--brand-color', cfg.branding.branding_color)
     logoUrl.value = cfg.branding?.branding_logo || ''
     showPoweredBy.value = cfg.show_powered_by !== false
+    signupEnabled.value = cfg.signup_enabled === true
   } catch {
     // Config endpoint may not be available pre-auth
   }

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -31,7 +31,7 @@
             Continue
           </button>
         </form>
-        <div class="text-sm text-slate-500 mt-6">
+        <div v-if="signupEnabled" class="text-sm text-slate-500 mt-6">
           Don't have an account?
           <router-link to="/signup" class="brand-text hover:brightness-125 transition-colors">Get started</router-link>
         </div>
@@ -190,7 +190,7 @@
             Forgot password?
           </router-link>
         </div>
-        <div class="text-sm text-slate-500">
+        <div v-if="signupEnabled" class="text-sm text-slate-500">
           Don't have an account?
           <router-link to="/signup" class="brand-text hover:brightness-125 transition-colors">Sign up</router-link>
         </div>
@@ -230,6 +230,7 @@ const orgSlug = ref('')
 const logoUrl = ref(null)
 const logoError = ref(false)
 const showPoweredBy = ref(true)
+const signupEnabled = ref(false)
 
 // Signup
 const oidcProviders = ref([])
@@ -481,6 +482,7 @@ onMounted(async () => {
     if (cfg.branding?.branding_color) document.documentElement.style.setProperty('--brand-color', cfg.branding.branding_color)
     logoUrl.value = cfg.branding?.branding_logo || ''
     showPoweredBy.value = cfg.show_powered_by !== false
+    signupEnabled.value = cfg.signup_enabled === true
     if (cfg.terms_url) termsUrl.value = cfg.terms_url
     else if (cfg.has_terms) termsUrl.value = '/terms'
     if (cfg.privacy_url) privacyUrl.value = cfg.privacy_url

--- a/web/src/views/Signup.vue
+++ b/web/src/views/Signup.vue
@@ -58,7 +58,10 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import api from '../api'
+
+const router = useRouter()
 
 const name = ref('')
 const email = ref('')
@@ -97,6 +100,12 @@ async function doSignup() {
 onMounted(async () => {
   try {
     const cfg = await api.getConfig()
+    // Self-registration disabled (ISMS_USER_SIGNUP unset) — the signup endpoint
+    // 403s anyway; don't dangle a dead form. Send them to the login page.
+    if (cfg.signup_enabled !== true) {
+      router.replace('/login')
+      return
+    }
     if (cfg.organization?.name) orgName.value = cfg.organization.name
     if (cfg.organization_name) orgName.value = cfg.organization_name
     if (cfg.branding?.branding_name) orgName.value = cfg.branding.branding_name

--- a/web/src/views/Signup.vue
+++ b/web/src/views/Signup.vue
@@ -117,7 +117,8 @@ onMounted(async () => {
     if (cfg.privacy_url) privacyUrl.value = cfg.privacy_url
     else if (cfg.has_privacy) privacyUrl.value = '/privacy'
   } catch {
-    // Public config endpoint may be limited
+    // Config unreachable — fail closed, same as signup_enabled === false.
+    router.replace('/login')
   }
 })
 </script>


### PR DESCRIPTION
Fixes #111.

With `ISMS_USER_SIGNUP` unset, the login page still showed `Don't have an account? Sign up` and `/signup` rendered a live form — even though `POST /auth/signup` returns 403. The UI had no signal for the flag. Surfaced live on isms.stsplatform.com.

**Change:** `/api/v1/config` now reports `signup_enabled` (derived from `ISMS_USER_SIGNUP`, same source as the signup handler's own 403 gate).
- **Login.vue** — hides both `Don't have an account?` blocks when disabled.
- **Signup.vue** — redirects to `/login` when disabled (no dangling form).
- **Landing.vue** — cloud CTAs (`Start in cloud` / `Start free`) hide; the managed-cloud card falls back to `Sign in`.

The redirect query-param (`?redirect=/sts`) was read correctly all along — this was purely the missing flag.

**No DB migration.**

**Tests:** `tests/test_signup_config.py` — `/config`'s `signup_enabled` must agree with the real `/auth/signup` gate (403 iff disabled). Green against the stack; runs in CI.