### PR TITLE
fix: self-hosted apex org resolution + operator diagnostics (#119)

### DIFF
--- a/cmd/isms/test_email.go
+++ b/cmd/isms/test_email.go
@@ -11,12 +11,18 @@ import (
 // testEmailCmd sends a test email using the current SMTP_* env vars, so an
 // operator can verify mail delivery without going through the signup flow.
 func testEmailCmd() *cobra.Command {
-	return &cobra.Command{
+	var orgSlug string
+	cmd := &cobra.Command{
 		Use:   "test-email <recipient>",
 		Short: "Send a test email to verify SMTP configuration",
 		Long: `Send a test email to the given recipient using the SMTP_* environment
 variables. Useful for confirming Postmark / SendGrid / SES credentials are correct
 before relying on signup verification or review-notification emails.
+
+With --org <slug>, the email is sent the way a tenant's real mail is: the org's
+name becomes the From display name (e.g. "STS" <noreply@host>) while the envelope
+sender stays SMTP_FROM, so SPF/DKIM alignment is preserved. Without --org, the
+raw SMTP_FROM is used as-is. --org needs DATABASE_URL set.
 
 Required env vars:
   SMTP_HOST       (e.g. smtp.postmarkapp.com)
@@ -43,6 +49,28 @@ Required env vars:
 				return fmt.Errorf("mailer not configured — set SMTP_HOST and SMTP_FROM at minimum")
 			}
 
+			// Resolve org branding when --org is given. SendBranded/PreviewFrom
+			// only consume Branding.Name (the From display name) — the generic
+			// test body isn't a colored template — so we set just the name.
+			var branding mail.Branding
+			if orgSlug != "" {
+				d, err := connectDB()
+				if err != nil {
+					return err
+				}
+				defer d.Close()
+				ctx := cmd.Context()
+				org, err := d.GetOrganizationBySlug(ctx, orgSlug)
+				if err != nil || org == nil {
+					return fmt.Errorf("organization %q not found", orgSlug)
+				}
+				branding.Name = org.Name
+				header, envelope := mail.PreviewFrom(cfg.From, branding.Name)
+				fmt.Printf("Org context: %s (%s)\n", org.Name, org.Slug)
+				fmt.Printf("From header: %s\n", header)
+				fmt.Printf("Envelope:    %s\n", envelope)
+			}
+
 			subject := "ISMS test email"
 			body := `<div style="font-family: sans-serif; max-width: 500px; margin: 0 auto;">
 <h2>SMTP test successful</h2>
@@ -50,13 +78,21 @@ Required env vars:
 <p style="color: #666; font-size: 12px;">Sent by <code>isms server test-email</code>.</p>
 </div>`
 
-			if err := m.Send(to, subject, body); err != nil {
-				return fmt.Errorf("send failed: %w", err)
+			var sendErr error
+			if orgSlug != "" {
+				sendErr = m.SendBranded(to, subject, body, branding)
+			} else {
+				sendErr = m.Send(to, subject, body)
+			}
+			if sendErr != nil {
+				return fmt.Errorf("send failed: %w", sendErr)
 			}
 			fmt.Printf("Test email sent to %s\n", to)
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&orgSlug, "org", "", "Send as this org (branded From display name); needs DATABASE_URL")
+	return cmd
 }
 
 // maskedLen returns "(N chars)" or "(empty)" for masked secret display.

--- a/cmd/isms/user.go
+++ b/cmd/isms/user.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"text/tabwriter"
 
@@ -17,7 +18,63 @@ func userCmd() *cobra.Command {
 		Short: "Manage users",
 	}
 
-	cmd.AddCommand(userCreateCmd(), userListCmd(), userSetPasswordCmd(), userVerifyCmd())
+	cmd.AddCommand(userCreateCmd(), userListCmd(), userSetPasswordCmd(), userVerifyCmd(), userTestAuthCmd(), userResetOTPCmd())
+	return cmd
+}
+
+// userResetOTPCmd clears a user's OTP so they can log in and re-enroll. The
+// primary use case: an OTP secret encrypted with a different ISMS_SECRET (e.g. a
+// DB copied to a new install with its own secret) can no longer be decrypted, so
+// GetUserByEmail errors and login fails with "invalid credentials" and no OTP
+// prompt. Clearing OTP lets the user in with just their password to re-enroll.
+func userResetOTPCmd() *cobra.Command {
+	var email string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "reset-otp",
+		Short: "Remove a user's OTP (2FA) so they can log in and re-enroll",
+		Long: `Clears otp_secret and otp_verified for the user.
+
+Use this when the OTP secret can no longer be decrypted — typically after a DB
+was copied to a new install that has its own ISMS_SECRET. The symptom is login
+failing with "invalid credentials" and NO OTP prompt (GetUserByEmail errors on
+the undecryptable OTP secret before the password check completes). After reset,
+the user logs in with just their password and can re-enroll 2FA, which is then
+encrypted with this install's ISMS_SECRET.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if email == "" {
+				return fmt.Errorf("--email is required")
+			}
+			d, err := connectDB()
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			ctx := cmd.Context()
+			user, err := d.GetUserByEmail(ctx, email)
+			if err != nil || user == nil {
+				return fmt.Errorf("user %q not found", email)
+			}
+			// This disables a security control (2FA), so confirm unless --yes —
+			// cheap insurance against a fat-fingered --email.
+			if !yes {
+				fmt.Printf("Clear OTP (2FA) for %s? [y/N] ", user.Email)
+				var resp string
+				fmt.Scanln(&resp)
+				if resp != "y" && resp != "Y" {
+					return fmt.Errorf("aborted")
+				}
+			}
+			if err := d.ClearOTP(ctx, user.ID); err != nil {
+				return fmt.Errorf("clearing OTP: %w", err)
+			}
+			fmt.Printf("OTP cleared for %s. Log in with just the password, then re-enroll 2FA.\n", user.Email)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip the confirmation prompt")
 	return cmd
 }
 
@@ -226,5 +283,121 @@ func userVerifyCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+	return cmd
+}
+
+// userTestAuthCmd runs the exact credential checks that POST /auth/login
+// performs — read-only, against this box's own DATABASE_URL. It isolates a
+// login failure as either bad data (wrong DB / stale hash / inactive account)
+// or transport (something altering the request before it reaches the API).
+func userTestAuthCmd() *cobra.Command {
+	var email, password string
+
+	cmd := &cobra.Command{
+		Use:   "test-auth",
+		Short: "Test whether an email + password would authenticate (read-only, mirrors login)",
+		Long: `Runs the same credential checks as POST /auth/login — user lookup, active
+check, password-set check, and bcrypt comparison — against this box's own
+DATABASE_URL. Read-only: records no login attempt and issues no token.
+
+Use it to tell apart a data problem (this box points at a different DB, the row's
+hash differs, or the account is inactive) from a transport problem (a proxy
+altering the request before it reaches the API). OTP is reported but not required
+here — the "invalid username or password" error happens before the OTP step.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if email == "" {
+				return fmt.Errorf("--email is required")
+			}
+
+			var pw []byte
+			if password != "" {
+				pw = []byte(password)
+			} else {
+				fmt.Print("Password: ")
+				var err error
+				pw, err = term.ReadPassword(int(os.Stdin.Fd()))
+				fmt.Println()
+				if err != nil {
+					return fmt.Errorf("reading password: %w", err)
+				}
+			}
+
+			// Show which DB we're actually talking to (credentials redacted) —
+			// the whole point is to confirm it's the DB you think it is.
+			if raw := os.Getenv("DATABASE_URL"); raw != "" {
+				if u, perr := url.Parse(raw); perr == nil {
+					fmt.Printf("DB:    %s%s\n\n", u.Host, u.Path)
+				}
+			}
+
+			d, err := connectDB()
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			ctx := cmd.Context()
+
+			user, err := d.GetUserByEmail(ctx, email)
+			if err != nil || user == nil {
+				fmt.Printf("✗ user %q NOT FOUND in this database\n\n", email)
+				fmt.Println("VERDICT: FAIL — no such user here. This box points at a different")
+				fmt.Println("         database than the one where the account exists (check DATABASE_URL).")
+				return nil
+			}
+			fmt.Printf("✓ user found: id=%d name=%q agent=%v\n", user.ID, user.Name, user.IsAgent)
+
+			if user.Active {
+				fmt.Println("✓ account active")
+			} else {
+				fmt.Println("✗ account INACTIVE")
+			}
+			fmt.Printf("• email_verified=%v (not required for login)\n", user.EmailVerified)
+
+			if !user.HasPassword() {
+				fmt.Println("✗ no local password set (external-auth-only account)")
+				fmt.Println()
+				fmt.Println("VERDICT: FAIL — login returns \"invalid credentials\" (no local password).")
+				return nil
+			}
+			hash := *user.PasswordHash
+			prefix := hash
+			if len(prefix) > 7 {
+				prefix = prefix[:7]
+			}
+			fmt.Printf("✓ password hash present: %s… (len %d)\n", prefix, len(hash))
+
+			bcryptErr := bcrypt.CompareHashAndPassword([]byte(hash), pw)
+			if bcryptErr != nil {
+				fmt.Printf("✗ bcrypt does NOT match: %v\n", bcryptErr)
+			} else {
+				fmt.Println("✓ bcrypt password MATCHES")
+			}
+
+			if user.HasOTP() {
+				fmt.Println("• OTP is ENABLED — a valid TOTP code is also required at login")
+			}
+
+			// Final verdict mirrors handleLogin's decision order.
+			fmt.Println()
+			switch {
+			case !user.Active:
+				fmt.Println("VERDICT: FAIL — account is INACTIVE; login returns \"invalid credentials\"")
+				fmt.Printf("         even with the right password. Fix: isms server user verify --email %s\n", email)
+			case bcryptErr != nil:
+				fmt.Println("VERDICT: FAIL — password does NOT match the stored hash in THIS database.")
+				fmt.Println("         Either the password differs, or this row's hash differs from the working box")
+				fmt.Println("         (a DB copy rather than the same DB).")
+			default:
+				fmt.Println("VERDICT: PASS — these credentials authenticate against this database.")
+				fmt.Println("         If the web login still fails, the problem is between the browser and the")
+				fmt.Println("         API (proxy/transport), not the credentials or the DB.")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "User email (required)")
+	cmd.Flags().StringVar(&password, "password", "", "Password (optional, prompts if not provided)")
 	return cmd
 }

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
+	"html"
 	"io/fs"
 	"log"
 	"net"
@@ -833,6 +834,32 @@ func (s *Server) routes() {
 	}
 	if spaFS != nil {
 		fileServer := http.FileServerFS(spaFS)
+		// serveIndex serves index.html with the deployment's apex host injected
+		// as window.__ISMS_APEX__. The SPA classifies its own hostname (apex vs
+		// tenant subdomain) at module-import time — before /api/v1/config is
+		// fetched — so it needs the apex synchronously. Without this a self-hosted
+		// apex like isms.stsplatform.com is misread as tenant "isms" on boot.
+		// See web/src/composables/useCurrentOrg.js.
+		serveIndex := func(w http.ResponseWriter) {
+			data, err := fs.ReadFile(spaFS, "index.html")
+			if err != nil {
+				http.Error(w, "index.html not found", http.StatusInternalServerError)
+				return
+			}
+			if s.apexHost != "" {
+				// Inject as a <meta> tag, NOT an inline <script>: the CSP set
+				// below (script-src 'self') blocks inline scripts, so a script
+				// tag would be silently dropped in production. A meta tag carries
+				// the value without executing JS, so CSP never touches it.
+				// html.EscapeString (not %q, which is Go string-escaping) so a
+				// stray quote in the apex can't break out of the attribute.
+				inject := fmt.Sprintf(`<meta name="isms-apex" content="%s"></head>`, html.EscapeString(s.apexHost))
+				data = []byte(strings.Replace(string(data), "</head>", inject, 1))
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Write(data)
+		}
 		s.echo.GET("/*", echo.WrapHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Go vanity import: go get isms.sh@latest
 			if r.URL.Query().Get("go-get") == "1" {
@@ -844,15 +871,16 @@ func (s *Server) routes() {
 				return
 			}
 			path := strings.TrimPrefix(r.URL.Path, "/")
-			if path == "" {
-				path = "index.html"
+			if path == "" || path == "index.html" {
+				serveIndex(w)
+				return
 			}
 			if f, err := fs.Stat(spaFS, path); err == nil && !f.IsDir() {
 				fileServer.ServeHTTP(w, r)
 				return
 			}
-			r.URL.Path = "/"
-			fileServer.ServeHTTP(w, r)
+			// SPA client-side route — serve the injected index.html.
+			serveIndex(w)
 		})))
 	}
 }
@@ -865,7 +893,18 @@ func (s *Server) handleGetConfig(c echo.Context) error {
 
 	// Org context comes strictly from URL (subdomain, custom domain, or path)
 	// via OrgResolverMiddleware which sets it on the request. No query-param
-	// fallback, no single-org auto-detect. Apex domain = no org = neutral config.
+	// fallback. Apex domain = no org = neutral config, EXCEPT:
+	//
+	// Single-org auto-detect: a self-hosted deployment with exactly one org has
+	// no meaningful "pick an org" step — the apex IS that org. Resolve to it so
+	// the login page auto-selects it (branding + org scope) instead of prompting
+	// for an org slug. Multi-tenant apexes (many orgs) are unaffected: the count
+	// is != 1, so orgID stays 0 and the apex serves neutral org-discovery.
+	if orgID == 0 {
+		if orgs, err := s.db.ListOrganizations(ctx); err == nil && len(orgs) == 1 {
+			orgID = orgs[0].ID
+		}
+	}
 
 	// All config comes from PostgreSQL — isms.yaml is not read at runtime.
 	type configResponse struct {

--- a/internal/isms/mail/mail.go
+++ b/internal/isms/mail/mail.go
@@ -85,6 +85,14 @@ func resolveFrom(configFrom, fromName string) (header, envelope string) {
 	return (&netmail.Address{Name: fromName, Address: envelope}).String(), envelope
 }
 
+// PreviewFrom returns the From header and envelope sender that a branded send
+// with brandName would produce, WITHOUT sending. For diagnostics (e.g.
+// `isms server test-email --org`), so an operator can see the exact From a
+// tenant's mail will carry. An empty brandName previews an unbranded send.
+func PreviewFrom(configFrom, brandName string) (header, envelope string) {
+	return resolveFrom(configFrom, brandName)
+}
+
 // Send sends an email using the configured SMTP_FROM as-is.
 func (m *Mailer) Send(to, subject, body string) error {
 	return m.sendAs(to, subject, body, "")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -77,7 +77,13 @@ class TestSubdomainResolution:
         )
 
     def test_apex_has_no_org_context(self):
-        """Plain apex Host → no org bound, neutral config."""
+        """Plain apex Host → no org bound, neutral config.
+
+        NB: the server auto-resolves the apex to the org when a deployment has
+        EXACTLY ONE org (single-org self-hosted convenience). This suite always
+        has multiple orgs (the admin org from conftest + acme-logistics created
+        in setup_class), so the apex stays neutral here.
+        """
         _require_subdomain_routing(self.cfg)
         r = requests.get(
             f"{BASE_URL}/api/v1/config",
@@ -86,7 +92,8 @@ class TestSubdomainResolution:
         assert r.status_code == 200
         cfg = r.json()
         assert not cfg.get("organization_slug"), (
-            f"apex must not surface an org_slug; got {cfg.get('organization_slug')!r}"
+            f"apex must not surface an org_slug with multiple orgs; "
+            f"got {cfg.get('organization_slug')!r}"
         )
 
     def test_unknown_subdomain_falls_through(self):
@@ -106,6 +113,57 @@ class TestSubdomainResolution:
         _require_subdomain_routing(self.cfg)
         assert self.cfg.get("subdomain_routing") is True
         assert self.cfg.get("apex_host"), "apex_host must be set when subdomain routing is on"
+
+
+class TestSpaApexInjection:
+    """Regression: the SPA index.html must carry the deployment's apex host as a
+    <meta name="isms-apex"> tag so the frontend classifies its own hostname (apex
+    vs tenant subdomain) synchronously at boot — before /api/v1/config loads.
+
+    Without it, host classification runs at module-import time (router.js,
+    App.vue) with only the isms.sh seed, so a self-hosted apex on any other
+    domain (e.g. isms.stsplatform.com) is misread as a tenant subdomain "isms".
+    The login page then probes a phantom org and 404s on /auth/oidc/providers.
+
+    A meta tag is used (not an inline <script>) because the CSP is script-src
+    'self' — an inline script would be blocked and silently never run.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.cfg = _server_config()
+
+    def test_index_html_injects_apex_host(self):
+        apex = self.cfg.get("apex_host")
+        if not apex:
+            pytest.skip("server has no apex_host configured (ISMS_DOMAIN unset)")
+        r = requests.get(f"{BASE_URL}/")
+        assert r.status_code == 200, f"got {r.status_code}: {r.text[:200]}"
+        assert "text/html" in r.headers.get("content-type", "")
+        marker = f'<meta name="isms-apex" content="{apex}">'
+        assert marker in r.text, (
+            f"expected {marker!r} injected into index.html; "
+            f"apex_host={apex!r} not found in served HTML"
+        )
+
+    def test_apex_injection_is_not_an_inline_script(self):
+        """Guard against regressing to an inline <script>, which the CSP
+        (script-src 'self') would block from executing."""
+        r = requests.get(f"{BASE_URL}/")
+        assert "window.__ISMS_APEX__" not in r.text, (
+            "apex host must be injected as a <meta> tag, not an inline script "
+            "(CSP script-src 'self' blocks inline scripts)"
+        )
+
+    def test_spa_fallback_route_also_injects(self):
+        """A deep-link client route (/login) falls back to index.html and must
+        carry the same injection — /login is exactly where the bug surfaced."""
+        apex = self.cfg.get("apex_host")
+        if not apex:
+            pytest.skip("server has no apex_host configured (ISMS_DOMAIN unset)")
+        r = requests.get(f"{BASE_URL}/login")
+        assert r.status_code == 200, f"got {r.status_code}: {r.text[:200]}"
+        assert f'<meta name="isms-apex" content="{apex}">' in r.text
 
 
 class TestDocsServedNatively:

--- a/web/src/composables/useCurrentOrg.js
+++ b/web/src/composables/useCurrentOrg.js
@@ -23,6 +23,20 @@ const _apexHosts = new Set([
   'www.isms.sh',
 ])
 
+// Race-free apex seed: the server injects its own apex host into index.html as
+// a <meta name="isms-apex"> tag (see server.go SPA handler). Host classification
+// runs at module-import time — in router.js and App.vue setup — which is BEFORE
+// the async /api/v1/config fetch calls setApexHost(). Without this synchronous
+// seed, a self-hosted apex on a non-isms.sh domain (e.g. isms.stsplatform.com)
+// is misclassified as a tenant subdomain "isms" on boot.
+//
+// A meta tag (not an inline <script>) is used deliberately: the server's CSP is
+// script-src 'self', which blocks inline scripts — a script tag would never run.
+if (typeof document !== 'undefined') {
+  const _apexMeta = document.querySelector('meta[name="isms-apex"]')
+  if (_apexMeta && _apexMeta.content) _apexHosts.add(_apexMeta.content.toLowerCase())
+}
+
 export function setApexHost(host) {
   if (host) _apexHosts.add(host.toLowerCase())
 }


### PR DESCRIPTION
Fixes #119

## Apex org resolution
- **Boot-race:** server injects its apex host into `index.html` as `<meta name="isms-apex">`; `useCurrentOrg.js` seeds `_apexHosts` synchronously at module load (before `/config`). Meta tag, not inline `<script>`, because CSP is `script-src 'self'`. Fixes a self-hosted apex being misread as tenant `isms`.
- **Single-org:** `GET /config` resolves the apex to the sole org when exactly one exists → login auto-selects it. Multi-tenant unaffected.

## Operator diagnostics (CLI)
- `user test-auth` — read-only login credential check against this box's DB.
- `user reset-otp` — clear OTP to re-enroll (ISMS_SECRET mismatch on a copied DB).
- `test-email --org` — branded-From preview + send.

No config change.

## Test plan
- [ ] `just build-web && just test-restart` then `just test tests/test_routing.py -v`
- [ ] On isms.stsplatform.com: apex auto-selects the single org, no `org=isms` 404