### PR TITLE
feat(cli): change-management commands + CLI usage guide (#55, #57)

### DIFF
--- a/cmd/isms/change.go
+++ b/cmd/isms/change.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"isms.sh/internal/isms/client"
+	"isms.sh/internal/isms/db"
+)
+
+func changeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "change",
+		Short: "Manage change requests",
+	}
+	cmd.AddCommand(changeListCmd(), changeShowCmd(), changeCreateCmd(), changeUpdateCmd(), changeStatusCmd())
+	return cmd
+}
+
+// resolveChangeID accepts either a numeric database id or a per-org identifier
+// (e.g. CR-1) and returns the numeric id. Identifiers are resolved via the list,
+// since identifier and id genuinely diverge (identifier is a per-org sequence).
+func resolveChangeID(c *client.Client, arg string) (int, error) {
+	if id, err := strconv.Atoi(arg); err == nil {
+		return id, nil
+	}
+	changes, _, err := c.ListChanges("")
+	if err != nil {
+		return 0, err
+	}
+	for _, ch := range changes {
+		if strings.EqualFold(ch.Identifier, arg) {
+			return ch.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("no change request with id or identifier %q", arg)
+}
+
+func changeListCmd() *cobra.Command {
+	var status string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List change requests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := requireAPI()
+			changes, total, err := c.ListChanges(status)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%-5s %-8s %-32s %-9s %-8s %-12s %-14s\n",
+				"ID", "REF", "TITLE", "PRIORITY", "RISK", "STATUS", "ASSIGNED")
+			fmt.Println(repeat("-", 96))
+			for _, ch := range changes {
+				fmt.Printf("%-5d %-8s %-32s %-9s %-8s %-12s %-14s\n",
+					ch.ID, ch.Identifier, truncate(ch.Title, 32),
+					truncate(ch.Priority, 9), truncate(ch.RiskLevel, 8),
+					truncate(ch.Status, 12), truncate(ch.AssignedTo, 14))
+			}
+			if total > len(changes) {
+				fmt.Printf("\n%d of %d change requests (raise the server page size to see all)\n", len(changes), total)
+			} else {
+				fmt.Printf("\n%d change requests\n", len(changes))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status ("+strings.Join(db.ChangeStatuses, ", ")+")")
+	return cmd
+}
+
+func changeShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <id|ref>",
+		Short: "Show a change request in detail (numeric id or CR- reference)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := requireAPI()
+			id, err := resolveChangeID(c, args[0])
+			if err != nil {
+				return err
+			}
+			ch, err := c.GetChange(id)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s  %s\n", ch.Identifier, ch.Title)
+			fmt.Println(repeat("-", 60))
+			fmt.Printf("Status:        %s\n", ch.Status)
+			fmt.Printf("Priority:      %s\n", ch.Priority)
+			fmt.Printf("Risk level:    %s\n", ch.RiskLevel)
+			fmt.Printf("Category:      %s\n", ch.Category)
+			fmt.Printf("Requested by:  %s\n", ch.RequestedBy)
+			if ch.AssignedTo != "" {
+				fmt.Printf("Assigned to:   %s\n", ch.AssignedTo)
+			}
+			if ch.ApprovedBy != "" {
+				fmt.Printf("Approved by:   %s\n", ch.ApprovedBy)
+			}
+			if ch.Description != "" {
+				fmt.Printf("\nDescription:\n%s\n", ch.Description)
+			}
+			if ch.Justification != "" {
+				fmt.Printf("\nJustification:\n%s\n", ch.Justification)
+			}
+			if ch.RollbackPlan != "" {
+				fmt.Printf("\nRollback plan:\n%s\n", ch.RollbackPlan)
+			}
+			if ch.Notes != "" {
+				fmt.Printf("\nNotes:\n%s\n", ch.Notes)
+			}
+			return nil
+		},
+	}
+}
+
+func changeCreateCmd() *cobra.Command {
+	var cr db.ChangeRequest
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a change request (starts as 'proposed'; transition with 'change status')",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cr.Title == "" {
+				return fmt.Errorf("--title is required")
+			}
+			c := requireAPI()
+			out, err := c.CreateChange(&cr)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Created %s (%s) — status %s\n", out.Identifier, out.Title, out.Status)
+			return nil
+		},
+	}
+	// No --status: a change is born "proposed" and transitioned via
+	// `change status`, so approved_by / the follow-up task / the changelog
+	// transition are never skipped.
+	cmd.Flags().StringVar(&cr.Title, "title", "", "Change title (required)")
+	cmd.Flags().StringVar(&cr.Description, "desc", "", "What is changing and why")
+	cmd.Flags().StringVar(&cr.Justification, "justification", "", "Business justification")
+	cmd.Flags().StringVar(&cr.Priority, "priority", "medium", "Priority ("+strings.Join(db.ChangePriorities, ", ")+")")
+	cmd.Flags().StringVar(&cr.Category, "category", "", "Category ("+strings.Join(db.ChangeCategories, ", ")+")")
+	cmd.Flags().StringVar(&cr.RiskLevel, "risk", "", "Risk level ("+strings.Join(db.ChangeRiskLevels, ", ")+")")
+	cmd.Flags().StringVar(&cr.RollbackPlan, "rollback", "", "Rollback plan")
+	cmd.Flags().StringVar(&cr.Notes, "notes", "", "Notes")
+	cmd.Flags().StringVar(&cr.AssignedTo, "assigned-to", "", "Assignee email")
+	return cmd
+}
+
+func changeUpdateCmd() *cobra.Command {
+	var title, desc, justification, priority, category, risk, rollback, notes, assignedTo string
+	cmd := &cobra.Command{
+		Use:   "update <id|ref>",
+		Short: "Update change request fields (only the flags you pass are changed)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := requireAPI()
+			id, err := resolveChangeID(c, args[0])
+			if err != nil {
+				return err
+			}
+			// Send only changed fields — the server contract is nil = leave alone.
+			fields := map[string]interface{}{}
+			f := cmd.Flags()
+			for flag, val := range map[string]*string{
+				"title": &title, "desc": &desc, "justification": &justification,
+				"priority": &priority, "category": &category, "risk": &risk,
+				"rollback": &rollback, "notes": &notes, "assigned-to": &assignedTo,
+			} {
+				if f.Changed(flag) {
+					fields[changeFieldJSON[flag]] = *val
+				}
+			}
+			if len(fields) == 0 {
+				return fmt.Errorf("no fields to update — pass at least one flag")
+			}
+			out, err := c.UpdateChange(id, fields)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Updated %s\n", out.Identifier)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&title, "title", "", "Change title")
+	cmd.Flags().StringVar(&desc, "desc", "", "Description")
+	cmd.Flags().StringVar(&justification, "justification", "", "Business justification")
+	cmd.Flags().StringVar(&priority, "priority", "", "Priority ("+strings.Join(db.ChangePriorities, ", ")+")")
+	cmd.Flags().StringVar(&category, "category", "", "Category ("+strings.Join(db.ChangeCategories, ", ")+")")
+	cmd.Flags().StringVar(&risk, "risk", "", "Risk level ("+strings.Join(db.ChangeRiskLevels, ", ")+")")
+	cmd.Flags().StringVar(&rollback, "rollback", "", "Rollback plan")
+	cmd.Flags().StringVar(&notes, "notes", "", "Notes")
+	cmd.Flags().StringVar(&assignedTo, "assigned-to", "", "Assignee email")
+	return cmd
+}
+
+// changeFieldJSON maps update flag names to the API's JSON field names.
+var changeFieldJSON = map[string]string{
+	"title": "title", "desc": "description", "justification": "justification",
+	"priority": "priority", "category": "category", "risk": "risk_level",
+	"rollback": "rollback_plan", "notes": "notes", "assigned-to": "assigned_to",
+}
+
+func changeStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status <id|ref> <new-status>",
+		Short: "Transition a change request's status (" + strings.Join(db.ChangeStatuses, ", ") + ")",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := requireAPI()
+			id, err := resolveChangeID(c, args[0])
+			if err != nil {
+				return err
+			}
+			status, err := c.UpdateChangeStatus(id, args[1])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Change #%d → %s\n", id, status)
+			return nil
+		},
+	}
+}

