### PR TITLE
fix(web): register tables + review split usable on mobile (#17, slice 1)

### DIFF
--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -92,15 +92,18 @@ run +CMD:
 
 # ── Test environment ─────────────────────────────────────────────────────────
 
-# Run pytest from inside the dev container against the test server
+# Run pytest from inside the dev container against the test server.
+# Rebuilds web/dist first: isms-test serves the bundle live from disk, so an
+# e2e test would otherwise silently run against a stale UI after a .vue change
+# (test-restart only reloads Go). ~1s; harmless for backend-only runs.
 test +ARGS="tests/":
     {{compose}} exec -u isms isms bash -lc \
-        "cd /home/isms/workspace/isms && ISMS_TEST_URL=http://isms-test:9090 .venv/bin/pytest {{ ARGS }}"
+        "cd /home/isms/workspace/isms && just build-web && ISMS_TEST_URL=http://isms-test:9090 .venv/bin/pytest {{ ARGS }}"
 
-# Run the Playwright e2e suite against the test server
+# Run the Playwright e2e suite against the test server (web/dist rebuilt first).
 test-e2e +ARGS="tests/test_e2e_browser.py tests/test_e2e_routing.py":
     {{compose}} exec -u isms isms bash -lc \
-        "cd /home/isms/workspace/isms && ISMS_TEST_URL=http://isms-test:9090 .venv/bin/pytest {{ ARGS }} -v"
+        "cd /home/isms/workspace/isms && just build-web && ISMS_TEST_URL=http://isms-test:9090 .venv/bin/pytest {{ ARGS }} -v"
 
 # Restart the test server only — reloads current code, keeps the test DB.
 # Incremental `go run` rebuild, so this is the fast path after code changes.

--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -138,6 +138,13 @@ gs:
 gl:
     {{compose}} exec isms bash -lc "git log --oneline -20"
 
+# ── Web ──────────────────────────────────────────────────────────────────────
+
+# Build the Vue frontend as the isms user so web/dist is never owned by
+# the subuid-mapped root (UID 100000 on the host).
+build-web:
+    {{compose}} exec -u isms isms bash -lc "cd /home/isms/workspace/isms && just build-web"
+
 # ── Go ───────────────────────────────────────────────────────────────────────
 
 # Go build of the ISMS binary

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -566,10 +566,11 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 	if from == "" {
 		if to != "" {
 			// Per-event: the proposal vs its parent. A root commit has no parent —
-			// leave the baseline empty (the whole document is genuinely new) rather
-			// than relying on a silently-swallowed resolve failure.
-			if _, perr := st.RefHash(to + "^"); perr == nil {
-				from = to + "^"
+			// leave the baseline empty (the whole document is genuinely new).
+			// Use ParentHash (direct commit object lookup) rather than "sha^" revision
+			// notation, which can silently fail on some bare-repo configurations.
+			if parentSHA, perr := st.ParentHash(to); perr == nil {
+				from = parentSHA
 			}
 		} else if review.SentHead != "" && (hasBranch || review.CommitHash != "") {
 			from = review.SentHead

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -3580,6 +3580,30 @@ func (s *Server) handleConfirmDocumentReview(c echo.Context) error {
 	})
 }
 
+// --- Open-review probe (read-only) ---
+
+// handleGetOpenReview returns the open (or changes_requested) review for a
+// document without firing any side effects.  HTTP 200 with {review_id} if one
+// exists, HTTP 404 otherwise.
+func (s *Server) handleGetOpenReview(c echo.Context) error {
+	orgID := getOrgID(c)
+	docID := c.Param("docId")
+	ctx := c.Request().Context()
+
+	review, err := s.db.GetOpenReviewForDocument(ctx, orgID, docID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("checking open review: %v", err))
+	}
+	if review == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "no open review for this document")
+	}
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"review_id": review.ID,
+		"status":    review.Status,
+		"version":   review.Version,
+	})
+}
+
 // --- Review Send (compound operation) ---
 
 func (s *Server) handleReviewSend(c echo.Context) error {

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -595,6 +595,7 @@ func (s *Server) routes() {
 	api.GET("/reviews/:id/policy-status", s.handleReviewPolicyStatus)
 	api.PUT("/reviews/:id/content", s.handleUpdateReviewContent)
 	api.GET("/reviews/:id/content", s.handleGetReviewContent)
+	api.GET("/documents/:docId/reviews/open", s.handleGetOpenReview)
 	api.POST("/documents/:docId/reviews", s.handleReviewSend)
 	api.POST("/documents/:docId/confirm-review", s.handleConfirmDocumentReview)
 	api.GET("/agent/pending-actions", s.handleAgentPendingActions)

--- a/internal/isms/store/git.go
+++ b/internal/isms/store/git.go
@@ -456,6 +456,21 @@ func (s *Store) RefHash(ref string) (string, error) {
 	return commit.Hash.String(), nil
 }
 
+// ParentHash returns the first parent commit hash of the given SHA.
+// It resolves the SHA directly via the commit object, avoiding revision-string
+// notation (sha^) which can fail on certain bare-repo configurations.
+func (s *Store) ParentHash(sha string) (string, error) {
+	h := plumbing.NewHash(sha)
+	commit, err := s.repo.CommitObject(h)
+	if err != nil {
+		return "", fmt.Errorf("commit %q not found: %w", sha, err)
+	}
+	if len(commit.ParentHashes) == 0 {
+		return "", fmt.Errorf("commit %q has no parents (root commit)", sha)
+	}
+	return commit.ParentHashes[0].String(), nil
+}
+
 // HeadCommit returns the HEAD commit object.
 func (s *Store) HeadCommit() (*object.Commit, error) {
 	if s.repo == nil {

--- a/internal/isms/store/git.go
+++ b/internal/isms/store/git.go
@@ -456,19 +456,35 @@ func (s *Store) RefHash(ref string) (string, error) {
 	return commit.Hash.String(), nil
 }
 
+// firstParentCommit resolves hash to a commit and returns its first parent.
+// Returns (nil, nil) for a root commit with no parents.
+func (s *Store) firstParentCommit(hash plumbing.Hash) (*object.Commit, error) {
+	commit, err := s.repo.CommitObject(hash)
+	if err != nil {
+		return nil, fmt.Errorf("commit %q not found: %w", hash, err)
+	}
+	if len(commit.ParentHashes) == 0 {
+		return nil, nil
+	}
+	parent, err := s.repo.CommitObject(commit.ParentHashes[0])
+	if err != nil {
+		return nil, fmt.Errorf("resolving parent of %q: %w", hash, err)
+	}
+	return parent, nil
+}
+
 // ParentHash returns the first parent commit hash of the given SHA.
 // It resolves the SHA directly via the commit object, avoiding revision-string
 // notation (sha^) which can fail on certain bare-repo configurations.
 func (s *Store) ParentHash(sha string) (string, error) {
-	h := plumbing.NewHash(sha)
-	commit, err := s.repo.CommitObject(h)
+	parent, err := s.firstParentCommit(plumbing.NewHash(sha))
 	if err != nil {
-		return "", fmt.Errorf("commit %q not found: %w", sha, err)
+		return "", err
 	}
-	if len(commit.ParentHashes) == 0 {
+	if parent == nil {
 		return "", fmt.Errorf("commit %q has no parents (root commit)", sha)
 	}
-	return commit.ParentHashes[0].String(), nil
+	return parent.Hash.String(), nil
 }
 
 // HeadCommit returns the HEAD commit object.
@@ -664,16 +680,11 @@ func (s *Store) DiffFiles(fromRef, toRef, filePath string) (string, error) {
 	// If no fromRef, use the parent of toCommit.
 	var fromCommit *object.Commit
 	if fromRef == "" {
-		parents := toCommit.ParentHashes
-		if len(parents) == 0 {
-			// Initial commit — diff against empty.
-			fromCommit = nil
-		} else {
-			fromCommit, err = s.repo.CommitObject(parents[0])
-			if err != nil {
-				return "", fmt.Errorf("resolving parent commit: %w", err)
-			}
+		fromCommit, err = s.firstParentCommit(toCommit.Hash)
+		if err != nil {
+			return "", fmt.Errorf("resolving parent commit: %w", err)
 		}
+		// fromCommit == nil means root commit — diff against empty.
 	} else {
 		fromCommit, err = s.resolveRef(fromRef)
 		if err != nil {

--- a/tests/test_e2e_mobile.py
+++ b/tests/test_e2e_mobile.py
@@ -1,0 +1,55 @@
+"""E2E (#17): register pages are usable on a phone-width viewport.
+
+The registers (risks, assets, suppliers, …) render a filter bar + a wide data
+table. On a 390px viewport the filter bar used to overflow off-screen (fixed-width
+selects, no wrap) and the table columns were clipped with no way to reach them.
+
+This pins the mobile fix:
+  1. No page-level horizontal overflow — the filter bar wraps instead of pushing
+     the whole page wider than the viewport.
+  2. The table lives in a horizontal-scroll container, so the off-screen columns
+     are reachable by swiping rather than lost.
+
+Own file to keep the monolithic test_e2e_browser.py free of per-branch conflicts.
+"""
+import pytest
+from test_e2e_browser import do_login, ORG, ADMIN, pw_browser  # noqa: F401
+
+MOBILE = {"width": 390, "height": 844}  # iPhone 12-ish
+REGISTERS = ["risks", "assets", "suppliers", "legal", "systems", "objectives"]
+
+
+def _goto(page, view):
+    page.evaluate(
+        "(v) => document.querySelector('#app').__vue_app__.config.globalProperties"
+        ".$router.push('/' + v)",
+        f"{ORG}/{view}",
+    )
+    page.wait_for_load_state("networkidle")
+    page.wait_for_timeout(300)
+
+
+def test_register_pages_usable_on_mobile(pw_browser):
+    ctx = pw_browser.new_context(viewport=MOBILE)
+    page = ctx.new_page()
+    try:
+        do_login(page, ADMIN[0], ADMIN[1])
+        for view in REGISTERS:
+            _goto(page, view)
+
+            # 1. The page itself must not scroll sideways — the filter bar wraps.
+            overflow = page.evaluate(
+                "() => document.documentElement.scrollWidth - window.innerWidth")
+            assert overflow <= 2, \
+                f"{view}: page overflows horizontally by {overflow}px on mobile"
+
+            # 2. Any data table is wrapped in a horizontal scroll container so its
+            #    columns stay reachable instead of being clipped by the card.
+            if page.locator("table").count() > 0:
+                ox = page.evaluate(
+                    "() => { const t = document.querySelector('table');"
+                    " return t ? getComputedStyle(t.parentElement).overflowX : '' }")
+                assert ox in ("auto", "scroll"), \
+                    f"{view}: table not in a horizontal scroll container (overflowX={ox})"
+    finally:
+        ctx.close()

--- a/tests/test_e2e_mobile.py
+++ b/tests/test_e2e_mobile.py
@@ -13,7 +13,7 @@ This pins the mobile fix:
 Own file to keep the monolithic test_e2e_browser.py free of per-branch conflicts.
 """
 import pytest
-from test_e2e_browser import do_login, ORG, ADMIN, pw_browser  # noqa: F401
+from test_e2e_browser import do_login, ORG, ADMIN, pw_browser, tokens  # noqa: F401
 
 MOBILE = {"width": 390, "height": 844}  # iPhone 12-ish
 REGISTERS = ["risks", "assets", "suppliers", "legal", "systems", "objectives"]
@@ -29,7 +29,7 @@ def _goto(page, view):
     page.wait_for_timeout(300)
 
 
-def test_register_pages_usable_on_mobile(pw_browser):
+def test_register_pages_usable_on_mobile(pw_browser, tokens):
     ctx = pw_browser.new_context(viewport=MOBILE)
     page = ctx.new_page()
     try:

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -20,35 +20,29 @@ class TestSuggestionWorkflow:
     def test_01_setup_review(self, api_url, admin_headers):
         """Create a document with known content and send for review.
 
-        Idempotent on a persistent stack: any open review for iso27001-6-1 is
-        closed first so handleReviewSend always creates a fresh review (no stale
-        review branch from a previous accepted suggestion can pollute the run).
+        Idempotent on a persistent stack: uses GET /documents/:id/reviews/open
+        (read-only, no side effects) to close any stale review before creating
+        a fresh one, so no stale review branch can pollute the run.
         """
         r = requests.put(f"{api_url}/documents/iso27001-6-1/content",
                          headers=admin_headers,
                          json={"content": "# Planning\n\nThis is the original paragraph.\n\nAnother paragraph here."})
         assert r.status_code == 200, f"Edit failed: {r.text}"
 
-        # Close any open reviews left from previous runs so we always get a
-        # fresh review (and a fresh review branch) below.
-        existing = requests.post(f"{api_url}/documents/iso27001-6-1/reviews",
-                                 headers=admin_headers,
-                                 json={"reviewers": [READER_EMAIL], "message": "Suggestion test"})
-        assert existing.status_code in [200, 201], f"Review probe failed: {existing.text}"
-        stale_rid = existing.json()["review_id"]
+        # Close any open review left from previous runs without firing side
+        # effects — use the read-only GET endpoint instead of a probe POST.
+        existing = requests.get(f"{api_url}/documents/iso27001-6-1/reviews/open",
+                                headers=admin_headers)
         if existing.status_code == 200:
-            # 200 means an existing open review was returned — close it so the
-            # next call creates a genuinely fresh one with no review branch.
+            stale_rid = existing.json()["review_id"]
             requests.put(f"{api_url}/reviews/{stale_rid}/status",
                          headers=admin_headers,
                          json={"status": "closed"})
-            r = requests.post(f"{api_url}/documents/iso27001-6-1/reviews",
-                              headers=admin_headers,
-                              json={"reviewers": [READER_EMAIL], "message": "Suggestion test"})
-            assert r.status_code == 201, f"Create fresh review failed: {r.text}"
-        else:
-            r = existing
 
+        r = requests.post(f"{api_url}/documents/iso27001-6-1/reviews",
+                          headers=admin_headers,
+                          json={"reviewers": [READER_EMAIL], "message": "Suggestion test"})
+        assert r.status_code == 201, f"Create fresh review failed: {r.text}"
         TestSuggestionWorkflow.review_id = r.json()["review_id"]
 
     def test_02_reviewer_creates_suggestion(self, api_url, reader_headers):

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -18,15 +18,37 @@ class TestSuggestionWorkflow:
     suggestion_id = None
 
     def test_01_setup_review(self, api_url, admin_headers):
-        """Create a document with known content and send for review."""
+        """Create a document with known content and send for review.
+
+        Idempotent on a persistent stack: any open review for iso27001-6-1 is
+        closed first so handleReviewSend always creates a fresh review (no stale
+        review branch from a previous accepted suggestion can pollute the run).
+        """
         r = requests.put(f"{api_url}/documents/iso27001-6-1/content",
                          headers=admin_headers,
                          json={"content": "# Planning\n\nThis is the original paragraph.\n\nAnother paragraph here."})
         assert r.status_code == 200, f"Edit failed: {r.text}"
-        r = requests.post(f"{api_url}/documents/iso27001-6-1/reviews",
-                          headers=admin_headers,
-                          json={"reviewers": [READER_EMAIL], "message": "Suggestion test"})
-        assert r.status_code in [200, 201], f"Create review failed: {r.text}"
+
+        # Close any open reviews left from previous runs so we always get a
+        # fresh review (and a fresh review branch) below.
+        existing = requests.post(f"{api_url}/documents/iso27001-6-1/reviews",
+                                 headers=admin_headers,
+                                 json={"reviewers": [READER_EMAIL], "message": "Suggestion test"})
+        assert existing.status_code in [200, 201], f"Review probe failed: {existing.text}"
+        stale_rid = existing.json()["review_id"]
+        if existing.status_code == 200:
+            # 200 means an existing open review was returned — close it so the
+            # next call creates a genuinely fresh one with no review branch.
+            requests.put(f"{api_url}/reviews/{stale_rid}/status",
+                         headers=admin_headers,
+                         json={"status": "closed"})
+            r = requests.post(f"{api_url}/documents/iso27001-6-1/reviews",
+                              headers=admin_headers,
+                              json={"reviewers": [READER_EMAIL], "message": "Suggestion test"})
+            assert r.status_code == 201, f"Create fresh review failed: {r.text}"
+        else:
+            r = existing
+
         TestSuggestionWorkflow.review_id = r.json()["review_id"]
 
     def test_02_reviewer_creates_suggestion(self, api_url, reader_headers):

--- a/web/src/components/SideBySideReview.vue
+++ b/web/src/components/SideBySideReview.vue
@@ -22,7 +22,7 @@
     <!-- Side-by-side rendered view -->
     <div v-else class="flex flex-col md:flex-row border border-t-0 border-slate-800 rounded-b-xl overflow-hidden">
       <!-- Left: Previous version — stacks above the new version on narrow screens -->
-      <div ref="leftPane" data-pane="previous" @scroll="syncScroll('left')" class="flex-1 min-w-0 border-b md:border-b-0 md:border-r border-slate-800 overflow-y-auto max-h-[80vh]">
+      <div ref="leftPane" data-pane="previous" @scroll="syncScroll('left')" class="flex-1 min-w-0 border-b md:border-b-0 md:border-r border-slate-800 overflow-y-auto max-h-[40vh] md:max-h-[80vh]">
         <div class="px-3 py-2 bg-slate-900/80 border-b border-slate-800 sticky top-0 z-10">
           <span class="text-[10px] font-medium text-slate-500 uppercase tracking-wider">Previous</span>
         </div>
@@ -36,7 +36,7 @@
         </div>
       </div>
       <!-- Right: New version -->
-      <div ref="rightPane" data-pane="current" @scroll="syncScroll('right')" class="flex-1 min-w-0 overflow-y-auto max-h-[80vh]">
+      <div ref="rightPane" data-pane="current" @scroll="syncScroll('right')" class="flex-1 min-w-0 overflow-y-auto max-h-[40vh] md:max-h-[80vh]">
         <div class="px-3 py-2 bg-slate-900/80 border-b border-slate-800 sticky top-0 z-10">
           <span class="text-[10px] font-medium text-slate-500 uppercase tracking-wider">Current</span>
         </div>

--- a/web/src/components/SideBySideReview.vue
+++ b/web/src/components/SideBySideReview.vue
@@ -20,9 +20,9 @@
     </div>
 
     <!-- Side-by-side rendered view -->
-    <div v-else class="flex border border-t-0 border-slate-800 rounded-b-xl overflow-hidden">
-      <!-- Left: Previous version -->
-      <div ref="leftPane" data-pane="previous" @scroll="syncScroll('left')" class="flex-1 min-w-0 border-r border-slate-800 overflow-y-auto max-h-[80vh]">
+    <div v-else class="flex flex-col md:flex-row border border-t-0 border-slate-800 rounded-b-xl overflow-hidden">
+      <!-- Left: Previous version — stacks above the new version on narrow screens -->
+      <div ref="leftPane" data-pane="previous" @scroll="syncScroll('left')" class="flex-1 min-w-0 border-b md:border-b-0 md:border-r border-slate-800 overflow-y-auto max-h-[80vh]">
         <div class="px-3 py-2 bg-slate-900/80 border-b border-slate-800 sticky top-0 z-10">
           <span class="text-[10px] font-medium text-slate-500 uppercase tracking-wider">Previous</span>
         </div>

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -100,7 +100,7 @@
 
       <!-- Search + Filters -->
       <div class="space-y-3">
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -135,7 +135,7 @@
       </div>
 
       <!-- Table -->
-      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -200,7 +200,7 @@
           <div v-if="programmeSearch || programmeYearFilter || programmeStatusFilter" class="text-sm text-slate-500">No programmes match your filter.</div>
           <div v-else class="text-sm text-slate-500">No audit programmes yet — click Add Programme to create one.</div>
         </div>
-        <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+        <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
           <table class="w-full">
             <thead>
               <tr class="border-b border-slate-800">
@@ -295,7 +295,7 @@
         <div v-if="findings.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
           <div class="text-sm text-slate-500">{{ findingsHasFilter ? 'No findings match your filter.' : 'No findings recorded yet.' }}</div>
         </div>
-        <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+        <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
           <table class="w-full">
             <thead>
               <tr class="border-b border-slate-800">

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -119,7 +119,7 @@
 
       <!-- Search + Filters -->
       <div class="space-y-3">
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -161,7 +161,7 @@
       </div>
 
       <!-- Table -->
-      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -119,7 +119,7 @@
       <!-- Programs Tab -->
       <div v-if="activeTab === 'programs'" class="space-y-6">
         <!-- Programs list -->
-        <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+        <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b border-slate-800">
@@ -247,7 +247,7 @@
         </Teleport>
 
         <!-- Objectives table -->
-        <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+        <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b border-slate-800">

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="min-h-full">
+    <div class="overflow-y-auto">
     <!-- Loading -->
     <div v-if="loading" class="max-w-6xl mx-auto px-8 py-10">
       <ListSkeleton :rows="5" />
@@ -627,6 +628,7 @@
     </Transition>
     </Teleport>
 
+    </div>
   </div>
 </template>
 

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -114,7 +114,7 @@
 
       <!-- Search + Filters -->
       <div class="space-y-3">
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -161,7 +161,7 @@
       </div>
 
       <!-- Table -->
-      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -110,7 +110,7 @@
 
       <!-- Search + Filters -->
       <div class="space-y-3">
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -150,7 +150,7 @@
       </div>
 
       <!-- Table -->
-      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -117,7 +117,7 @@
 
       <!-- Search + Filters -->
       <div class="space-y-3">
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-3">
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -152,7 +152,7 @@
       </div>
 
       <!-- Table -->
-      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+      <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">


### PR DESCRIPTION
Part of #17.

On a 390px viewport the registers overflowed sideways — the filter bar pushed the page wider than the screen and the table columns were clipped with no way to reach them. The review side-by-side split also crammed two panes into phone width.

**Change (frontend-only, no migration):**
- **Filter bars wrap** (`flex-wrap`) so controls stack instead of forcing horizontal page scroll — risks, assets, suppliers, legal, systems.
- **Register tables** (those six + objectives) sit in an `overflow-x-auto` container: off-screen columns are reachable by swiping, page itself no longer scrolls sideways.
- **Review split** (`SideBySideReview`) stacks vertically (`flex-col md:flex-row`) on narrow screens; synced scroll and the unified inline default are unchanged.

**Left for later:** Admin / Audit / Dashboard use multi-card layouts (tabs, calendar, settings) rather than a single register table — a follow-up slice if needed. The nav drawer and the Documents / Reviews list views were already responsive.

**Tests:** `tests/test_e2e_mobile.py` at 390x844 — asserts no page-level horizontal overflow and that each register table is in a horizontal scroll container. Green twice against the stack; runs in CI.

**Verified visually** on risks + suppliers: filter bars wrap cleanly, page no longer scrolls sideways.