### PR TITLE
fix: log changelog write errors instead of swallowing them (#115)

### DIFF
--- a/internal/isms/api/api_audit.go
+++ b/internal/isms/api/api_audit.go
@@ -288,7 +288,7 @@ func (s *Server) handleCreateAudit(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "audit",
 		EntityID:   int64(out.ID),
 		Action:     "create",
@@ -360,7 +360,7 @@ func (s *Server) handleUpdateAudit(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	if changes := db.DiffFields("audit", int64(id), actor, c.QueryParam("reason"), before.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, changes)
+		s.logChanges(ctx, orgID, changes)
 	}
 	s.logAndNotify(ctx, orgID, &db.Activity{
 		Actor:  actor,
@@ -402,7 +402,7 @@ func (s *Server) handleUpdateAuditStatus(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	if changes := db.DiffFields("audit", int64(id), actor, "", before.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, changes)
+		s.logChanges(ctx, orgID, changes)
 	}
 	s.logAndNotify(ctx, orgID, &db.Activity{
 		Actor:  actor,
@@ -707,7 +707,7 @@ func (s *Server) handleAddAuditFinding(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "audit_finding",
 		EntityID:   int64(out.ID),
 		Action:     "create",
@@ -774,7 +774,7 @@ func (s *Server) handleUpdateAuditFinding(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if changes := db.DiffFields("audit_finding", int64(id), actor, c.QueryParam("reason"), before.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, changes)
+		s.logChanges(ctx, orgID, changes)
 	}
 	if req.Status != nil && before.Status != after.Status {
 		s.logAndNotify(ctx, orgID, &db.Activity{
@@ -818,7 +818,7 @@ func (s *Server) handleUpdateAuditFindingStatus(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	if changes := db.DiffFields("audit_finding", int64(id), actor, "", before.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, changes)
+		s.logChanges(ctx, orgID, changes)
 	}
 	s.logAndNotify(ctx, orgID, &db.Activity{
 		Actor:  actor,
@@ -844,7 +844,7 @@ func (s *Server) handleDeleteAuditFinding(c echo.Context) error {
 	if err := s.db.SoftDeleteAuditFinding(ctx, orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusConflict, err.Error())
 	}
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "audit_finding",
 		EntityID:   int64(id),
 		Action:     "delete",

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -54,6 +55,22 @@ func (s *Server) logAndNotify(ctx context.Context, orgID int, a *db.Activity) {
 				},
 			})
 		}
+	}
+}
+
+// logChange writes a single changelog entry and logs any write error.
+// The main request is never failed on changelog errors — audit trail writes
+// are best-effort and must not block mutations.
+func (s *Server) logChange(ctx context.Context, orgID int, entry *db.ChangelogEntry) {
+	if err := s.db.LogChange(ctx, orgID, entry); err != nil {
+		log.Printf("changelog write error (org %d, entity %s %d): %v", orgID, entry.EntityType, entry.EntityID, err)
+	}
+}
+
+// logChanges writes multiple changelog entries and logs any write error.
+func (s *Server) logChanges(ctx context.Context, orgID int, entries []db.ChangelogEntry) {
+	if err := s.db.LogChanges(ctx, orgID, entries); err != nil {
+		log.Printf("changelog write error (org %d, %d entries): %v", orgID, len(entries), err)
 	}
 }
 
@@ -2060,7 +2077,7 @@ func (s *Server) handleCreateTask(c echo.Context) error {
 
 	s.searchUpsert(orgID, "task", t.Identifier, t.Title, t.Identifier+" "+t.Title+" "+t.Description)
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "task",
 		EntityID:   int64(t.ID),
 		Action:     "create",
@@ -2119,7 +2136,7 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	if changes := db.DiffFields("task", int64(id), actor, "", before.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, changes)
+		s.logChanges(ctx, orgID, changes)
 	}
 	s.logAndNotify(ctx, orgID, &db.Activity{
 		Actor:  actor,
@@ -2218,7 +2235,7 @@ func (s *Server) handleUpdateTask(c echo.Context) error {
 
 	user := getUserEmail(c)
 	diffs := db.DiffFields("task", int64(id), user, "", old.ToChangeMap(), t.ToChangeMap())
-	_ = s.db.LogChanges(ctx, orgID, diffs)
+	s.logChanges(ctx, orgID, diffs)
 
 	s.searchUpsert(orgID, "task", old.Identifier, t.Title, old.Identifier+" "+t.Title+" "+t.Description)
 
@@ -2257,7 +2274,7 @@ func (s *Server) handleDeleteTask(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "task",
 		EntityID:   int64(id),
 		Action:     "delete",
@@ -2451,7 +2468,7 @@ func (s *Server) handleCreateChange(c echo.Context) error {
 		cr = *out
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "change_request",
 		EntityID:   int64(cr.ID),
 		Action:     "create",
@@ -2568,7 +2585,7 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 	actor := getUserEmail(c)
 	diffs := db.DiffFields("change_request", int64(id), actor, "", oldMap, updated.ToChangeMap())
 	if len(diffs) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, diffs)
+		s.logChanges(ctx, orgID, diffs)
 	}
 
 	s.searchUpsert(orgID, "change", updated.Identifier, updated.Title, updated.Identifier+" "+updated.Title+" "+updated.Description)
@@ -2628,7 +2645,7 @@ func (s *Server) handleUpdateChangeStatus(c echo.Context) error {
 	if oldStatus != req.Status {
 		ov := oldStatus
 		nv := req.Status
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "change_request",
 			EntityID:   int64(id),
 			Action:     "update",
@@ -2674,7 +2691,7 @@ func (s *Server) createChangeFollowupTask(ctx context.Context, orgID int, update
 		DueDate:     &due,
 	}
 	if err := s.db.CreateTask(ctx, orgID, t); err == nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "task",
 			EntityID:   int64(t.ID),
 			Action:     "create",
@@ -2718,7 +2735,7 @@ func (s *Server) handleDeleteChange(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "change_request",
 		EntityID:   int64(id),
 		Action:     "delete",

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -144,7 +144,7 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 		ca = *out
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "corrective_action",
 		EntityID:   int64(ca.ID),
 		Action:     "create",
@@ -293,7 +293,7 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("corrective_action", int64(id), actor, reason, oldMap, after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 	}
 
@@ -391,7 +391,7 @@ func (s *Server) handleDeleteCorrectiveAction(c echo.Context) error {
 	}
 
 	if old != nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "corrective_action",
 			EntityID:   int64(old.ID),
 			Action:     "delete",

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -206,7 +206,7 @@ func (s *Server) handleCreateIncident(c echo.Context) error {
 		inc = *out
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "incident",
 		EntityID:   int64(inc.ID),
 		Action:     "create",
@@ -415,7 +415,7 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("incident", int64(id), actor, reason, oldMap, after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 	}
 
@@ -563,7 +563,7 @@ func (s *Server) handleDeleteIncident(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "incident",
 		EntityID:   int64(id),
 		Action:     "delete",

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -154,7 +154,7 @@ func (s *Server) handleCreateLegal(c echo.Context) error {
 	actor := getUserEmail(c)
 	s.createReferencesForEntity(ctx, orgID, "legal_requirement", lr.Identifier, actor, req.References)
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "legal_requirement",
 		EntityID:   int64(lr.ID),
 		Action:     "create",
@@ -295,7 +295,7 @@ func (s *Server) handleUpdateLegal(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("legal_requirement", int64(id), actor, reason, oldMap, after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 	}
 
@@ -337,7 +337,7 @@ func (s *Server) handleDeleteLegal(c echo.Context) error {
 	}
 
 	if lr != nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "legal_requirement",
 			EntityID:   int64(lr.ID),
 			Action:     "delete",

--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -129,7 +129,7 @@ func (s *Server) handleCreateProgram(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "program",
 		EntityID:   p.ID,
 		Action:     "create",
@@ -206,7 +206,7 @@ func (s *Server) handleUpdateProgram(c echo.Context) error {
 		after = &p
 	}
 	diffs := db.DiffFields("program", id, user, "", old.ToChangeMap(), after.ToChangeMap())
-	_ = s.db.LogChanges(ctx, orgID, diffs)
+	s.logChanges(ctx, orgID, diffs)
 
 	return c.JSON(http.StatusOK, after)
 }
@@ -227,7 +227,7 @@ func (s *Server) handleDeleteProgram(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "program",
 		EntityID:   id,
 		Action:     "delete",
@@ -344,7 +344,7 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 	user := getUserEmail(c)
 	s.createReferencesForEntity(ctx, orgID, "objective", o.DisplayID, user, req.References)
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "objective",
 		EntityID:   o.ID,
 		Action:     "create",
@@ -461,7 +461,7 @@ func (s *Server) handleUpdateObjective(c echo.Context) error {
 		after = &o
 	}
 	diffs := db.DiffFields("objective", id, user, "", old.ToChangeMap(), after.ToChangeMap())
-	_ = s.db.LogChanges(ctx, orgID, diffs)
+	s.logChanges(ctx, orgID, diffs)
 
 	return c.JSON(http.StatusOK, after)
 }
@@ -482,7 +482,7 @@ func (s *Server) handleDeleteObjective(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "objective",
 		EntityID:   id,
 		Action:     "delete",
@@ -520,7 +520,7 @@ func (s *Server) handleArchiveObjective(c echo.Context) error {
 
 	user := getUserEmail(c)
 	newStatus := "archived"
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "objective",
 		EntityID:   id,
 		Action:     "update",
@@ -565,7 +565,7 @@ func (s *Server) handleUnarchiveObjective(c echo.Context) error {
 	if after != nil {
 		newStatus = after.Status
 	}
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "objective",
 		EntityID:   id,
 		Action:     "update",
@@ -655,7 +655,7 @@ func (s *Server) handleCreateCheckin(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "checkin",
 		EntityID:   ci.ID,
 		Action:     "create",
@@ -731,7 +731,7 @@ func (s *Server) handleUpdateCheckin(c echo.Context) error {
 
 	user := getUserEmail(c)
 	if changes := db.DiffFields("checkin", id, user, "", existing.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
-		_ = s.db.LogChanges(ctx, orgID, changes)
+		s.logChanges(ctx, orgID, changes)
 	}
 
 	objLabel := fmt.Sprintf("#%d", existing.ObjectiveID)
@@ -763,7 +763,7 @@ func (s *Server) handleDeleteCheckin(c echo.Context) error {
 	}
 
 	user := getUserEmail(c)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "checkin",
 		EntityID:   id,
 		Action:     "delete",

--- a/internal/isms/api/api_readings.go
+++ b/internal/isms/api/api_readings.go
@@ -69,7 +69,7 @@ func (s *Server) handleCreateRiskReading(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, txErr.Error())
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "risk",
 		EntityID:   riskID,
 		Action:     "reading",
@@ -212,7 +212,7 @@ func (s *Server) handleCreateAssetReading(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, txErr.Error())
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "asset",
 		EntityID:   assetID,
 		Action:     "reading",
@@ -336,7 +336,7 @@ func (s *Server) handleCreateLegalReading(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, txErr.Error())
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "legal_requirement",
 		EntityID:   legalID,
 		Action:     "reading",
@@ -439,7 +439,7 @@ func (s *Server) handleCreateSupplierReading(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, txErr.Error())
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "supplier",
 		EntityID:   supplierID,
 		Action:     "reading",
@@ -539,7 +539,7 @@ func (s *Server) handleCreateSystemReading(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, txErr.Error())
 	}
 
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "system",
 		EntityID:   systemID,
 		Action:     "reading",

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1857,7 +1857,7 @@ func (s *Server) handleAddAsset(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	s.createReferencesForEntity(ctx, orgID, "asset", a.Identifier, actor, req.References)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "asset",
 		EntityID:   a.ID,
 		Action:     "create",
@@ -1885,7 +1885,7 @@ func (s *Server) handleDeleteAsset(c echo.Context) error {
 		return pgxHTTPError(err)
 	}
 	if old != nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "asset",
 			EntityID:   old.ID,
 			Action:     "delete",
@@ -2014,7 +2014,7 @@ func (s *Server) handleCreateSystem(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	s.createReferencesForEntity(ctx, orgID, "system", sys.Identifier, actor, req.References)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "system",
 		EntityID:   sys.ID,
 		Action:     "create",
@@ -2162,7 +2162,7 @@ func (s *Server) handleAddRisk(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	s.createReferencesForEntity(ctx, orgID, "risk", r.Identifier, actor, req.References)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "risk",
 		EntityID:   r.ID,
 		Action:     "create",
@@ -2306,7 +2306,7 @@ func (s *Server) handleDeleteRisk(c echo.Context) error {
 		return pgxHTTPError(err)
 	}
 	if old != nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "risk",
 			EntityID:   old.ID,
 			Action:     "delete",
@@ -2428,7 +2428,7 @@ func (s *Server) handleAddSupplier(c echo.Context) error {
 	}
 	actor := getUserEmail(c)
 	s.createReferencesForEntity(ctx, orgID, "supplier", sup.Identifier, actor, req.References)
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "supplier",
 		EntityID:   sup.ID,
 		Action:     "create",
@@ -2522,7 +2522,7 @@ func (s *Server) handleUpdateAsset(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("asset", id, actor, reason, old.ToChangeMap(), after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 		s.searchUpsert(orgID, "asset", after.Identifier, after.Name, after.Identifier+" "+after.Name+" "+after.Description)
 		s.logAndNotify(ctx, orgID, &db.Activity{
@@ -2689,7 +2689,7 @@ func (s *Server) handleUpdateRisk(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("risk", id, actor, reason, old.ToChangeMap(), after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 		s.searchUpsert(orgID, "risk", after.Identifier, after.Title, after.Identifier+" "+after.Title+" "+after.Description+" "+after.Category)
 		s.logAndNotify(ctx, orgID, &db.Activity{
@@ -2804,7 +2804,7 @@ func (s *Server) handleUpdateSystem(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("system", id, actor, reason, old.ToChangeMap(), after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 		s.searchUpsert(orgID, "system", after.Identifier, after.Name, after.Identifier+" "+after.Name+" "+after.Description)
 		s.logAndNotify(ctx, orgID, &db.Activity{
@@ -2832,7 +2832,7 @@ func (s *Server) handleDeleteSystem(c echo.Context) error {
 		return pgxHTTPError(err)
 	}
 	if old != nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "system",
 			EntityID:   old.ID,
 			Action:     "delete",
@@ -2888,7 +2888,7 @@ func (s *Server) handleCreateAccessReview(c echo.Context) error {
 	if err := s.db.CreateAccessReview(ctx, orgID, &ar); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+	s.logChange(ctx, orgID, &db.ChangelogEntry{
 		EntityType: "access_review",
 		EntityID:   ar.ID,
 		Action:     "create",
@@ -3007,7 +3007,7 @@ func (s *Server) handleUpdateSupplier(c echo.Context) error {
 		reason := c.QueryParam("reason")
 		changes := db.DiffFields("supplier", id, actor, reason, old.ToChangeMap(), after.ToChangeMap())
 		if len(changes) > 0 {
-			_ = s.db.LogChanges(ctx, orgID, changes)
+			s.logChanges(ctx, orgID, changes)
 		}
 		s.searchUpsert(orgID, "supplier", after.Identifier, after.Name, after.Identifier+" "+after.Name+" "+after.Notes)
 		s.logAndNotify(ctx, orgID, &db.Activity{
@@ -3035,7 +3035,7 @@ func (s *Server) handleDeleteSupplier(c echo.Context) error {
 		return pgxHTTPError(err)
 	}
 	if old != nil {
-		_ = s.db.LogChange(ctx, orgID, &db.ChangelogEntry{
+		s.logChange(ctx, orgID, &db.ChangelogEntry{
 			EntityType: "supplier",
 			EntityID:   old.ID,
 			Action:     "delete",


### PR DESCRIPTION
## Summary

54 callsites used `_ = s.db.LogChange(...)` / `_ = s.db.LogChanges(...)`, silently discarding any error from audit-trail writes.

Adds `logChange` and `logChanges` helpers on `Server` that log errors with `log.Printf` and return — changelog writes are best-effort and must not block mutations, but errors should be visible in server logs.

All 54 callsites replaced across 8 files.

## Test plan
- [ ] `just test` green
- [ ] `go build ./...` clean