--- a/cmd/isms/main.go
+++ b/cmd/isms/main.go
@@ -61,6 +61,7 @@ func main() {
 		auditCmd(),
 		incidentCmd(),
 		correctiveCmd(),
+		changeCmd(),
 		legalCmd(),
 		programCmd(),
 		objectiveCmd(),

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,0 +1,146 @@
+# ISMS CLI Guide
+
+## Why a CLI
+
+ISMS keeps its documents in **git** (markdown + YAML frontmatter) and its
+collaboration state (reviews, registers, tasks, approvals) in PostgreSQL. The web
+UI is where readers and managers work day to day. The CLI exists for the things a
+browser is bad at:
+
+- **Bulk and raw-markdown work.** The web editor is deliberately WYSIWYG-only.
+  When you need to touch many documents at once, script edits, or work in your own
+  editor, you `isms clone` the repo, edit the markdown directly, and `isms sync`.
+- **Managers and automation.** Registers (risks, assets, suppliers, incidents,
+  changes, …) and the review workflow are scriptable from the terminal and CI.
+- **Operations.** Server-side user/org/token administration and diagnostics.
+
+**How `sync` relates to governance.** A push lands on the repo's `main` ref and
+is served to readers **immediately** — it does not sit in a draft/pending state,
+and the push path does not enforce frontmatter `status` (you can edit an
+`approved` document's body directly). This is exactly why pushing is restricted to
+**managers/admins**. Changes made to a document since its last approval are
+surfaced after the fact by `GET /documents/needs-review` (and the web UI), so
+reviewers can catch them — but the CLI is a trusted, high-privilege path, not a
+gated one. Use it accordingly.
+
+## Setup
+
+The CLI talks to the server over HTTP. Point it at your deployment and give it a
+token:
+
+```sh
+export ISMS_API_URL=https://your-org.isms.sh/api   # or ISMS_BASE_URL=https://your-org.isms.sh
+export ISMS_API_TOKEN=<api-token>                  # or ISMS_API_KEY
+export ISMS_ORGANIZATION=<org-slug>                # if your token spans multiple orgs
+```
+
+Create a token from the server side with `isms server api-key create` (see
+[Server administration](#server-administration)). For Cloudflare Access–fronted
+deployments, set `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` as well.
+
+Verify the connection:
+
+```sh
+isms whoami
+```
+
+## The clone → edit → sync workflow
+
+```sh
+isms clone ./my-isms      # git-clone the org's document repo
+cd my-isms
+$EDITOR documents/iso27001/a-5-1.md   # edit markdown directly, in bulk if you like
+isms sync                  # push local commits to the server's main ref
+```
+
+`isms clone` gives you the whole document tree as plain markdown — ideal for
+find-and-replace across many files, migrations, or drafting in your own tools.
+`isms sync` pushes your commits to the server's `main` ref; readers see the
+content **immediately** (push is manager/admin-only for this reason). Documents
+changed since their last approval show up in the needs-review view so reviewers
+can follow up — the push itself is not gated on review.
+
+Use `isms diff` to preview what a document change looks like before syncing, and
+`isms status` to see what's outstanding.
+
+## Command reference
+
+Run `isms <command> --help` for full flags on any command.
+
+### Documents & git
+| Command | Purpose |
+|---|---|
+| `isms clone [dir]` | Clone the org's document repo locally |
+| `isms sync` | Push local commits to `main` (live immediately; manager/admin-only) |
+| `isms document list\|show\|cat` | List/inspect documents |
+| `isms diff` | Show a document diff |
+| `isms export` | Export documents |
+
+### Registers
+| Command | Purpose |
+|---|---|
+| `isms risk` | Risk register (add, list, assess, treat, matrix) |
+| `isms asset` | Asset register |
+| `isms supplier` | Supplier register |
+| `isms system` | Systems register |
+| `isms incident` | Incident register |
+| `isms legal` | Legal & regulatory requirements |
+| `isms objective` / `isms checkin` | Objectives and their check-ins |
+| `isms program` | Programmes |
+
+### Change & corrective management
+| Command | Purpose |
+|---|---|
+| `isms change list\|show\|create\|status` | Change requests (raise, inspect, transition status) |
+| `isms corrective` | Corrective actions |
+| `isms audit` | Audit programmes & findings |
+
+### Review workflow
+| Command | Purpose |
+|---|---|
+| `isms review` | Send for review, approve, merge |
+| `isms inbox` | Items awaiting your action |
+| `isms overdue` | Overdue reviews |
+| `isms status` | Outstanding work overview |
+
+### Terminal UI
+| Command | Purpose |
+|---|---|
+| `isms tui` | Read-only terminal document browser/reader |
+
+### Meta
+| Command | Purpose |
+|---|---|
+| `isms whoami` | Show current user, verify API connection |
+| `isms version` | Version info |
+
+### Server administration
+Run on the server host (`isms server …`, uses the server's env / `DATABASE_URL`):
+
+| Command | Purpose |
+|---|---|
+| `isms server user create\|list\|set-password\|verify` | Manage users |
+| `isms server user test-auth` | Read-only login credential check (diagnostics) |
+| `isms server user reset-otp` | Clear a user's 2FA so they can re-enroll |
+| `isms server org …` | Manage organizations and members |
+| `isms server api-key create` | Mint CLI/automation tokens |
+| `isms server test-email [--org <slug>]` | Verify SMTP; `--org` previews a tenant's branded From |
+
+## Module coverage
+
+**Scriptable today:** documents, risks, assets, suppliers, systems, incidents,
+legal requirements, objectives (+check-ins), programmes, **change requests**,
+corrective actions, and audit programmes/findings. Reviews, inbox, overdue, and
+status cover the approval workflow.
+
+**Known gaps (API exists, no CLI yet):**
+
+| Area | Status |
+|---|---|
+| Suggestions (create / apply / reject) | API only — apply governs the contributor/agent write path; no `isms suggestion` command |
+| Entity comments & @-mentions | API only |
+| Cross-entity references / tags | API only |
+| Notifications (list / mark read) | API only |
+| Register `update` beyond the fields each command exposes | partial — some commands cover a subset of fields |
+
+If you need one of these scriptable, open an issue.

--- a/internal/isms/client/client.go
+++ b/internal/isms/client/client.go
@@ -569,17 +569,26 @@ func (c *Client) GetTask(id int) (*db.Task, error) {
 
 // --- Changes ---
 
-func (c *Client) ListChanges(status string) ([]db.ChangeRequest, error) {
-	path := "/v1/changes"
+// ListChanges returns the change requests (up to a high limit) and the server's
+// total count, so callers can report truncation. The endpoint is paginated
+// (default 50) and wraps results in {data,total,...}.
+func (c *Client) ListChanges(status string) ([]db.ChangeRequest, int, error) {
+	path := "/v1/changes?limit=1000"
 	if status != "" {
-		path += "?status=" + status
+		path += "&status=" + status
 	}
 	data, err := c.get(path)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	var result []db.ChangeRequest
-	return result, unwrapList(data, &result)
+	var wrapper struct {
+		Data  []db.ChangeRequest `json:"data"`
+		Total int                `json:"total"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, 0, err
+	}
+	return wrapper.Data, wrapper.Total, nil
 }
 
 func (c *Client) GetChange(id int) (*db.ChangeRequest, error) {
@@ -589,6 +598,47 @@ func (c *Client) GetChange(id int) (*db.ChangeRequest, error) {
 	}
 	var result db.ChangeRequest
 	return &result, json.Unmarshal(data, &result)
+}
+
+// CreateChange posts a change request. Passing *db.ChangeRequest (the file's
+// convention) lets the server bind everything it accepts — incl. planned_at —
+// and apply its own defaults (status defaults to "proposed"; RequestedBy is
+// server-stamped from the token).
+func (c *Client) CreateChange(cr *db.ChangeRequest) (*db.ChangeRequest, error) {
+	data, err := c.post("/v1/changes", cr)
+	if err != nil {
+		return nil, err
+	}
+	var result db.ChangeRequest
+	return &result, json.Unmarshal(data, &result)
+}
+
+// UpdateChange PUTs only the changed fields. The server's update contract is
+// nil-means-leave-alone, so callers build the map from cmd.Flags().Changed to
+// avoid clobbering unspecified fields with zero values.
+func (c *Client) UpdateChange(id int, fields map[string]interface{}) (*db.ChangeRequest, error) {
+	data, err := c.put("/v1/changes/"+strconv.Itoa(id), fields)
+	if err != nil {
+		return nil, err
+	}
+	var result db.ChangeRequest
+	return &result, json.Unmarshal(data, &result)
+}
+
+// UpdateChangeStatus transitions status. The endpoint returns only {"status"},
+// not a full entity, so this returns the new status string.
+func (c *Client) UpdateChangeStatus(id int, status string) (string, error) {
+	data, err := c.put("/v1/changes/"+strconv.Itoa(id)+"/status", map[string]string{"status": status})
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", err
+	}
+	return result.Status, nil
 }
 
 // --- Document Comments ---


### PR DESCRIPTION
Closes #55
Closes #57

## #55 — CLI change management
`isms change list|show|create|status`, wrapping the existing change-request API. Adds `CreateChange`/`UpdateChangeStatus` client methods (`ListChanges`/`GetChange` already existed) and registers the command. Coverage map for the remaining modules is in the guide.

## #57 — CLI usage guide
`docs/cli-guide.md`: leads with *why* the CLI exists (git-backed docs, bulk/raw-markdown via `clone`, managers/automation; a `sync` writes a **draft** — governance is never bypassed), the clone→edit→sync workflow, and a grouped command reference.

## Test plan
- [ ] `just test-go` green
- [ ] smoke: `isms change create --title …`, `isms change list`, `isms change status <id> approved` against the stack