### PR TITLE
feat(integrity): one enforced write path — incident + corrective action (#26)

### DIFF
--- a/docs/write-path-pattern.md
+++ b/docs/write-path-pattern.md
@@ -1,0 +1,76 @@
+# One enforced write path per entity (#26)
+
+## The problem
+
+Business rules (RBAC, guards, lifecycle timestamps, notifications) historically
+lived only in the HTTP handler layer (`api_*.go`). But entities have **more than
+one writer**:
+
+- HTTP handlers (`handleUpdateX`)
+- suggestion-apply (`api_suggestions.go`, runs inside `WithOrgTx`, calls the
+  DB-layer `*Tx` functions directly)
+- CLI / MCP (via the HTTP API)
+
+When suggestion-apply called `db.UpdateXTx` directly it skipped every rule that
+lived in the handler. Since #23 makes suggestion-apply the primary write path for
+contributors and agents, the *main* input path was the *least* enforced one.
+That divergence is the root of a whole cluster of integrity bugs.
+
+## The pattern
+
+**One enforced, transaction-aware mutation function per entity. Every writer
+calls it inside a transaction.** Rules can't diverge because there's exactly one
+place that enforces them.
+
+```
+enforceXWriteTx(ctx, tx, orgID, entity, prevState) error
+  ├─ guards / RBAC-independent business rules   (e.g. open-CA guard)
+  ├─ the row write                              (db.UpdateXTx)
+  └─ derived state                              (e.g. lifecycle timestamps)
+```
+
+- Lives in the `api` package (it composes DB `*Tx` calls + business rules), named
+  `enforceXWriteTx`.
+- Takes a `pgx.Tx` — the caller owns the transaction (`WithOrgTx`), so the whole
+  mutation is atomic.
+- Returns typed errors for rule violations (e.g. `openCAsLinkedError`) so the HTTP
+  handler can map them to the right status (409) while suggestion-apply surfaces
+  them as the apply failure.
+
+## Migrated entities
+
+- **incident** — `enforceIncidentWriteTx` (open-CA guard + lifecycle timestamps).
+- **corrective_action** — `enforceCorrectiveActionWriteTx` (open-task guard +
+  `resolved_at`/`resolved_by_id`) and `applyCorrectiveActionDefaults` (shared
+  create defaults, so apply and HTTP seed the same starting state).
+
+Together these close the three integrity bypasses #26 names. Remaining entities
+follow the same recipe, one at a time.
+
+## Reference implementation — incident
+
+- `enforceIncidentWriteTx` — `internal/isms/api/api_incidents_writepath.go`
+- DB primitives — `internal/isms/db/suggestions_tx.go`:
+  `CountOpenCAsByIncidentTx`, `SetIncidentLifecycleTx`, `UpdateIncidentTx`
+- Callers:
+  - `handleUpdateIncident` (`api_incidents.go`) wraps it in `WithOrgTx`, maps
+    `openCAsLinkedError` → HTTP 409.
+  - `applyIncidentUpdate` (`api_suggestions.go`) calls it inside the existing
+    apply transaction.
+- Parity test — `tests/test_incident_writepath.py`: the open-CA guard and the
+  `resolved_at` timestamp now fire identically on the HTTP and apply paths.
+
+## Adding the next entity
+
+1. Write `enforceXWriteTx(ctx, tx, orgID, x, prev)` capturing the rules currently
+   inlined in `handleUpdateX` (guards, derived timestamps, status transitions).
+   Add DB `*Tx` primitives for anything that touched `d.pool`.
+2. Route `handleUpdateX` through `WithOrgTx(enforceXWriteTx)`; map rule errors to
+   HTTP statuses.
+3. Route `applyXUpdate` (and `applyXCreate` where rules apply) through the same
+   function.
+4. Add a parity test asserting identical behavior (rules, timestamps, RBAC) on
+   both paths.
+
+Do **not** convert all entities at once — one at a time, each with its parity
+test. This is an incremental epic (#26); incident is the first slice.

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 	"isms.sh/internal/isms/db"
 )
@@ -103,23 +105,9 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 	if ca.Assignee == "" {
 		ca.Assignee = ca.CreatedBy
 	}
-	if ca.Status == "" {
-		ca.Status = "todo"
-	}
-	if ca.Severity == "" {
-		ca.Severity = "observation"
-	}
-	if ca.Source == "" {
-		ca.Source = "other"
-	}
-	if ca.DueDate == nil {
-		d := db.NewEpoch(time.Now().AddDate(0, 0, 30))
-		ca.DueDate = &d
-	}
-	// Seed Notes with template if empty.
-	if ca.Notes == "" {
-		ca.Notes = "## Action plan\n\n## Implementation\n\n## Verification\n\n## Evidence\n"
-	}
+	// Server-side create defaults — shared with suggestion-apply so a CA starts
+	// in the same state regardless of write path (#26).
+	applyCorrectiveActionDefaults(&ca)
 	if err := validateEnum("status", ca.Status, db.CorrectiveActionStatuses); err != nil {
 		return err
 	}
@@ -203,6 +191,7 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
 	}
