### PR TITLE
feat(tui): read the local clone offline instead of the API (#126)

### DIFF
--- a/cmd/isms/tui.go
+++ b/cmd/isms/tui.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"isms.sh/internal/isms/tui"
 )
@@ -8,10 +10,14 @@ import (
 func tuiCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "tui",
-		Short: "Interactive terminal UI",
+		Short: "Interactive terminal reader for the local clone (offline)",
+		Long:  "Browse and read the documents in your local ISMS clone, offline. Reads the clone at --root / ISMS_ROOT, or walks up from the current directory — run `isms clone` first if you don't have one.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := requireAPI()
-			return tui.Run(c)
+			root, err := resolveRepoRoot()
+			if err != nil {
+				return fmt.Errorf("no ISMS repo found — set ISMS_ROOT or cd into your clone (run `isms clone` first)")
+			}
+			return tui.Run(root)
 		},
 	}
 }

--- a/internal/isms/tui/tui.go
+++ b/internal/isms/tui/tui.go
@@ -12,7 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
-	"isms.sh/internal/isms/client"
+	"isms.sh/internal/isms/store"
 )
 
 // mode controls the top-level layout.
@@ -24,17 +24,21 @@ const (
 )
 
 // item is a row in the document list — either a folder header or a document.
+// Document rows cache the parsed body/version so the reader is fully offline —
+// no re-read when previewing or opening.
 type item struct {
 	docID    string // empty for folder rows
 	title    string
 	path     string // folder path for folder rows
 	status   string
+	version  string
+	body     string // markdown body (frontmatter stripped), empty for folder rows
 	isFolder bool
 }
 
 // Model is the bubbletea model for the document TUI.
 type Model struct {
-	client   *client.Client
+	store    *store.Store
 	width    int
 	height   int
 	ready    bool
@@ -56,14 +60,14 @@ const (
 	helpHeight    = 1
 )
 
-// New creates a new document-focused TUI model.
-func New(c *client.Client) Model {
+// New creates a document-focused TUI model that reads the local clone at root.
+func New(root string) Model {
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 		glamour.WithWordWrap(80),
 	)
 	m := Model{
-		client:   c,
+		store:    store.New(root),
 		renderer: r,
 	}
 	m.loadDocuments()
@@ -182,7 +186,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.mode == modeList {
 			vis := m.visibleItems()
 			if m.cursor < len(vis) && !vis[m.cursor].isFolder {
-				m.openDocument(vis[m.cursor].docID)
+				m.openDocument(vis[m.cursor])
 			}
 		}
 		return m, nil
@@ -373,34 +377,22 @@ func (m Model) renderPreview() string {
 			Foreground(lipgloss.Color("240")).PaddingLeft(2).PaddingTop(1).
 			Render("Folder — select a document.")
 	}
-	doc, err := m.client.GetDocumentBody(it.docID)
-	if err != nil || doc == nil {
-		return lipgloss.NewStyle().Width(w).Height(h).
-			Foreground(lipgloss.Color("203")).PaddingLeft(2).PaddingTop(1).
-			Render("Could not load document.")
-	}
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 		glamour.WithWordWrap(w-4),
 	)
-	body := stripFrontmatter(doc.Body)
-	rendered, _ := r.Render(body)
-	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).Render(doc.Title)
+	rendered, _ := r.Render(it.body)
+	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).Render(it.title)
 	meta := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
-		fmt.Sprintf("%s · %s · v%s · enter to read", doc.DocumentID, doc.Status, doc.Version))
+		fmt.Sprintf("%s · %s · v%s · enter to read", it.docID, it.status, it.version))
 	combined := header + "\n" + meta + "\n\n" + rendered
 	return lipgloss.NewStyle().Width(w).Height(h).PaddingLeft(2).PaddingTop(1).Render(combined)
 }
 
