### PR TITLE
feat(review): @-mention members in entity comments + change requests (#4)

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -94,10 +94,11 @@ func docLink(docID string) string {
 // email local-part (maria@… → @maria) or their name with spaces removed.
 var mentionRe = regexp.MustCompile(`@([a-zA-Z0-9._-]+)`)
 
-// notifyReviewMentions creates an in-app notification for each org member
-// @-mentioned in a review comment (#4), excluding the comment's author. Matching
-// is case-insensitive against the member's email local-part or name-slug.
-func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, actor, body string) {
+// notifyMentions creates an in-app notification for each org member @-mentioned
+// in body (excluding the actor), with the given title and link. Matching is
+// case-insensitive against the member's email local-part or name-slug. Generic
+// across surfaces — review comments, entity comments, change fields (#4).
+func (s *Server) notifyMentions(ctx context.Context, orgID int, actor, body, title, link string) {
 	matches := mentionRe.FindAllStringSubmatchIndex(body, -1)
 	if len(matches) == 0 {
 		return
@@ -124,8 +125,6 @@ func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, 
 		}
 	}
 	snippet := truncateStr(body, 200)
-	title := fmt.Sprintf("%s mentioned you in a review comment", actor)
-	link := fmt.Sprintf("/reviews/%d", reviewID)
 	notified := map[string]bool{}
 	for _, m := range matches {
 		// Skip "@scope/pkg" tokens (e.g. @babel/core): a '/' right after the
@@ -144,6 +143,43 @@ func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, 
 		notified[email] = true
 		_ = s.db.CreateNotificationByEmail(ctx, orgID, email, title, snippet, link)
 	}
+}
+
+// notifyReviewMentions notifies members @-mentioned in a review comment (#4).
+func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, actor, body string) {
+	s.notifyMentions(ctx, orgID, actor, body,
+		fmt.Sprintf("%s mentioned you in a review comment", actor),
+		fmt.Sprintf("/reviews/%d", reviewID))
+}
+
+// entityLink returns the SPA route for an entity, or "" if the type has no
+// direct route (mirrors web/src/router.js). Points mention notifications at the
+// mentioned entity. entityID is the entity's identifier (e.g. "CR-1"); the
+// register views resolve the route param by numeric id OR identifier, so an
+// identifier-based deep link opens the entity.
+func entityLink(entityType, entityID string) string {
+	if entityID == "" {
+		return ""
+	}
+	if entityType == "document" {
+		return docLink(entityID) // documents resolve by doc_id (/documents?doc=…), not a path param
+	}
+	prefix := map[string]string{
+		"risk":              "/risks/",
+		"supplier":          "/suppliers/",
+		"asset":             "/assets/",
+		"system":            "/systems/",
+		"legal_requirement": "/legal/",
+		"incident":          "/incidents/",
+		"change_request":    "/changes/",
+		"corrective_action": "/corrective-actions/",
+		"task":              "/tasks/",
+	}[entityType]
+	// objective / audit* use tab-nested routes with no flat deep-link — deliberately unlinked.
+	if prefix == "" {
+		return ""
+	}
+	return prefix + entityID
 }
 
 // getUserEmail extracts the authenticated user email from context or headers.
@@ -2482,6 +2518,15 @@ func (s *Server) handleCreateChange(c echo.Context) error {
 		Action: "change_requested",
 		Detail: fmt.Sprintf("Change request: %s", cr.Title),
 	})
+
+	// Notify anyone @-mentioned in the change's free-text fields (#4). Create-only
+	// (not on update) so re-saving a persistent field doesn't re-notify — new
+	// mentions added during collaboration go through comments.
+	s.notifyMentions(ctx, orgID, cr.RequestedBy,
+		strings.Join([]string{cr.Description, cr.Justification, cr.Notes, cr.RollbackPlan}, "\n"),
+		fmt.Sprintf("%s mentioned you in a change request", cr.RequestedBy),
+		entityLink("change_request", strconv.Itoa(cr.ID)))
+
 	return c.JSON(http.StatusCreated, cr)
 }
 

--- a/internal/isms/api/api_entity_comments.go
+++ b/internal/isms/api/api_entity_comments.go
@@ -66,6 +66,12 @@ func (s *Server) handleCreateEntityComment(c echo.Context) error {
 		Detail: fmt.Sprintf("Comment on %s %s: %s", req.EntityType, req.EntityID, truncateStr(req.Body, 80)),
 	})
 
+	// Notify anyone @-mentioned in the comment (#4) — works on any entity type,
+	// so change-request comments (and every other register) pull members in.
+	s.notifyMentions(ctx, orgID, actor, req.Body,
+		fmt.Sprintf("%s mentioned you in a comment", actor),
+		entityLink(req.EntityType, req.EntityID))
+
 	return c.JSON(http.StatusCreated, comment)
 }
 