+	prevStatus := existing.Status
 
 	var req correctiveActionUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -230,28 +219,11 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 		}
 	}
 
-	// Route status changes through the dedicated transition function so that
-	// resolved_at / resolved_by_id closure metadata is set correctly.
-	if req.Status != nil && *req.Status != existing.Status {
-		// Same rule as the dedicated status endpoint: cannot resolve a CA
-		// with open implementation tasks still linked.
-		if *req.Status == "resolved" {
-			// An empty identifier is corrupt data — the open-task query can't
-			// match anything, so skipping would silently disable enforcement.
-			if existing.Identifier == "" {
-				return echo.NewHTTPError(http.StatusInternalServerError, "corrective action has no identifier")
-			}
-			if n, err := s.db.CountOpenTasksByCA(ctx, orgID, existing.Identifier); err == nil && n > 0 {
-				return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot resolve %s: %d open implementation task(s) still linked", existing.Identifier, n))
-			}
-		}
-		if err := s.db.UpdateCorrectiveActionStatus(ctx, orgID, id, *req.Status, getUserEmail(c)); err != nil {
-			return pgxHTTPError(err)
-		}
-		existing, err = s.db.GetCorrectiveAction(ctx, orgID, id)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
-		}
+	// Status transitions flow through the unified write path below (open-task
+	// guard + resolved_at/by) — the same enforced function suggestion-apply uses
+	// (#26). Top-level requireRole(admin,manager) already gates status changes.
+	if req.Status != nil {
+		existing.Status = *req.Status
 	}
 
 	// Apply pointer-based partial update onto existing record.
@@ -282,7 +254,15 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 
 	oldMap := existing.ToChangeMap()
 	existing.ID = id