-// openDocument fetches and renders a single document into the viewport.
-func (m *Model) openDocument(docID string) {
-	doc, err := m.client.GetDocumentBody(docID)
-	if err != nil || doc == nil {
-		m.loadErr = "Could not load document: " + docID
-		return
-	}
-	m.docBody = stripFrontmatter(doc.Body)
-	m.docTitle = fmt.Sprintf("%s — %s (%s, v%s)", doc.DocumentID, doc.Title, doc.Status, doc.Version)
+// openDocument renders the selected (already-loaded) document into the viewport.
+func (m *Model) openDocument(it item) {
+	m.docBody = it.body
+	m.docTitle = fmt.Sprintf("%s — %s (%s, v%s)", it.docID, it.title, it.status, it.version)
 	m.mode = modeReader
 	m.rebuildViewport()
 	m.rerender()
@@ -420,52 +412,32 @@ func (m *Model) rerender() {
 	m.viewport.SetContent(m.rendered)
 }
 
-// loadDocuments fetches the document tree and flattens it into the list.
+// loadDocuments reads the local clone: one section header per top-level folder,
+// with its documents (recursively, flattened) listed under it. Bodies are parsed
+// and cached now so preview/read need no re-read.
 func (m *Model) loadDocuments() {
-	folders, err := m.client.ListAllDocuments()
-	if err != nil {
-		m.loadErr = err.Error()
-		return
-	}
 	m.items = nil
-	for _, f := range folders {
-		m.collectFolder(f, f.Title, 0)
-	}
-}
-
-func (m *Model) collectFolder(f client.DocFolder, label string, depth int) {
-	if label == "" {
-		label = f.Name
-	}
-	all := append([]client.DocSummary{}, f.Files...)
-	for _, sub := range f.SubFolders {
-		// Inline subfolder files into the parent for a flat layout — folder
-		// headers stay only at the top level so the list reads as section
-		// dividers, not a nested tree.
-		all = append(all, sub.Files...)
-	}
-	if len(all) == 0 && len(f.SubFolders) == 0 {
-		return
-	}
-
-	if depth == 0 {
-		m.items = append(m.items, item{title: strings.ToUpper(label), isFolder: true, path: f.Name})
-	}
-
-	sort.SliceStable(all, func(i, j int) bool {
-		return all[i].DocumentID < all[j].DocumentID
-	})
-	for _, d := range all {
-		m.items = append(m.items, item{
-			docID:  d.DocumentID,
-			title:  d.Title,
-			status: d.Status,
-		})
-	}
-	if depth == 0 {
-		for _, sub := range f.SubFolders {
-			m.collectFolder(sub, sub.Title, depth+1)
+	for _, folder := range m.store.ListDocFolders() {
+		docs, err := m.store.LoadDocumentsFromDir(folder)
+		if err != nil || len(docs) == 0 {
+			continue
 		}
+		m.items = append(m.items, item{title: strings.ToUpper(folder), isFolder: true, path: folder})
+		sort.SliceStable(docs, func(i, j int) bool {
+			return docs[i].Frontmatter.DocumentID < docs[j].Frontmatter.DocumentID
+		})
+		for _, d := range docs {
+			m.items = append(m.items, item{
+				docID:   d.Frontmatter.DocumentID,
+				title:   d.Frontmatter.Title,
+				status:  d.Frontmatter.Status,
+				version: d.Frontmatter.Version,
+				body:    d.Body,
+			})
+		}
+	}
+	if len(m.items) == 0 {
+		m.loadErr = "No documents found in the local clone (looked under documents/)."
 	}
 }
 
@@ -485,18 +457,6 @@ func (m Model) visibleItems() []item {
 		}
 	}
 	return out
-}
-
-// stripFrontmatter removes a leading YAML frontmatter block from the body.
-func stripFrontmatter(s string) string {
-	if !strings.HasPrefix(s, "---\n") {
-		return s
-	}
-	end := strings.Index(s[4:], "\n---\n")
-	if end < 0 {
-		return s
-	}
-	return strings.TrimLeft(s[4+end+5:], "\n")
 }
 
 func padRight(s string, n int) string {
@@ -519,9 +479,9 @@ func truncRight(s string, n int) string {
 	return s[:n-1] + "…"
 }
 
-// Run starts the TUI.
-func Run(c *client.Client) error {
-	m := New(c)
+// Run starts the TUI against the local clone at root.
+func Run(root string) error {
+	m := New(root)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err := p.Run()
 	return err

--- a/internal/isms/tui/tui.go
+++ b/internal/isms/tui/tui.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -32,7 +33,7 @@ type item struct {
 	path     string // folder path for folder rows
 	status   string
 	version  string
-	body     string // markdown body (frontmatter stripped), empty for folder rows
+	body     string // markdown body (frontmatter already parsed out by store), empty for folder rows
 	isFolder bool
 }
 
@@ -417,12 +418,17 @@ func (m *Model) rerender() {
 // and cached now so preview/read need no re-read.
 func (m *Model) loadDocuments() {
 	m.items = nil
+	var loadErrs []string
 	for _, folder := range m.store.ListDocFolders() {
 		docs, err := m.store.LoadDocumentsFromDir(folder)
-		if err != nil || len(docs) == 0 {
+		if err != nil {
+			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", folder, err))
 			continue
 		}
-		m.items = append(m.items, item{title: strings.ToUpper(folder), isFolder: true, path: folder})
+		if len(docs) == 0 {
+			continue
+		}
+		m.items = append(m.items, item{title: strings.ToUpper(m.folderLabel(folder)), isFolder: true, path: folder})
 		sort.SliceStable(docs, func(i, j int) bool {
 			return docs[i].Frontmatter.DocumentID < docs[j].Frontmatter.DocumentID
 		})
@@ -436,9 +442,22 @@ func (m *Model) loadDocuments() {
 			})
 		}
 	}
-	if len(m.items) == 0 {
+	if len(loadErrs) > 0 {
+		m.loadErr = "Failed to load: " + strings.Join(loadErrs, "; ")
+	} else if len(m.items) == 0 {
 		m.loadErr = "No documents found in the local clone (looked under documents/)."
 	}
+}
+
+// folderLabel returns the folder's display name — the content of a .title file
+// under it, the same convention the API-backed folder tree honored via
+// readDirTitle — falling back to the raw folder name when no .title is set.
+func (m *Model) folderLabel(folder string) string {
+	data, err := m.store.ReadFile(filepath.Join(m.store.DocsRoot(), folder, ".title"))
+	if err != nil || len(data) == 0 {
+		return folder
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func (m Model) visibleItems() []item {

--- a/internal/isms/tui/tui_test.go
+++ b/internal/isms/tui/tui_test.go
@@ -51,3 +51,57 @@ func TestNewLoadsLocalCloneDocuments(t *testing.T) {
 		t.Errorf("doc body not cached for offline read: %q", docRow.body)
 	}
 }
+
+// TestFolderHeaderUsesDotTitle verifies the folder header honors a .title file's
+// display name (as the API-backed tree did), not the raw directory name (#130 review).
+func TestFolderHeaderUsesDotTitle(t *testing.T) {
+	root := t.TempDir()
+	docDir := filepath.Join(root, "documents", "iso27001")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docDir, ".title"), []byte("ISO 27001:2022\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	md := "---\ndocument_id: iso27001-4-1\ntitle: Context\nstatus: approved\nversion: \"1\"\n---\n\nbody\n"
+	if err := os.WriteFile(filepath.Join(docDir, "4-1.md"), []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(root)
+
+	want := strings.ToUpper("ISO 27001:2022")
+	var found bool
+	for _, it := range m.items {
+		if it.isFolder && it.title == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("folder header should use .title display name %q; got items=%+v", want, m.items)
+	}
+}
+
+// TestBadDocSurfacesError verifies a malformed doc surfaces a load error instead
+// of silently zeroing the folder with a misleading "no documents" message (#130 review).
+func TestBadDocSurfacesError(t *testing.T) {
+	root := t.TempDir()
+	docDir := filepath.Join(root, "documents", "iso27001")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := "---\ndocument_id: iso27001-4-1\ntitle: Context\nstatus: approved\nversion: \"1\"\n---\n\nbody\n"
+	if err := os.WriteFile(filepath.Join(docDir, "4-1.md"), []byte(good), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No frontmatter delimiters → LoadDocumentsFromDir errors for the folder.
+	if err := os.WriteFile(filepath.Join(docDir, "4-2.md"), []byte("just text, no frontmatter\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(root)
+
+	if !strings.Contains(m.loadErr, "Failed to load") || !strings.Contains(m.loadErr, "iso27001") {
+		t.Errorf("expected a surfaced load error naming the folder, got loadErr=%q", m.loadErr)
+	}
+}

--- a/internal/isms/tui/tui_test.go
+++ b/internal/isms/tui/tui_test.go
@@ -1,0 +1,53 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNewLoadsLocalCloneDocuments verifies the TUI reads the local clone off disk
+// (#126) — a folder header plus the document, with body + metadata cached so the
+// reader is fully offline (no API).
+func TestNewLoadsLocalCloneDocuments(t *testing.T) {
+	root := t.TempDir()
+	docDir := filepath.Join(root, "documents", "iso27001")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	md := "---\n" +
+		"document_id: iso27001-4-1\n" +
+		"title: Context\n" +
+		"status: approved\n" +
+		"version: \"2\"\n" +
+		"---\n\n# Context\n\nbody line\n"
+	if err := os.WriteFile(filepath.Join(docDir, "4-1.md"), []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(root)
+
+	var folderHdr, docRow *item
+	for i := range m.items {
+		it := &m.items[i]
+		if it.isFolder && it.title == "ISO27001" {
+			folderHdr = it
+		}
+		if it.docID == "iso27001-4-1" {
+			docRow = it
+		}
+	}
+	if folderHdr == nil {
+		t.Errorf("expected a folder header for iso27001; got items=%+v", m.items)
+	}
+	if docRow == nil {
+		t.Fatalf("expected the document row; got items=%+v", m.items)
+	}
+	if docRow.title != "Context" || docRow.status != "approved" || docRow.version != "2" {
+		t.Errorf("doc metadata not loaded from frontmatter: %+v", *docRow)
+	}
+	if !strings.Contains(docRow.body, "body line") {
+		t.Errorf("doc body not cached for offline read: %q", docRow.body)
+	}
+}


### PR DESCRIPTION
Closes #126

The TUI now reads the **local clone** (offline), not the server API — it belongs to the clone→edit→sync workflow, so it reflects your un-synced local edits and needs no token/network.

- `tui.Run(root)` / `New(root)` open `store.New(root)` and list docs via `ListDocFolders` + `LoadDocumentsFromDir`, caching parsed bodies (no re-read on preview/open).
- The command resolves the clone with `resolveRepoRoot()` (--root / ISMS_ROOT / walk-up) and errors with 'run isms clone first' if none — offline-first, no API fallback.
- Drops the client dependency + dead `stripFrontmatter`.

## Test plan
- [ ] `just test-go` green (incl. new TUI load test)
- [ ] `isms tui` inside a clone → browse folders, read a doc rendered
- [ ] `ISMS_ROOT=/path/to/clone isms tui` from elsewhere → works
- [ ] `isms tui` with no clone → clear 'run isms clone first' error