--- a/tests/test_review_mentions.py
+++ b/tests/test_review_mentions.py
@@ -64,6 +64,29 @@ def test_unknown_handle_and_self_mention_produce_no_notification(api_url, admin_
         "author self-mention must not create a notification"
 
 
+def test_entity_comment_mention_notifies_the_member(api_url, admin_headers, reader_headers):
+    """#4 slice 2: @-mentioning in an entity comment (any register — here a change
+    request) notifies the member, linking to the entity.
+
+    The link uses the entity IDENTIFIER (what CommentsPanel sends as entity_id,
+    e.g. /changes/CR-1). This is deliberate and load-bearing: the register views'
+    openXFromRoute resolve the route param by numeric id OR identifier, so an
+    identifier link opens the entity. Don't "fix" this to a numeric link without
+    the numeric id in hand — the backend only has the identifier here."""
+    suffix = uuid.uuid4().hex[:8]
+    entity_id = f"chg-{suffix}"
+    handle = READER_EMAIL.split("@")[0]
+    c = requests.post(f"{api_url}/entity-comments", headers=admin_headers, json={
+        "entity_type": "change_request", "entity_id": entity_id,
+        "body": f"@{handle} can you own the rollback step?",
+    })
+    assert c.status_code in (200, 201), c.text
+
+    items = _notifications(api_url, reader_headers)
+    assert any("mentioned you in a comment" in (n.get("title", "")) and f"/changes/{entity_id}" in (n.get("link") or "")
+               for n in items), "reader should have an entity-comment mention notification linking to the change"
+
+
 def test_scoped_package_token_is_not_a_mention(api_url, admin_headers, reader_headers):
     """`@handle/...` (e.g. @babel/core) is a package path, not a mention (#4 review)."""
     suffix = uuid.uuid4().hex[:8]

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -644,7 +644,7 @@ async function selectItem(item) {
 
 async function openItemFromRoute(id) {
   const numId = parseInt(id)
-  let item = assets.value.find(a => a.id === numId)
+  let item = assets.value.find(a => a.id === numId || a.identifier === id)
   if (!item) {
     try { item = await api.fetchJSON(`/api/v1/assets/${numId}`) } catch { return }
   }

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -714,7 +714,7 @@ async function saveSection() {
 
 async function openChangeFromRoute(id) {
   const numId = parseInt(id)
-  let cr = changes.value.find(c => c.id === numId)
+  let cr = changes.value.find(c => c.id === numId || c.identifier === id)
   if (!cr) {
     try { cr = await api.fetchJSON(`/api/v1/changes/${numId}`) } catch { return }
   }

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -625,7 +625,7 @@ function resolveUserName(email) {
 
 async function openCAFromRoute(id) {
   const numId = parseInt(id)
-  let ca = actions.value.find(a => a.id === numId)
+  let ca = actions.value.find(a => a.id === numId || a.identifier === id)
   if (!ca) {
     try { ca = await api.fetchJSON(`/api/v1/corrective-actions/${numId}`) } catch { return }
   }

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -692,7 +692,7 @@ function resolveUserName(email) {
 
 async function openIncidentFromRoute(id) {
   const numId = parseInt(id)
-  let inc = incidents.value.find(i => i.id === numId)
+  let inc = incidents.value.find(i => i.id === numId || i.identifier === id)
   if (!inc) {
     try { inc = await api.fetchJSON(`/api/v1/incidents/${numId}`) } catch { return }
   }

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -731,7 +731,7 @@ async function selectItem(item) {
 async function openItemFromRoute(id) {
   const numId = parseInt(id)
   // Try current page first; otherwise fetch the item directly so deep links work across pages
-  let item = items.value.find(i => i.id === numId)
+  let item = items.value.find(i => i.id === numId || i.identifier === id)
   if (!item) {
     try { item = await api.fetchJSON(`/api/v1/legal/${numId}`) } catch { return }
   }

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -1017,7 +1017,7 @@ async function selectRisk(risk) {
 
 async function openRiskFromRoute(id) {
   const numId = parseInt(id)
-  let risk = risks.value.find(r => r.id === numId)
+  let risk = risks.value.find(r => r.id === numId || r.identifier === id)
   if (!risk) {
     try { risk = await api.fetchJSON(`/api/v1/risks/${numId}`) } catch { return }
   }

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -756,7 +756,7 @@ async function selectItem(item) {
 
 async function openItemFromRoute(id) {
   const numId = parseInt(id)
-  let item = suppliers.value.find(s => s.id === numId)
+  let item = suppliers.value.find(s => s.id === numId || s.identifier === id)
   if (!item) {
     try { item = await api.fetchJSON(`/api/v1/suppliers/${numId}`) } catch { return }
   }

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -839,7 +839,7 @@ async function selectItem(item) {
 
 async function openItemFromRoute(id) {
   const numId = parseInt(id)
-  let item = systems.value.find(s => s.id === numId)
+  let item = systems.value.find(s => s.id === numId || s.identifier === id)
   if (!item) {
     try { item = await api.fetchJSON(`/api/v1/systems/${numId}`) } catch { return }
   }

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -801,7 +801,7 @@ async function generateOverdueTasks() {
 
 async function openTaskFromRoute(id) {
   const numId = parseInt(id)
-  let task = tasks.value.find(t => t.id === numId)
+  let task = tasks.value.find(t => t.id === numId || t.identifier === id)
   if (!task) {
     try { task = await api.fetchJSON(`/api/v1/tasks/${numId}`) } catch { return }
   }


### PR DESCRIPTION
Closes #4

Slice 2 (slice 1 = review comments, merged in #110). Mentions + notifications now work across the app, not just reviews.

## What
- `notifyReviewMentions` generalized to `notifyMentions(…, title, link)`; review path unchanged.
- `handleCreateEntityComment` notifies @-mentions on **any** entity comment (change requests + all registers), linked via `entityLink(type,id)` (mirrors `router.js`).
- Change-request **description + rollback plan** notify @-mentions **on create**.

## Scope note
Field mentions (description/rollback) fire on **create only** — re-scanning a mutable field on every edit would re-notify the same people. Ongoing collaboration uses comments, which are append-only and notify once. If edit-time field mentions are wanted, that's a separate follow-up (needs new-vs-old diffing).

## Test plan
- [ ] `just test-go` green
- [ ] `just test tests/test_review_mentions.py` (entity-comment mention notification)