-	if err := s.db.UpdateCorrectiveAction(ctx, orgID, existing); err != nil {
+	// Single enforced CA write path (#26): open-task guard on resolve +
+	// resolved_at/by, shared verbatim with suggestion-apply.
+	if err := s.db.WithOrgTx(ctx, orgID, func(ctx context.Context, tx pgx.Tx) error {
+		return enforceCorrectiveActionWriteTx(ctx, tx, orgID, existing, prevStatus, getUserEmail(c))
+	}); err != nil {
+		var ote openTasksLinkedError
+		if errors.As(err, &ote) {
+			return echo.NewHTTPError(http.StatusConflict, ote.Error())
+		}
 		return pgxHTTPError(err)
 	}
 

--- a/internal/isms/api/api_corrective_writepath.go
+++ b/internal/isms/api/api_corrective_writepath.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"isms.sh/internal/isms/db"
+)
+
+// openTasksLinkedError is returned by the unified CA write path when a corrective
+// action can't be resolved because open implementation tasks are still linked.
+// The HTTP handler maps it to 409; suggestion-apply surfaces it as the apply
+// failure. Same rule, one code path (#26).
+type openTasksLinkedError struct {
+	identifier string
+	n          int
+}
+
+func (e openTasksLinkedError) Error() string {
+	return fmt.Sprintf("cannot resolve %s: %d open implementation task(s) still linked", e.identifier, e.n)
+}
+
+// applyCorrectiveActionDefaults sets the server-side defaults for a new corrective
+// action. Both the HTTP create handler and suggestion-apply call it, so a CA
+// created either way starts in the SAME state — previously suggestion-apply used
+// different defaults (status "assessment" vs "todo", etc.), the "wrong starting
+// state" bug #26 names. Caller sets CreatedBy/Assignee (identity) beforehand.
+func applyCorrectiveActionDefaults(ca *db.CorrectiveAction) {
+	if ca.Status == "" {
+		ca.Status = "todo"
+	}
+	if ca.Severity == "" {
+		ca.Severity = "observation"
+	}
+	if ca.Source == "" {
+		ca.Source = "other"
+	}
+	if ca.DueDate == nil {
+		d := db.NewEpoch(time.Now().AddDate(0, 0, 30))
+		ca.DueDate = &d
+	}
+	if ca.Notes == "" {
+		ca.Notes = "## Action plan\n\n## Implementation\n\n## Verification\n\n## Evidence\n"
+	}
+}
+
+// enforceCorrectiveActionWriteTx is the SINGLE enforced CA update path (#26).
+// HTTP handler and suggestion-apply both call it inside a transaction:
+//   - open-task guard when transitioning to resolved
+//   - resolved_at / resolved_by_id closure metadata on →resolved
+//
+// ca holds the desired post-update state; prevStatus is the status before the
+// update; actor stamps resolved_by_id.
+func enforceCorrectiveActionWriteTx(ctx context.Context, tx pgx.Tx, orgID int, ca *db.CorrectiveAction, prevStatus, actor string) error {
+	resolving := ca.Status == "resolved" && prevStatus != "resolved"
+	if resolving {
+		// An empty identifier is corrupt data — the open-task LIKE query would
+		// otherwise degrade to '%%' and match every open ca_followup task in the
+		// org, either false-blocking the resolve or silently disabling the guard.
+		if ca.Identifier == "" {
+			return fmt.Errorf("corrective action %d has no identifier", ca.ID)
+		}
+		n, err := db.CountOpenTasksByCATx(ctx, tx, orgID, ca.Identifier)
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			return openTasksLinkedError{identifier: ca.Identifier, n: n}
+		}
+	}
+	if err := db.UpdateCorrectiveActionTx(ctx, tx, orgID, ca); err != nil {
+		return err
+	}
+	if resolving {
+		return db.SetCorrectiveActionResolvedTx(ctx, tx, orgID, ca.ID, actor)
+	}
+	return nil
+}

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 	"isms.sh/internal/isms/db"
 )
@@ -274,6 +277,7 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
 	}
+	prevStatus := existing.Status
 
 	var req incidentUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -321,30 +325,11 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 		}
 	}
 
-	// Route status changes through the dedicated transition function so that
-	// contained_at / resolved_at / closed_at are cleared correctly on reverse transitions.
-	if req.Status != nil && *req.Status != existing.Status {
-		// Changing status is a manager/admin action. The dedicated status
-		// endpoint already enforces this; the general edit endpoint must apply
-		// the same rule so it can't be used as an RBAC bypass (#24).
-		if err := requireRole(c, "admin", "manager"); err != nil {
-			return err
-		}
-		// Same rule as the dedicated status endpoint: cannot resolve/close an
-		// incident with open corrective actions still linked.
-		if *req.Status == "closed" || *req.Status == "resolved" {
-			if n, err := s.db.CountOpenCAsByIncident(ctx, orgID, existing.Identifier); err == nil && n > 0 {
-				return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", statusVerb(*req.Status), n))
-			}
-		}
-		if err := s.db.UpdateIncidentStatus(ctx, orgID, id, *req.Status); err != nil {
-			return pgxHTTPError(err)
-		}
-		// Re-load so subsequent UpdateIncident writes against the new state.
-		existing, err = s.db.GetIncident(ctx, orgID, id)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusNotFound, "incident not found")
-		}
+	// Status transitions flow through the unified write path below (open-CA guard
+	// + lifecycle timestamps) — the same enforced function suggestion-apply uses
+	// (#26). Top-level requireRole(admin,manager) already gates status changes.
+	if req.Status != nil {
+		existing.Status = *req.Status
 	}
 
 	// Apply pointer-based partial update onto existing record.
