### PR TITLE
fix(cli): honor ISMS_ROOT / --root for clone, sync, git (#124)

### DIFF
--- a/cmd/isms/clone.go
+++ b/cmd/isms/clone.go
@@ -20,7 +20,8 @@ func cloneCmd() *cobra.Command {
 		Short: "Clone the ISMS repository from the server",
 		Long: `Clone the organization's ISMS git repository from the server.
 
-Directory defaults to {org-slug}-isms. All config comes from your env file:
+Directory defaults to the configured root (--root or ISMS_ROOT), else
+{org-slug}-isms. All config comes from your env file:
   ISMS_BASE_URL, ISMS_API_TOKEN, ISMS_ORGANIZATION`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get base URL and token from env
@@ -50,13 +51,20 @@ Directory defaults to {org-slug}-isms. All config comes from your env file:
 				return fmt.Errorf("token is not scoped to an organization")
 			}
 
-			// Target directory
+			// Target directory. Precedence: explicit --dir/arg, then the
+			// configured root (--root or ISMS_ROOT) so clone and the other local
+			// commands agree on where the repo lives, then {slug}-isms.
 			target := dir
 			if target == "" && len(args) > 0 {
 				target = args[0]
 			}
 			if target == "" {
-				target = info.OrganizationSlug + "-isms"
+				if r := configuredRoot(); r != "" {
+					target = r
+					fmt.Printf("Using configured root %s (from --root/ISMS_ROOT)\n", target)
+				} else {
+					target = info.OrganizationSlug + "-isms"
+				}
 			}
 
 			if _, err := os.Stat(target); err == nil {

--- a/cmd/isms/git.go
+++ b/cmd/isms/git.go
@@ -18,16 +18,16 @@ func gitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "git [-- git-args...]",
 		Short:              "Run a git command inside the ISMS repo (auth handled)",
-		Long:               "Thin passthrough to the system `git` CLI. Runs in the ISMS repo root and uses the credential helper that `isms sync` configured for the remote, so the user does not have to manage tokens.",
+		Long:               "Thin passthrough to the system `git` CLI. Runs in the ISMS repo root and uses the credential helper that `isms sync` configured for the remote, so the user does not have to manage tokens.\n\nNote: --root is NOT supported here (args are passed straight through to the system git CLI) — use ISMS_ROOT to point at a clone from another directory.",
 		DisableFlagParsing: true,
 		Args:               cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := exec.LookPath("git"); err != nil {
 				return fmt.Errorf("git CLI not found on PATH — install it")
 			}
-			root, err := gitRoot()
+			root, err := resolveRepoRoot()
 			if err != nil {
-				return fmt.Errorf("not in an ISMS git repository — run `isms clone` first")
+				return fmt.Errorf("no ISMS repo found — set ISMS_ROOT, or cd into your clone (or run `isms clone`)")
 			}
 			// Refresh credential helper for the current API token. Idempotent —
 			// catches older repos that were cloned before the helper code worked.

--- a/cmd/isms/main.go
+++ b/cmd/isms/main.go
@@ -113,20 +113,25 @@ func isServerCommand(cmd *cobra.Command) bool {
 	return false
 }
 
-func getRoot() string {
+// configuredRoot returns the explicitly configured repo root — the --root flag,
+// else ISMS_ROOT — or "" if neither is set. The single place that encodes that
+// precedence, shared by resolveRepoRoot and clone so they can't drift.
+func configuredRoot() string {
 	if ismsRoot != "" {
 		return ismsRoot
 	}
-	if v := os.Getenv("ISMS_ROOT"); v != "" {
-		return v
+	return os.Getenv("ISMS_ROOT")
+}
+
+// resolveRepoRoot locates the local ISMS clone for repo commands (sync, git):
+// the configured root (--root / ISMS_ROOT), then walking up from cwd to a .git.
+// Errors when none is found so commands fail clearly instead of silently
+// operating on the current directory.
+func resolveRepoRoot() (string, error) {
+	if r := configuredRoot(); r != "" {
+		return r, nil
 	}
-	if root, err := gitRoot(); err == nil {
-		return root
-	}
-	if cwd, err := os.Getwd(); err == nil {
-		return cwd
-	}
-	return "."
+	return gitRoot()
 }
 
 func gitRoot() (string, error) {

--- a/cmd/isms/sync.go
+++ b/cmd/isms/sync.go
@@ -41,10 +41,10 @@ and reset to main.`,
 				return err
 			}
 
-			// Verify we are inside a git repo
-			root, err := gitRoot()
+			// Locate the local clone: --root / ISMS_ROOT, else walk up from cwd.
+			root, err := resolveRepoRoot()
 			if err != nil {
-				return fmt.Errorf("not in a git repository — run 'isms init' first or cd into your ISMS repo")
+				return fmt.Errorf("no ISMS repo found — set ISMS_ROOT, pass --root, or cd into your clone")
 			}
 
 			repo, err := git.PlainOpen(root)


### PR DESCRIPTION
Closes #124

`ISMS_ROOT`/`--root` were dead config (only `getRoot()` read them, and it was never called). Now `resolveRepoRoot()` (`--root` → `ISMS_ROOT` → walk-up-to-.git) is the one resolver:
- `clone` uses the configured root as the target when no dir arg (prints it; still fails if it exists).
- `sync`/`git` find the repo from anywhere via the same resolver.

## Test plan
- [ ] `ISMS_ROOT=/tmp/x isms clone` → clones into /tmp/x, prints 'Using configured root'
- [ ] `ISMS_ROOT=/tmp/x isms sync` from a different cwd → operates on /tmp/x
- [ ] no ISMS_ROOT, inside a clone → sync/git still work (walk-up)
- [ ] `just test-go` green