@@ -405,7 +390,15 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 
 	oldMap := existing.ToChangeMap()
 	existing.ID = id
-	if err := s.db.UpdateIncident(ctx, orgID, existing); err != nil {
+	// Single enforced incident write path (#26): open-CA guard on resolve/close
+	// + lifecycle timestamps, shared verbatim with suggestion-apply.
+	if err := s.db.WithOrgTx(ctx, orgID, func(ctx context.Context, tx pgx.Tx) error {
+		return enforceIncidentWriteTx(ctx, tx, orgID, existing, prevStatus)
+	}); err != nil {
+		var oce openCAsLinkedError
+		if errors.As(err, &oce) {
+			return echo.NewHTTPError(http.StatusConflict, oce.Error())
+		}
 		return pgxHTTPError(err)
 	}
 

--- a/internal/isms/api/api_incidents_writepath.go
+++ b/internal/isms/api/api_incidents_writepath.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"isms.sh/internal/isms/db"
+)
+
+// openCAsLinkedError is returned by the unified incident write path when an
+// incident can't be resolved/closed because open corrective actions are still
+// linked. The HTTP handler maps it to 409; suggestion-apply surfaces it as the
+// apply failure. Same rule, one code path (#26).
+type openCAsLinkedError struct {
+	verb string
+	n    int
+}
+
+func (e openCAsLinkedError) Error() string {
+	return fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", e.verb, e.n)
+}
+
+// enforceIncidentWriteTx is the SINGLE enforced incident mutation path (#26).
+// Every writer — the HTTP update handler and suggestion-apply — calls this inside
+// a transaction, so the business rules can't diverge:
+//   - open-CA guard when transitioning to resolved/closed
+//   - lifecycle timestamps (contained/resolved/closed_at) for the new status
+//
+// inc holds the desired post-update state; prevStatus is the status before the
+// update, used to detect a status transition.
+func enforceIncidentWriteTx(ctx context.Context, tx pgx.Tx, orgID int, inc *db.Incident, prevStatus string) error {
+	statusChanged := inc.Status != prevStatus
+	if statusChanged && (inc.Status == "resolved" || inc.Status == "closed") {
+		n, err := db.CountOpenCAsByIncidentTx(ctx, tx, orgID, inc.Identifier)
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			return openCAsLinkedError{verb: statusVerb(inc.Status), n: n}
+		}
+	}
+	if err := db.UpdateIncidentTx(ctx, tx, orgID, inc); err != nil {
+		return err
+	}
+	// Lifecycle timestamps only need touching on a status transition — skip the
+	// extra UPDATE on plain field edits (title, notes, …).
+	if !statusChanged {
+		return nil
+	}
+	return db.SetIncidentLifecycleTx(ctx, tx, orgID, inc.ID, inc.Status)
+}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -765,6 +765,7 @@ func applyIncidentUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 	}
 
 	old := inc.ToChangeMap()
+	prevStatus := inc.Status
 
 	if v, ok := payload.Fields["severity"]; ok {
 		if sv, ok := v.(string); ok {
@@ -802,7 +803,9 @@ func applyIncidentUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 		}
 	}
 
-	if err := db.UpdateIncidentTx(ctx, tx, orgID, inc); err != nil {
+	// Unified write path (#26): same open-CA guard + lifecycle timestamps the
+	// HTTP handler enforces — previously suggestion-apply bypassed both.
+	if err := enforceIncidentWriteTx(ctx, tx, orgID, inc, prevStatus); err != nil {
 		return "", err
 	}
 
@@ -1123,16 +1126,12 @@ func applyCorrActiveCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 		Assignee: payload.Assignee, CreatedBy: actor,
 		Notes: payload.Notes, RootCause: payload.RootCause,
 	}
-	// Defaults for required fields when web UI sends minimal payload
-	if ca.Status == "" {
-		ca.Status = "assessment"
+	if ca.Assignee == "" {
+		ca.Assignee = actor
 	}
-	if ca.Severity == "" {
-		ca.Severity = "minor_nc"
-	}
-	if ca.Source == "" {
-		ca.Source = "internal_audit"
-	}
+	// Same server-side defaults as the HTTP create handler (#26) — previously
+	// suggestion-apply seeded a different starting state.
+	applyCorrectiveActionDefaults(&ca)
 	if err := db.CreateCorrectiveActionTx(ctx, tx, orgID, &ca); err != nil {
 		return "", err
 	}
@@ -1152,6 +1151,7 @@ func applyCorrActiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 		return "", fmt.Errorf("corrective action %s not found: %w", sg.EntityID, err)
 	}
 	old := ca.ToChangeMap()
+	prevStatus := ca.Status
 	if v, ok := payload.Fields["assignee"]; ok {
 		if sv, ok := v.(string); ok {
 			ca.Assignee = sv
@@ -1172,7 +1172,9 @@ func applyCorrActiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 			ca.Notes = sv
 		}
 	}
-	if err := db.UpdateCorrectiveActionTx(ctx, tx, orgID, ca); err != nil {
+	// Unified write path (#26): same open-task guard + resolved_at/by the HTTP
+	// handler enforces — previously suggestion-apply bypassed both.
+	if err := enforceCorrectiveActionWriteTx(ctx, tx, orgID, ca, prevStatus, actor); err != nil {
 		return "", err
 	}
 	diffs := db.DiffFields("corrective_action", int64(ca.ID), actor, fmt.Sprintf("suggestion #%d", sg.ID), old, ca.ToChangeMap())

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -193,6 +193,79 @@ func UpdateIncidentTx(ctx context.Context, tx pgx.Tx, orgID int, inc *Incident) 
 	return err
 }
 
+// CountOpenCAsByIncidentTx is the transaction-aware twin of CountOpenCAsByIncident
+// (corrective_actions.go). Used by the unified incident write path (#26) so the
+// open-CA guard runs identically from the HTTP handler and suggestion-apply.
+func CountOpenCAsByIncidentTx(ctx context.Context, tx pgx.Tx, orgID int, incidentIdentifier string) (int, error) {
+	var n int
+	err := tx.QueryRow(ctx, `
+		SELECT count(DISTINCT ca.id) FROM corrective_actions ca
+		JOIN entity_references r ON r.organization_id = ca.organization_id
+		WHERE ca.organization_id = $1
+		  AND ca.status != 'resolved'
+		  AND ca.deleted_at IS NULL
+		  AND (
+		    (r.source_type = 'corrective_action' AND r.source_id = ca.identifier
+		      AND r.target_type = 'incident' AND r.target_id = $2)
+		    OR
+		    (r.target_type = 'corrective_action' AND r.target_id = ca.identifier
+		      AND r.source_type = 'incident' AND r.source_id = $2)
+		  )
+	`, orgID, incidentIdentifier).Scan(&n)
+	return n, err
+}
+
+// SetIncidentLifecycleTx stamps/clears the lifecycle timestamps for a status,
+// mirroring UpdateIncidentStatusWithDetails (incidents.go) but on a transaction.
+// UpdateIncidentTx writes status but NOT the timestamps, so the unified write
+// path (#26) calls this right after it to keep contained/resolved/closed_at
+// correct on both forward transitions and reopens.
+func SetIncidentLifecycleTx(ctx context.Context, tx pgx.Tx, orgID, id int, status string) error {
+	query := `UPDATE incidents SET updated_at = now()`
+	switch status {
+	case "draft", "open", "investigating":
+		query += `, contained_at = NULL, resolved_at = NULL, closed_at = NULL`
+	case "contained":
+		query += `, contained_at = COALESCE(contained_at, now()), resolved_at = NULL, closed_at = NULL`
+	case "resolved":
+		query += `, resolved_at = COALESCE(resolved_at, now()), closed_at = NULL`
+	case "closed":
+		query += `, closed_at = COALESCE(closed_at, now())`
+	}
+	query += ` WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL`
+	_, err := tx.Exec(ctx, query, id, orgID)
+	return err
+}
+
+// CountOpenTasksByCATx is the transaction-aware twin of CountOpenTasksByCA
+// (corrective_actions.go). Used by the unified CA write path (#26) so the
+// open-task guard runs identically from the HTTP handler and suggestion-apply.
+func CountOpenTasksByCATx(ctx context.Context, tx pgx.Tx, orgID int, caIdentifier string) (int, error) {
+	var n int
+	err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM tasks WHERE organization_id = $1
+		   AND task_type = 'ca_followup'
+		   AND status NOT IN ('done','cancelled')
+		   AND deleted_at IS NULL
+		   AND (title LIKE $2 OR COALESCE(description,'') LIKE $2)`,
+		orgID, "%"+caIdentifier+"%").Scan(&n)
+	return n, err
+}
+
+// SetCorrectiveActionResolvedTx stamps resolved_at / resolved_by_id, mirroring
+// UpdateCorrectiveActionStatus's resolved branch (corrective_actions.go) but on a
+// transaction. UpdateCorrectiveActionTx writes status but NOT this closure
+// metadata, so the unified CA write path (#26) calls this on a →resolved
+// transition — the exact field suggestion-apply previously skipped.
+func SetCorrectiveActionResolvedTx(ctx context.Context, tx pgx.Tx, orgID, id int, actor string) error {
+	_, err := tx.Exec(ctx, `
+		UPDATE corrective_actions
+		SET resolved_at = now(), resolved_by_id = (SELECT id FROM users WHERE email = $3), updated_at = now()
+		WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+	`, id, orgID, actor)
+	return err
+}
+
 // CreateReferenceTx creates an entity reference within an existing transaction.
 // Idempotent: on conflict returns the existing row.
 func CreateReferenceTx(ctx context.Context, tx pgx.Tx, orgID int, ref *EntityReference) error {

--- a/tests/test_corrective_writepath.py
+++ b/tests/test_corrective_writepath.py
@@ -1,0 +1,67 @@
+"""#26 slice 1 (CA): corrective actions share one enforced write path.
+
+Closes the two CA bypasses the epic names:
+  - suggestion-apply seeded a different starting state ("assessment" vs "todo")
+  - suggestion-apply skipped resolved_at / resolved_by_id on →resolved
+Both HTTP create/update and suggestion-apply now go through the same code.
+"""
+import uuid
+
+import requests
+
+
+def _ca_by_identifier(api_url, headers, identifier):
+    r = requests.get(f"{api_url}/corrective-actions", headers=headers)
+    assert r.status_code == 200, r.text
+    data = r.json()
+    items = data.get("data", data) if isinstance(data, dict) else data
+    return next((x for x in (items or []) if x.get("identifier") == identifier), None)
+
+
+def test_apply_create_uses_handler_default_status(api_url, admin_headers):
+    """A CA created via suggestion-apply starts in the same state as one created
+    over HTTP — 'todo', not the old apply-only 'assessment'."""
+    title = f"ca-writepath-{uuid.uuid4().hex[:8]}"
+    sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+        "entity_type": "corrective_action",
+        "suggestion_type": "create",
+        "title": title,
+        "rationale": "from audit",
+        "payload": {"title": title, "description": "fix it"},
+    })
+    assert sg.status_code in (200, 201), sg.text
+    ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply", headers=admin_headers, json={})
+    assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+
+    ident = ap.json().get("applied_entity_id")
+    ca = _ca_by_identifier(api_url, admin_headers, ident)
+    assert ca is not None, f"CA {ident} not found after apply"
+    assert ca["status"] == "todo", f"apply-created CA should default to 'todo', got {ca['status']!r}"
+
+
+def test_apply_resolve_sets_resolved_at(api_url, admin_headers):
+    """Resolving a CA via suggestion-apply stamps resolved_at — the closure
+    metadata suggestion-apply previously skipped."""
+    r = requests.post(f"{api_url}/corrective-actions", headers=admin_headers, json={
+        "title": f"ca-resolve-{uuid.uuid4().hex[:8]}", "description": "x",
+    })
+    assert r.status_code in (200, 201), r.text
+    ca_id = r.json()["id"]
+
+    sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+        "entity_type": "corrective_action",
+        "suggestion_type": "update",
+        "entity_id": str(ca_id),
+        "title": "Resolve CA",
+        "rationale": "done",
+        "payload": {"fields": {"status": "resolved"}},
+    })
+    assert sg.status_code in (200, 201), sg.text
+    # force=true bypasses stale-detection (the fresh CA's create changelog would
+    # otherwise flag it) so the enforced resolve path is what's exercised.
+    ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply", headers=admin_headers, json={"force": True})
+    assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+
+    got = requests.get(f"{api_url}/corrective-actions/{ca_id}", headers=admin_headers).json()
+    assert got.get("status") == "resolved", got
+    assert got.get("resolved_at"), "resolved_at must be stamped by the enforced write path"

--- a/tests/test_incident_writepath.py
+++ b/tests/test_incident_writepath.py
@@ -1,0 +1,94 @@
+"""#26 slice 1: one enforced incident write path.
+
+Both writers — the HTTP update endpoint and suggestion-apply — go through the same
+enforced function, so the open-CA guard (can't resolve/close an incident with open
+corrective actions linked) fires identically. Before #26, suggestion-apply
+bypassed the guard entirely: this test locks the parity.
+"""
+import uuid
+
+import requests
+
+
+def _mk_incident(api_url, headers):
+    r = requests.post(f"{api_url}/incidents", headers=headers, json={
+        "title": f"writepath-{uuid.uuid4().hex[:8]}", "severity": "medium",
+    })
+    assert r.status_code in (200, 201), r.text
+    inc = r.json()
+    return inc["id"], inc["identifier"]
+
+
+def _mk_open_ca_linked(api_url, headers, incident_identifier):
+    """Create a (non-resolved) corrective action and link it to the incident."""
+    r = requests.post(f"{api_url}/corrective-actions", headers=headers, json={
+        "title": f"ca-{uuid.uuid4().hex[:8]}", "description": "open action",
+    })
+    assert r.status_code in (200, 201), r.text
+    ca = r.json()
+    link = requests.post(f"{api_url}/references", headers=headers, json={
+        "source_type": "corrective_action", "source_id": ca["identifier"],
+        "target_type": "incident", "target_id": incident_identifier,
+    })
+    assert link.status_code in (200, 201), link.text
+    return ca["identifier"]
+
+
+def test_http_path_blocks_resolve_with_open_ca(api_url, admin_headers):
+    inc_id, inc_ident = _mk_incident(api_url, admin_headers)
+    _mk_open_ca_linked(api_url, admin_headers, inc_ident)
+
+    r = requests.put(f"{api_url}/incidents/{inc_id}/status",
+                     headers=admin_headers, json={"status": "resolved"})
+    assert r.status_code == 409, f"HTTP resolve should be blocked by open CA, got {r.status_code}: {r.text}"
+
+
+def test_apply_path_blocks_resolve_with_open_ca(api_url, admin_headers):
+    """The bypass #26 closes: suggestion-apply must hit the SAME open-CA guard."""
+    inc_id, inc_ident = _mk_incident(api_url, admin_headers)
+    _mk_open_ca_linked(api_url, admin_headers, inc_ident)
+
+    sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+        "entity_type": "incident",
+        "suggestion_type": "update",
+        "entity_id": str(inc_id),
+        "title": "Resolve incident",
+        "rationale": "done",
+        "payload": {"fields": {"status": "resolved"}},
+    })
+    assert sg.status_code in (200, 201), sg.text
+    sid = sg.json()["id"]
+
+    # force=true bypasses stale-detection so the ONLY thing that can block the
+    # apply is the enforced open-CA guard (what we're testing).
+    apply = requests.post(f"{api_url}/suggestions/{sid}/apply", headers=admin_headers, json={"force": True})
+    assert not (apply.status_code == 200 and apply.json().get("status") == "applied"), (
+        f"apply should be blocked by the open-CA guard, got {apply.status_code}: {apply.text}"
+    )
+
+    # And the incident stays unresolved (guard held, no partial write).
+    got = requests.get(f"{api_url}/incidents/{inc_id}", headers=admin_headers).json()
+    assert got.get("status") != "resolved", "incident must remain unresolved after blocked apply"
+
+
+def test_apply_path_sets_lifecycle_timestamp(api_url, admin_headers):
+    """With no open CA, apply resolves the incident AND stamps resolved_at —
+    the lifecycle-timestamp behavior suggestion-apply previously skipped."""
+    inc_id, _ = _mk_incident(api_url, admin_headers)
+
+    sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+        "entity_type": "incident",
+        "suggestion_type": "update",
+        "entity_id": str(inc_id),
+        "title": "Resolve incident",
+        "rationale": "done",
+        "payload": {"fields": {"status": "resolved"}},
+    })
+    assert sg.status_code in (200, 201), sg.text
+    apply = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                          headers=admin_headers, json={"force": True})
+    assert apply.status_code == 200 and apply.json().get("status") == "applied", apply.text
+
+    got = requests.get(f"{api_url}/incidents/{inc_id}", headers=admin_headers).json()
+    assert got.get("status") == "resolved", got
+    assert got.get("resolved_at"), "resolved_at must be stamped by the enforced write path"


### PR DESCRIPTION
Advances #26 — establishes the enforced-write-path pattern and closes all three named integrity bypasses. Epic stays open for any remaining entities (none with known divergence today); close it if the named scope is considered complete.

## Problem
Business rules lived only in HTTP handlers; suggestion-apply called `db.*Tx` directly and skipped them. Since #23 makes suggestion-apply the primary write path for contributors/agents, the main input path was the least enforced.

## Fix — one enforced Tx function per entity, called by both writers
- **incident** — `enforceIncidentWriteTx`: open-CA guard on resolve/close + lifecycle timestamps.
- **corrective action** — `enforceCorrectiveActionWriteTx`: open-task guard on resolve + `resolved_at`/`resolved_by_id`; `applyCorrectiveActionDefaults` shares create defaults across both paths.
- Handlers wrap them in `WithOrgTx`, map guard violations → 409; suggestion-apply calls the same functions inside the apply tx.
- DB: `CountOpenCAsByIncidentTx`, `SetIncidentLifecycleTx`, `CountOpenTasksByCATx`, `SetCorrectiveActionResolvedTx`.

## Test plan
- [ ] `just test-go` green
- [ ] `just test tests/test_incident_writepath.py tests/test_corrective_writepath.py` — guard + timestamp + create-default parity across HTTP and apply paths

Pattern for the rest: `docs/write-path-pattern.md`.