### PR TITLE
feat(tui): collapsible folder tree with titles + stable scroll (#53)

### DIFF
--- a/internal/isms/tui/tui.go
+++ b/internal/isms/tui/tui.go
@@ -1,10 +1,15 @@
 // Package tui provides an interactive terminal UI for the ISMS, focused on
-// reading documents. List view on the left, rendered document on the right.
-// Press enter to open a document in full-screen reader mode; q/esc to go back.
+// reading documents. A collapsible folder tree on the left mirroring the real
+// documents/ directory (template → subfolders → docs, closed by default), and the
+// selected document rendered in a scrollable pane on the right. The tree stays
+// visible while reading: enter/→ moves focus into the document to scroll it,
+// esc/←/h returns focus to the tree.
 package tui
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,49 +21,71 @@ import (
 	"isms.sh/internal/isms/store"
 )
 
-// mode controls the top-level layout.
-type mode int
-
-const (
-	modeList   mode = iota // two-pane: list on left, preview on right
-	modeReader             // full-screen rendered document
-)
-
-// item is a row in the document list — either a folder header or a document.
-// Document rows cache the parsed body/version so the reader is fully offline —
-// no re-read when previewing or opening.
-type item struct {
-	docID    string // empty for folder rows
-	title    string
-	path     string // folder path for folder rows
+// treeItem is one row of the flattened document tree (pre-order DFS). Folders
+// carry an expand flag and depth; a folder's descendants are the following items
+// with a greater depth. Documents carry cached metadata + body (offline read).
+type treeItem struct {
+	isFolder bool
+	label    string // folder .title/name, or document title
+	depth    int
+	expanded bool // folders only
+	docID    string
 	status   string
 	version  string
-	body     string // markdown body (frontmatter already parsed out by store), empty for folder rows
+	body     string // markdown body (frontmatter already parsed out by store)
+	path     string // absolute file path (for opening in $EDITOR)
+}
+
+// display is the row's shown name — the label, falling back to the document id
+// when a doc has no title (matches how the web viewer labels documents).
+func (it treeItem) display() string {
+	if !it.isFolder && strings.TrimSpace(it.label) == "" {
+		return it.docID
+	}
+	return it.label
+}
+
+// tnode is the nested tree built while reading the clone; flattened into
+// []treeItem for display.
+type tnode struct {
 	isFolder bool
+	label    string
+	docID    string
+	status   string
+	version  string
+	body     string
+	path     string
+	children []tnode
+}
+
+// editDoneMsg is delivered after $EDITOR exits (idx = the item edited).
+type editDoneMsg struct {
+	idx int
+	err error
 }
 
 // Model is the bubbletea model for the document TUI.
 type Model struct {
-	store    *store.Store
-	width    int
-	height   int
-	ready    bool
-	mode     mode
-	items    []item
-	cursor   int
-	filter   string
-	filterOn bool
-	viewport viewport.Model
-	docBody  string // raw markdown of the currently-open document
-	docTitle string
-	rendered string
-	renderer *glamour.TermRenderer
-	loadErr  string
+	store      *store.Store
+	width      int
+	height     int
+	ready      bool
+	reading    bool // focus is on the document pane (scrolling) vs the tree
+	items      []treeItem
+	cursor     int    // index into visibleRows()
+	listOffset int    // first visible row (stable scroll)
+	loadedDoc  string // docID currently rendered in the viewport
+	filter     string
+	filterOn   bool
+	viewport   viewport.Model
+	renderer   *glamour.TermRenderer
+	loadErr    string
 }
 
 const (
 	listPaneWidth = 38
 	helpHeight    = 1
+	readerHeader  = 2 // title + meta lines above the scrollable body
 )
 
 // New creates a document-focused TUI model that reads the local clone at root.
@@ -86,53 +113,157 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.rebuildViewport()
 		m.ready = true
-		if m.docBody != "" {
-			m.rerender()
-		}
+		m.loadedDoc = "" // force a re-render at the new width
+		m.syncPreview()
 		return m, nil
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)
-	}
 
-	if m.mode == modeReader {
-		var cmd tea.Cmd
-		m.viewport, cmd = m.viewport.Update(msg)
-		return m, cmd
+	case editDoneMsg:
+		// Re-read the edited file from the working tree so the change shows.
+		if msg.err == nil && msg.idx >= 0 && msg.idx < len(m.items) && m.items[msg.idx].path != "" {
+			if pf, err := m.store.LoadDocument(m.items[msg.idx].path); err == nil {
+				m.items[msg.idx].label = pf.Frontmatter.Title
+				m.items[msg.idx].status = pf.Frontmatter.Status
+				m.items[msg.idx].version = pf.Frontmatter.Version
+				m.items[msg.idx].body = pf.Body
+			}
+		}
+		m.loadedDoc = "" // force the viewport to re-render
+		m.syncPreview()
+		return m, nil
 	}
 	return m, nil
 }
 
-func (m *Model) rebuildViewport() {
-	w := m.width - 4
-	if m.mode == modeList {
-		w = m.width - listPaneWidth - 4
+// editCurrent opens the selected document in $EDITOR (if set), suspending the TUI
+// while the editor runs. Read-only stays the default; this is the power-user path
+// to edit the raw markdown in the local clone (edits become un-synced working-tree
+// changes, consistent with clone→edit→sync).
+func (m Model) editCurrent() (tea.Model, tea.Cmd) {
+	it, ok := m.currentItem()
+	if !ok || it.isFolder || it.path == "" {
+		return m, nil
 	}
+	editor := strings.TrimSpace(os.Getenv("EDITOR"))
+	if editor == "" {
+		m.loadErr = "Set $EDITOR to edit documents from the reader."
+		return m, nil
+	}
+	idx := m.cursorItemIndex()
+	// $EDITOR may carry flags (e.g. "code -w"); split into command + args.
+	parts := strings.Fields(editor)
+	args := append(parts[1:], it.path)
+	c := exec.Command(parts[0], args...)
+	return m, tea.ExecProcess(c, func(err error) tea.Msg {
+		return editDoneMsg{idx: idx, err: err}
+	})
+}
+
+// rightPaneWidth is the usable width of the document pane.
+func (m Model) rightPaneWidth() int {
+	w := m.width - listPaneWidth - 4
 	if w < 20 {
 		w = 20
 	}
+	return w
+}
+
+// listHeight is the number of rows in each pane (tree rows / reader lines).
+func (m Model) listHeight() int {
 	h := m.height - helpHeight - 2
 	if h < 5 {
 		h = 5
 	}
+	return h
+}
+
+func (m *Model) rebuildViewport() {
+	w := m.rightPaneWidth()
+	h := m.listHeight() - readerHeader
+	if h < 3 {
+		h = 3
+	}
 	m.viewport = viewport.New(w, h)
-	m.viewport.Style = lipgloss.NewStyle().PaddingLeft(1).PaddingRight(1)
+	m.viewport.Style = lipgloss.NewStyle().PaddingLeft(1)
 	m.renderer, _ = glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 		glamour.WithWordWrap(w-2),
 	)
 }
 
+// syncPreview loads the currently-selected document into the viewport (once per
+// selection) so the right pane always reflects the tree cursor. Folders clear it.
+func (m *Model) syncPreview() {
+	it, ok := m.currentItem()
+	if !ok || it.isFolder {
+		m.loadedDoc = ""
+		return
+	}
+	if it.docID == m.loadedDoc {
+		return
+	}
+	m.loadedDoc = it.docID
+	body := it.body
+	if m.renderer != nil {
+		if out, err := m.renderer.Render(it.body); err == nil {
+			body = out
+		}
+	}
+	m.viewport.SetContent(body)
+	m.viewport.GotoTop()
+}
+
+// currentItem returns the tree item under the cursor.
+func (m Model) currentItem() (treeItem, bool) {
+	rows := m.visibleRows()
+	if m.cursor < 0 || m.cursor >= len(rows) {
+		return treeItem{}, false
+	}
+	return m.items[rows[m.cursor]], true
+}
+
+// clampCursor keeps the cursor in range and scrolls the tree window just enough
+// to keep it visible — the offset moves only when the cursor would leave the pane.
+func (m *Model) clampCursor(n int) {
+	if n <= 0 {
+		m.cursor = 0
+		m.listOffset = 0
+		return
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	if m.cursor > n-1 {
+		m.cursor = n - 1
+	}
+	h := m.listHeight()
+	if m.cursor < m.listOffset {
+		m.listOffset = m.cursor
+	}
+	if m.cursor >= m.listOffset+h {
+		m.listOffset = m.cursor - h + 1
+	}
+	if m.listOffset < 0 {
+		m.listOffset = 0
+	}
+	if m.listOffset > n-1 {
+		m.listOffset = n - 1
+	}
+}
+
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	// Filter input mode — keys flow into the filter string.
-	if m.filterOn && m.mode == modeList {
+	if m.filterOn {
 		switch key {
 		case "esc":
 			m.filterOn = false
 			m.filter = ""
-			m.cursor = 0
+			m.cursor, m.listOffset = 0, 0
+			m.syncPreview()
 			return m, nil
 		case "enter":
 			m.filterOn = false
@@ -140,120 +271,158 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "backspace":
 			if len(m.filter) > 0 {
 				m.filter = m.filter[:len(m.filter)-1]
-				m.cursor = 0
+				m.cursor, m.listOffset = 0, 0
+				m.syncPreview()
 			}
 			return m, nil
 		default:
 			if len(key) == 1 {
 				m.filter += key
-				m.cursor = 0
+				m.cursor, m.listOffset = 0, 0
+				m.syncPreview()
 				return m, nil
 			}
+			return m, nil
 		}
 	}
 
+	// Edit the selected document in $EDITOR (works from tree or reader focus).
+	if key == "e" {
+		return m.editCurrent()
+	}
+
+	// Reader focus — keys scroll the document; esc/←/h/q return to the tree.
+	if m.reading {
+		switch key {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "esc", "q", "h", "left":
+			m.reading = false
+			return m, nil
+		case "g":
+			m.viewport.GotoTop()
+			return m, nil
+		case "G":
+			m.viewport.GotoBottom()
+			return m, nil
+		case "ctrl+f", "pgdown", " ":
+			m.viewport.ViewDown()
+			return m, nil
+		case "ctrl+b", "pgup":
+			m.viewport.ViewUp()
+			return m, nil
+		case "ctrl+d":
+			m.viewport.HalfViewDown()
+			return m, nil
+		case "ctrl+u":
+			m.viewport.HalfViewUp()
+			return m, nil
+		default:
+			var cmd tea.Cmd
+			m.viewport, cmd = m.viewport.Update(msg)
+			return m, cmd
+		}
+	}
+
+	// Tree focus.
 	switch key {
 	case "q", "ctrl+c":
-		if m.mode == modeReader {
-			m.mode = modeList
-			m.docBody = ""
-			m.rendered = ""
-			m.rebuildViewport()
-			return m, nil
-		}
 		return m, tea.Quit
 
 	case "esc":
-		if m.mode == modeReader {
-			m.mode = modeList
-			m.docBody = ""
-			m.rendered = ""
-			m.rebuildViewport()
-			return m, nil
-		}
 		if m.filter != "" {
 			m.filter = ""
-			m.cursor = 0
+			m.clampCursor(len(m.visibleRows()))
+			m.syncPreview()
 		}
 		return m, nil
 
 	case "/":
-		if m.mode == modeList {
-			m.filterOn = true
-			return m, nil
-		}
+		m.filterOn = true
+		return m, nil
 
 	case "enter", "l", "right":
-		if m.mode == modeList {
-			vis := m.visibleItems()
-			if m.cursor < len(vis) && !vis[m.cursor].isFolder {
-				m.openDocument(vis[m.cursor])
+		rows := m.visibleRows()
+		if m.cursor < len(rows) {
+			it := m.items[rows[m.cursor]]
+			if it.isFolder {
+				if m.filter == "" {
+					m.items[rows[m.cursor]].expanded = !it.expanded
+					m.clampCursor(len(m.visibleRows()))
+				}
+			} else {
+				// Focus the document to scroll it — the tree stays visible.
+				m.reading = true
+			}
+		}
+		return m, nil
+
+	case "h", "left":
+		if m.filter == "" {
+			rows := m.visibleRows()
+			if m.cursor < len(rows) {
+				ci := rows[m.cursor]
+				it := m.items[ci]
+				if it.isFolder && it.expanded {
+					m.items[ci].expanded = false
+				} else {
+					for j := ci - 1; j >= 0; j-- {
+						if m.items[j].isFolder && m.items[j].depth < it.depth {
+							m.items[j].expanded = false
+							m.cursor = visIndexOf(m.visibleRows(), j)
+							break
+						}
+					}
+				}
+				m.clampCursor(len(m.visibleRows()))
+				m.syncPreview()
 			}
 		}
 		return m, nil
 
 	case "r":
-		// Reload list (handy after a sync)
-		if m.mode == modeList {
-			m.loadDocuments()
-			m.cursor = 0
-		}
+		m.loadDocuments()
+		m.cursor, m.listOffset = 0, 0
+		m.loadedDoc = ""
+		m.syncPreview()
 		return m, nil
 
 	case "up", "k":
-		if m.mode == modeList {
-			if m.cursor > 0 {
-				m.cursor--
-			}
-			return m, nil
-		}
-		var cmd tea.Cmd
-		m.viewport, cmd = m.viewport.Update(msg)
-		return m, cmd
+		m.cursor--
+		m.clampCursor(len(m.visibleRows()))
+		m.syncPreview()
+		return m, nil
 
 	case "down", "j":
-		if m.mode == modeList {
-			if m.cursor < len(m.visibleItems())-1 {
-				m.cursor++
-			}
-			return m, nil
-		}
-		var cmd tea.Cmd
-		m.viewport, cmd = m.viewport.Update(msg)
-		return m, cmd
+		m.cursor++
+		m.clampCursor(len(m.visibleRows()))
+		m.syncPreview()
+		return m, nil
 
 	case "g":
-		if m.mode == modeReader {
-			m.viewport.GotoTop()
-		} else {
-			m.cursor = 0
-		}
+		m.cursor = 0
+		m.clampCursor(len(m.visibleRows()))
+		m.syncPreview()
 		return m, nil
 
 	case "G":
-		if m.mode == modeReader {
-			m.viewport.GotoBottom()
-		} else if vis := m.visibleItems(); len(vis) > 0 {
-			m.cursor = len(vis) - 1
-		}
+		m.cursor = len(m.visibleRows()) - 1
+		m.clampCursor(len(m.visibleRows()))
+		m.syncPreview()
 		return m, nil
-
-	case "pgdown", "ctrl+d", "ctrl+f", " ":
-		if m.mode == modeReader {
-			var cmd tea.Cmd
-			m.viewport, cmd = m.viewport.Update(msg)
-			return m, cmd
-		}
-
-	case "pgup", "ctrl+u", "ctrl+b":
-		if m.mode == modeReader {
-			var cmd tea.Cmd
-			m.viewport, cmd = m.viewport.Update(msg)
-			return m, cmd
-		}
 	}
 
 	return m, nil
+}
+
+// visIndexOf returns the position of item index `it` within the visible rows.
+func visIndexOf(rows []int, it int) int {
+	for i, r := range rows {
+		if r == it {
+			return i
+		}
+	}
+	return 0
 }
 
 // View implements tea.Model.
@@ -261,37 +430,19 @@ func (m Model) View() string {
 	if !m.ready {
 		return "Loading..."
 	}
-	if m.mode == modeReader {
-		return m.viewReader()
-	}
-	return m.viewListMode()
-}
-
-func (m Model) viewListMode() string {
-	list := m.renderList()
-	preview := m.renderPreview()
-	body := lipgloss.JoinHorizontal(lipgloss.Top, list, preview)
+	body := lipgloss.JoinHorizontal(lipgloss.Top, m.renderList(), m.renderReader())
 	return lipgloss.JoinVertical(lipgloss.Left, body, m.helpLine())
-}
-
-func (m Model) viewReader() string {
-	header := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("12")).
-		PaddingLeft(1).
-		Render(m.docTitle)
-	return lipgloss.JoinVertical(lipgloss.Left, header, m.viewport.View(), m.helpLine())
 }
 
 func (m Model) helpLine() string {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(1)
-	if m.mode == modeReader {
-		return style.Render("j/k scroll · g/G top/bottom · q/esc back · ctrl+c quit")
-	}
 	if m.filterOn {
 		return style.Render(fmt.Sprintf("filter: %s_ · esc cancel · enter accept", m.filter))
 	}
-	hint := "j/k move · enter read · / filter · r reload · q quit"
+	if m.reading {
+		return style.Render("j/k scroll · ctrl+f/b page · g/G top/bottom · e edit · esc/←/h tree · ctrl+c quit")
+	}
+	hint := "j/k move · enter/→ open/expand · ←/h collapse · e edit · / filter · r reload · q quit"
 	if m.filter != "" {
 		hint = fmt.Sprintf("filter: %s · esc clear · / edit · enter read", m.filter)
 	}
@@ -299,52 +450,49 @@ func (m Model) helpLine() string {
 }
 
 func (m Model) renderList() string {
-	vis := m.visibleItems()
-	h := m.height - helpHeight - 2
-	if h < 5 {
-		h = 5
-	}
+	rows := m.visibleRows()
+	h := m.listHeight()
 	var b strings.Builder
 
-	// Window of items around cursor — simple paging by height.
-	start := 0
-	if len(vis) > h && m.cursor >= h-2 {
-		start = m.cursor - (h - 3)
-		if start < 0 {
-			start = 0
-		}
-		if start+h > len(vis) {
-			start = len(vis) - h
-		}
+	end := m.listOffset + h
+	if end > len(rows) {
+		end = len(rows)
 	}
-	end := start + h
-	if end > len(vis) {
-		end = len(vis)
-	}
+	inner := listPaneWidth - 2
 
-	for i := start; i < end; i++ {
-		it := vis[i]
+	for i := m.listOffset; i < end; i++ {
+		it := m.items[rows[i]]
+		selected := i == m.cursor
+		indent := strings.Repeat("  ", it.depth)
 		var line string
 		if it.isFolder {
-			line = lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Bold(true).Render(it.title)
+			glyph := "▸"
+			if it.expanded || m.filter != "" {
+				glyph = "▾"
+			}
+			label := truncRight(indent+glyph+" "+it.display(), inner)
+			st := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Bold(true)
+			if selected {
+				st = st.Background(lipgloss.Color("236"))
+			}
+			line = st.Render(padRight(label, inner))
 		} else {
-			prefix := "  "
-			label := fmt.Sprintf("%s  %s", padRight(it.docID, 18), truncRight(it.title, listPaneWidth-22))
-			if i == m.cursor {
-				line = lipgloss.NewStyle().
-					Background(lipgloss.Color("24")).
-					Foreground(lipgloss.Color("15")).
-					Render(prefix + label)
+			label := truncRight(indent+"  "+it.display(), inner)
+			if selected {
+				bg := lipgloss.Color("238") // dimmed when focus is on the reader
+				if !m.reading {
+					bg = lipgloss.Color("24")
+				}
+				line = lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color("15")).
+					Render(padRight(label, inner))
 			} else {
-				line = prefix + label
+				line = label
 			}
 		}
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
-
-	// Fill remaining lines so right pane lines up.
-	for i := end - start; i < h; i++ {
+	for i := end - m.listOffset; i < h; i++ {
 		b.WriteString("\n")
 	}
 
@@ -357,145 +505,265 @@ func (m Model) renderList() string {
 		Render(b.String())
 }
 
-func (m Model) renderPreview() string {
-	vis := m.visibleItems()
-	w := m.width - listPaneWidth - 4
-	if w < 20 {
-		w = 20
+// renderReader draws the right pane: a folder placeholder, or the selected
+// document's title/meta header above its scrollable body. The tree always stays
+// visible alongside it.
+func (m Model) renderReader() string {
+	w := m.rightPaneWidth()
+	h := m.listHeight()
+	dim := lipgloss.NewStyle().Width(w).Height(h).
+		Foreground(lipgloss.Color("240")).PaddingLeft(2).PaddingTop(1)
+
+	it, ok := m.currentItem()
+	if !ok {
+		if m.loadErr != "" {
+			return dim.Foreground(lipgloss.Color("203")).Render(m.loadErr)
+		}
+		return dim.Render("No documents.")
 	}
-	h := m.height - helpHeight - 2
-	if h < 5 {
-		h = 5
-	}
-	if len(vis) == 0 || m.cursor >= len(vis) {
-		return lipgloss.NewStyle().Width(w).Height(h).
-			Foreground(lipgloss.Color("240")).PaddingLeft(2).PaddingTop(1).
-			Render("No documents.")
-	}
-	it := vis[m.cursor]
 	if it.isFolder {
-		return lipgloss.NewStyle().Width(w).Height(h).
-			Foreground(lipgloss.Color("240")).PaddingLeft(2).PaddingTop(1).
-			Render("Folder — select a document.")
+		verb := "enter/→ to expand"
+		if it.expanded {
+			verb = "←/h to collapse"
+		}
+		return dim.Render(fmt.Sprintf("%s\n\n%d document(s) · %s", it.display(), m.countDocs(m.cursorItemIndex()), verb))
 	}
-	r, _ := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(w-4),
-	)
-	rendered, _ := r.Render(it.body)
-	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).Render(it.title)
-	meta := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
-		fmt.Sprintf("%s · %s · v%s · enter to read", it.docID, it.status, it.version))
-	combined := header + "\n" + meta + "\n\n" + rendered
-	return lipgloss.NewStyle().Width(w).Height(h).PaddingLeft(2).PaddingTop(1).Render(combined)
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).PaddingLeft(1)
+	if m.reading {
+		titleStyle = titleStyle.Foreground(lipgloss.Color("14"))
+	}
+	header := titleStyle.Render(truncRight(it.display(), w-2))
+	meta := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(1).Render(
+		truncRight(fmt.Sprintf("%s · %s · v%s%s", it.docID, it.status, it.version,
+			readerHint(m.reading)), w-2))
+	return lipgloss.JoinVertical(lipgloss.Left, header, meta, m.viewport.View())
 }
 
-// openDocument renders the selected (already-loaded) document into the viewport.
-func (m *Model) openDocument(it item) {
-	m.docBody = it.body
-	m.docTitle = fmt.Sprintf("%s — %s (%s, v%s)", it.docID, it.title, it.status, it.version)
-	m.mode = modeReader
-	m.rebuildViewport()
-	m.rerender()
-	m.viewport.GotoTop()
+func readerHint(reading bool) string {
+	if reading {
+		return "   [reading — esc to tree]"
+	}
+	return "   [enter to read]"
 }
 
-func (m *Model) rerender() {
-	if m.renderer == nil || m.docBody == "" {
-		return
+// cursorItemIndex returns the m.items index under the cursor (-1 if none).
+func (m Model) cursorItemIndex() int {
+	rows := m.visibleRows()
+	if m.cursor < 0 || m.cursor >= len(rows) {
+		return -1
 	}
-	out, err := m.renderer.Render(m.docBody)
-	if err != nil {
-		m.rendered = m.docBody
-	} else {
-		m.rendered = out
-	}
-	m.viewport.SetContent(m.rendered)
+	return rows[m.cursor]
 }
 
-// loadDocuments reads the local clone: one section header per top-level folder,
-// with its documents (recursively, flattened) listed under it. Bodies are parsed
-// and cached now so preview/read need no re-read.
+// countDocs counts the document descendants of the folder at item index fi.
+func (m Model) countDocs(fi int) int {
+	if fi < 0 {
+		return 0
+	}
+	d := m.items[fi].depth
+	n := 0
+	for j := fi + 1; j < len(m.items) && m.items[j].depth > d; j++ {
+		if !m.items[j].isFolder {
+			n++
+		}
+	}
+	return n
+}
+
+// loadDocuments reads the local clone into a nested folder tree that mirrors the
+// real documents/ layout (template → subfolders → docs), with .title display
+// names at every level — the same structure the web viewer shows. Folders start
+// collapsed; a lone top-level folder opens so the reader isn't a single dead row.
 func (m *Model) loadDocuments() {
 	m.items = nil
-	var loadErrs []string
-	for _, folder := range m.store.ListDocFolders() {
-		docs, err := m.store.LoadDocumentsFromDir(folder)
-		if err != nil {
-			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", folder, err))
-			continue
-		}
-		if len(docs) == 0 {
-			continue
-		}
-		m.items = append(m.items, item{title: strings.ToUpper(m.folderLabel(folder)), isFolder: true, path: folder})
-		sort.SliceStable(docs, func(i, j int) bool {
-			return docs[i].Frontmatter.DocumentID < docs[j].Frontmatter.DocumentID
-		})
-		for _, d := range docs {
-			m.items = append(m.items, item{
-				docID:   d.Frontmatter.DocumentID,
-				title:   d.Frontmatter.Title,
-				status:  d.Frontmatter.Status,
-				version: d.Frontmatter.Version,
-				body:    d.Body,
-			})
+	m.loadErr = ""
+	var errs []string
+
+	docsRoot := m.store.DocsRoot()
+	entries, err := m.store.ReadDir(docsRoot)
+	if err != nil {
+		m.loadErr = "No documents found in the local clone (looked under documents/)."
+		return
+	}
+	var tops []string
+	for _, de := range entries {
+		if de.IsDir() && !strings.HasPrefix(de.Name(), ".") {
+			tops = append(tops, de.Name())
 		}
 	}
-	if len(loadErrs) > 0 {
-		m.loadErr = "Failed to load: " + strings.Join(loadErrs, "; ")
+	sort.Strings(tops)
+
+	var roots []tnode
+	for _, td := range tops {
+		if n, ok := m.buildFolder(filepath.Join(docsRoot, td), &errs); ok {
+			roots = append(roots, n)
+		}
+	}
+
+	var flatten func(nodes []tnode, depth int)
+	flatten = func(nodes []tnode, depth int) {
+		for _, n := range nodes {
+			m.items = append(m.items, treeItem{
+				isFolder: n.isFolder, label: n.label, depth: depth,
+				docID: n.docID, status: n.status, version: n.version, body: n.body, path: n.path,
+			})
+			if n.isFolder {
+				flatten(n.children, depth+1)
+			}
+		}
+	}
+	flatten(roots, 0)
+
+	if len(roots) == 1 && len(m.items) > 0 && m.items[0].isFolder {
+		m.items[0].expanded = true
+	}
+
+	if len(errs) > 0 {
+		m.loadErr = "Failed to load: " + strings.Join(errs, "; ")
 	} else if len(m.items) == 0 {
 		m.loadErr = "No documents found in the local clone (looked under documents/)."
 	}
 }
 
-// folderLabel returns the folder's display name — the content of a .title file
-// under it, the same convention the API-backed folder tree honored via
-// readDirTitle — falling back to the raw folder name when no .title is set.
-func (m *Model) folderLabel(folder string) string {
-	data, err := m.store.ReadFile(filepath.Join(m.store.DocsRoot(), folder, ".title"))
+// buildFolder recursively reads dir into a tnode (subfolders first, then docs by
+// id). Returns ok=false for an empty folder so bare directories don't clutter the
+// tree. Load errors are collected, not fatal.
+func (m *Model) buildFolder(dir string, errs *[]string) (tnode, bool) {
+	n := tnode{isFolder: true, label: m.folderLabel(dir)}
+	entries, err := m.store.ReadDir(dir)
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("%s: %v", filepath.Base(dir), err))
+		return n, false
+	}
+	var subdirs, files []string
+	for _, de := range entries {
+		if strings.HasPrefix(de.Name(), ".") {
+			continue
+		}
+		if de.IsDir() {
+			subdirs = append(subdirs, de.Name())
+		} else if strings.HasSuffix(de.Name(), ".md") {
+			files = append(files, de.Name())
+		}
+	}
+	sort.Strings(subdirs)
+	sort.Strings(files)
+
+	for _, sd := range subdirs {
+		if sub, ok := m.buildFolder(filepath.Join(dir, sd), errs); ok {
+			n.children = append(n.children, sub)
+		}
+	}
+	var docs []tnode
+	for _, f := range files {
+		path := filepath.Join(dir, f)
+		pf, lerr := m.store.LoadDocument(path)
+		if lerr != nil {
+			*errs = append(*errs, fmt.Sprintf("%s: %v", filepath.Base(dir), lerr))
+			continue
+		}
+		docs = append(docs, tnode{
+			docID:   pf.Frontmatter.DocumentID,
+			label:   pf.Frontmatter.Title,
+			status:  pf.Frontmatter.Status,
+			version: pf.Frontmatter.Version,
+			body:    pf.Body,
+			path:    path,
+		})
+	}
+	sort.SliceStable(docs, func(i, j int) bool { return docs[i].docID < docs[j].docID })
+	n.children = append(n.children, docs...)
+	return n, len(n.children) > 0
+}
+
+// folderLabel returns a folder's display name — the content of its .title file,
+// the same convention the web/API folder tree honors — falling back to the raw
+// directory name when no .title is set.
+func (m *Model) folderLabel(dir string) string {
+	data, err := m.store.ReadFile(filepath.Join(dir, ".title"))
 	if err != nil || len(data) == 0 {
-		return folder
+		return filepath.Base(dir)
 	}
 	return strings.TrimSpace(string(data))
 }
 
-func (m Model) visibleItems() []item {
-	if m.filter == "" {
-		return m.items
+// visibleRows flattens the tree into the item indices currently on screen: folder
+// headers plus the contents of expanded folders. While filtering, only folders on
+// the path to a matching document appear, with just the matching docs.
+func (m Model) visibleRows() []int {
+	if m.filter != "" {
+		return m.filteredRows()
 	}
+	var rows []int
+	skip := -1
+	for i := range m.items {
+		it := m.items[i]
+		if skip >= 0 {
+			if it.depth > skip {
+				continue
+			}
+			skip = -1
+		}
+		rows = append(rows, i)
+		if it.isFolder && !it.expanded {
+			skip = it.depth
+		}
+	}
+	return rows
+}
+
+// filteredRows returns matching documents and their ancestor folders, in order.
+func (m Model) filteredRows() []int {
 	q := strings.ToLower(m.filter)
-	out := make([]item, 0, len(m.items))
-	for _, it := range m.items {
+	keep := make([]bool, len(m.items))
+	var stack []int
+	for i := range m.items {
+		it := m.items[i]
+		for len(stack) > 0 && m.items[stack[len(stack)-1]].depth >= it.depth {
+			stack = stack[:len(stack)-1]
+		}
 		if it.isFolder {
+			stack = append(stack, i)
 			continue
 		}
 		if strings.Contains(strings.ToLower(it.docID), q) ||
-			strings.Contains(strings.ToLower(it.title), q) {
-			out = append(out, it)
+			strings.Contains(strings.ToLower(it.label), q) {
+			keep[i] = true
+			for _, a := range stack {
+				keep[a] = true
+			}
 		}
 	}
-	return out
+	var rows []int
+	for i := range m.items {
+		if keep[i] {
+			rows = append(rows, i)
+		}
+	}
+	return rows
 }
 
 func padRight(s string, n int) string {
-	if len(s) >= n {
-		return s[:n]
+	w := len([]rune(s))
+	if w >= n {
+		return s
 	}
-	return s + strings.Repeat(" ", n-len(s))
+	return s + strings.Repeat(" ", n-w)
 }
 
 func truncRight(s string, n int) string {
 	if n <= 0 {
 		return ""
 	}
-	if len(s) <= n {
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
 	if n <= 1 {
-		return s[:n]
+		return string(r[:n])
 	}
-	return s[:n-1] + "…"
+	return string(r[:n-1]) + "…"
 }
 
 // Run starts the TUI against the local clone at root.

--- a/internal/isms/tui/tui.go
+++ b/internal/isms/tui/tui.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -253,6 +254,14 @@ func (m *Model) clampCursor(n int) {
 	}
 }
 
+// setCursor moves the tree cursor, keeps the window/scroll in range, and loads
+// the newly-selected item into the reader pane.
+func (m *Model) setCursor(n int) {
+	m.cursor = n
+	m.clampCursor(len(m.visibleRows()))
+	m.syncPreview()
+}
+
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
@@ -269,18 +278,17 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterOn = false
 			return m, nil
 		case "backspace":
-			if len(m.filter) > 0 {
-				m.filter = m.filter[:len(m.filter)-1]
-				m.cursor, m.listOffset = 0, 0
-				m.syncPreview()
+			if r := []rune(m.filter); len(r) > 0 {
+				m.filter = string(r[:len(r)-1])
+				m.setCursor(0)
 			}
 			return m, nil
 		default:
-			if len(key) == 1 {
-				m.filter += key
-				m.cursor, m.listOffset = 0, 0
-				m.syncPreview()
-				return m, nil
+			// A single rune (not a multi-byte no-op) extends the filter — measure
+			// runes, not bytes, so accented/non-ASCII titles are searchable.
+			if r := []rune(key); len(r) == 1 {
+				m.filter += string(r[0])
+				m.setCursor(0)
 			}
 			return m, nil
 		}
@@ -331,9 +339,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "esc":
 		if m.filter != "" {
+			// Row indices differ between filtered and full views — reset to the top
+			// rather than leaving the cursor on an unrelated item.
 			m.filter = ""
-			m.clampCursor(len(m.visibleRows()))
-			m.syncPreview()
+			m.setCursor(0)
 		}
 		return m, nil
 
@@ -369,7 +378,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					for j := ci - 1; j >= 0; j-- {
 						if m.items[j].isFolder && m.items[j].depth < it.depth {
 							m.items[j].expanded = false
-							m.cursor = visIndexOf(m.visibleRows(), j)
+							m.cursor = slices.Index(m.visibleRows(), j)
 							break
 						}
 					}
@@ -388,41 +397,23 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "up", "k":
-		m.cursor--
-		m.clampCursor(len(m.visibleRows()))
-		m.syncPreview()
+		m.setCursor(m.cursor - 1)
 		return m, nil
 
 	case "down", "j":
-		m.cursor++
-		m.clampCursor(len(m.visibleRows()))
-		m.syncPreview()
+		m.setCursor(m.cursor + 1)
 		return m, nil
 
 	case "g":
-		m.cursor = 0
-		m.clampCursor(len(m.visibleRows()))
-		m.syncPreview()
+		m.setCursor(0)
 		return m, nil
 
 	case "G":
-		m.cursor = len(m.visibleRows()) - 1
-		m.clampCursor(len(m.visibleRows()))
-		m.syncPreview()
+		m.setCursor(len(m.visibleRows()) - 1)
 		return m, nil
 	}
 
 	return m, nil
-}
-
-// visIndexOf returns the position of item index `it` within the visible rows.
-func visIndexOf(rows []int, it int) int {
-	for i, r := range rows {
-		if r == it {
-			return i
-		}
-	}
-	return 0
 }
 
 // View implements tea.Model.
@@ -556,16 +547,40 @@ func (m Model) cursorItemIndex() int {
 	return rows[m.cursor]
 }
 
-// countDocs counts the document descendants of the folder at item index fi.
+// countDocs counts the document descendants of the folder at item index fi that
+// are actually reachable in the current view — so a filtered folder reports the
+// matches, not the full subtree.
 func (m Model) countDocs(fi int) int {
 	if fi < 0 {
 		return 0
 	}
 	d := m.items[fi].depth
-	n := 0
-	for j := fi + 1; j < len(m.items) && m.items[j].depth > d; j++ {
-		if !m.items[j].isFolder {
-			n++
+	if m.filter == "" {
+		// Full subtree — the count is meaningful even while the folder is collapsed
+		// ("3 documents · enter to expand").
+		n := 0
+		for j := fi + 1; j < len(m.items) && m.items[j].depth > d; j++ {
+			if !m.items[j].isFolder {
+				n++
+			}
+		}
+		return n
+	}
+	// Filtering: count only the docs reachable in the filtered view.
+	rows := m.visibleRows()
+	inSubtree, n := false, 0
+	for _, r := range rows {
+		if r == fi {
+			inSubtree = true
+			continue
+		}
+		if inSubtree {
+			if m.items[r].depth <= d {
+				break
+			}
+			if !m.items[r].isFolder {
+				n++
+			}
 		}
 	}
 	return n
@@ -674,7 +689,11 @@ func (m *Model) buildFolder(dir string, errs *[]string) (tnode, bool) {
 	}
 	sort.SliceStable(docs, func(i, j int) bool { return docs[i].docID < docs[j].docID })
 	n.children = append(n.children, docs...)
-	return n, len(n.children) > 0
+	// Keep an otherwise-empty folder if it carries an explicit .title, matching the
+	// web API's tree builder (server.go: `sub.Title != ""`) — a placeholder folder
+	// scaffolded before its docs should show on both surfaces. folderLabel returns
+	// the raw dir name when there's no .title, so a differing label signals one.
+	return n, len(n.children) > 0 || n.label != filepath.Base(dir)
 }
 
 // folderLabel returns a folder's display name — the content of its .title file,

--- a/internal/isms/tui/tui_test.go
+++ b/internal/isms/tui/tui_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // writeDoc writes a minimal valid document under documents/<folder>/<name>.
@@ -212,6 +214,90 @@ func TestEditNoEditorIsNoOp(t *testing.T) {
 	}
 	if !strings.Contains(nm.(Model).loadErr, "EDITOR") {
 		t.Errorf("expected an $EDITOR hint, got %q", nm.(Model).loadErr)
+	}
+}
+
+// TestEscClearingFilterResetsCursor verifies clearing an active filter with esc
+// (tree focus) resets the cursor to the top rather than leaving it on an unrelated
+// row of the full list (#136 review finding 1).
+func TestEscClearingFilterResetsCursor(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001/clauses", "5-1.md", "iso27001-5-1", "Leadership")
+	writeDoc(t, root, "policies", "acc.md", "policies-access", "Access Policy")
+
+	m := New(root)
+	m.filter = "leadership"
+	m.cursor = len(m.visibleRows()) - 1 // sitting on the matched doc
+
+	nm, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	got := nm.(Model)
+	if got.filter != "" {
+		t.Errorf("esc should clear the filter, got %q", got.filter)
+	}
+	if got.cursor != 0 {
+		t.Errorf("esc should reset cursor to 0, got %d", got.cursor)
+	}
+}
+
+// TestFilterAcceptsNonASCII verifies a multi-byte rune extends the filter (#136
+// review finding 2 — was dropped by a byte-length check).
+func TestFilterAcceptsNonASCII(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Ábyrgð")
+
+	m := New(root)
+	m.filterOn = true
+	nm, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Á")})
+	if got := nm.(Model).filter; got != "Á" {
+		t.Errorf("filter should accept a non-ASCII rune, got %q", got)
+	}
+}
+
+// TestTitledEmptyFolderKept verifies a folder that only carries a .title (no docs
+// yet) still appears — matching the web viewer's tree (#136 review finding 3).
+func TestTitledEmptyFolderKept(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001/clauses", "4-1.md", "iso27001-4-1", "Context")
+	// annex-a: empty folder with only a .title placeholder.
+	annex := filepath.Join(root, "documents", "iso27001", "annex-a")
+	if err := os.MkdirAll(annex, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(annex, ".title"), []byte("Annex A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(root)
+	if _, ok := folderItem(m, "Annex A"); !ok {
+		t.Errorf("a .title-only folder should still appear; items=%+v", m.items)
+	}
+}
+
+// TestFilteredCountDocsCountsMatches verifies the folder placeholder counts only
+// filter-reachable docs, not the full subtree (#136 review finding 4).
+func TestFilteredCountDocsCountsMatches(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001/clauses", "4-1.md", "iso27001-4-1", "Context")
+	writeDoc(t, root, "iso27001/clauses", "5-1.md", "iso27001-5-1", "Leadership")
+	writeDoc(t, root, "iso27001/clauses", "6-1.md", "iso27001-6-1", "Planning")
+
+	m := New(root)
+	// Unfiltered: clauses has 3 docs.
+	clausesIdx := -1
+	for i, it := range m.items {
+		if it.isFolder && it.label == "clauses" {
+			clausesIdx = i
+		}
+	}
+	if clausesIdx < 0 {
+		t.Fatal("clauses folder not found")
+	}
+	if n := m.countDocs(clausesIdx); n != 3 {
+		t.Errorf("unfiltered clauses should count 3 docs, got %d", n)
+	}
+	m.filter = "leadership"
+	if n := m.countDocs(clausesIdx); n != 1 {
+		t.Errorf("filtered clauses should count 1 reachable doc, got %d", n)
 	}
 }
 

--- a/internal/isms/tui/tui_test.go
+++ b/internal/isms/tui/tui_test.go
@@ -7,101 +7,226 @@ import (
 	"testing"
 )
 
-// TestNewLoadsLocalCloneDocuments verifies the TUI reads the local clone off disk
-// (#126) — a folder header plus the document, with body + metadata cached so the
-// reader is fully offline (no API).
-func TestNewLoadsLocalCloneDocuments(t *testing.T) {
-	root := t.TempDir()
-	docDir := filepath.Join(root, "documents", "iso27001")
-	if err := os.MkdirAll(docDir, 0o755); err != nil {
+// writeDoc writes a minimal valid document under documents/<folder>/<name>.
+// folder may be nested, e.g. "iso27001/clauses".
+func writeDoc(t *testing.T, root, folder, name, id, title string) {
+	t.Helper()
+	dir := filepath.Join(root, "documents", folder)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	md := "---\n" +
-		"document_id: iso27001-4-1\n" +
-		"title: Context\n" +
+		"document_id: " + id + "\n" +
+		"title: " + title + "\n" +
 		"status: approved\n" +
-		"version: \"2\"\n" +
-		"---\n\n# Context\n\nbody line\n"
-	if err := os.WriteFile(filepath.Join(docDir, "4-1.md"), []byte(md), 0o644); err != nil {
+		"version: \"1\"\n" +
+		"---\n\n# " + title + "\n\nbody line\n"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(md), 0o644); err != nil {
 		t.Fatal(err)
-	}
-
-	m := New(root)
-
-	var folderHdr, docRow *item
-	for i := range m.items {
-		it := &m.items[i]
-		if it.isFolder && it.title == "ISO27001" {
-			folderHdr = it
-		}
-		if it.docID == "iso27001-4-1" {
-			docRow = it
-		}
-	}
-	if folderHdr == nil {
-		t.Errorf("expected a folder header for iso27001; got items=%+v", m.items)
-	}
-	if docRow == nil {
-		t.Fatalf("expected the document row; got items=%+v", m.items)
-	}
-	if docRow.title != "Context" || docRow.status != "approved" || docRow.version != "2" {
-		t.Errorf("doc metadata not loaded from frontmatter: %+v", *docRow)
-	}
-	if !strings.Contains(docRow.body, "body line") {
-		t.Errorf("doc body not cached for offline read: %q", docRow.body)
 	}
 }
 
-// TestFolderHeaderUsesDotTitle verifies the folder header honors a .title file's
-// display name (as the API-backed tree did), not the raw directory name (#130 review).
+func docItem(m Model, id string) (treeItem, bool) {
+	for _, it := range m.items {
+		if !it.isFolder && it.docID == id {
+			return it, true
+		}
+	}
+	return treeItem{}, false
+}
+
+func folderItem(m Model, label string) (treeItem, bool) {
+	for _, it := range m.items {
+		if it.isFolder && it.label == label {
+			return it, true
+		}
+	}
+	return treeItem{}, false
+}
+
+// TestNewLoadsLocalCloneDocuments verifies the TUI reads the local clone off disk
+// (#126) into the tree — document metadata + body cached for offline read.
+func TestNewLoadsLocalCloneDocuments(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+
+	m := New(root)
+
+	d, ok := docItem(m, "iso27001-4-1")
+	if !ok {
+		t.Fatalf("expected the document in the tree; items=%+v", m.items)
+	}
+	if d.status != "approved" || d.version != "1" {
+		t.Errorf("doc metadata not loaded from frontmatter: %+v", d)
+	}
+	if !strings.Contains(d.body, "body line") {
+		t.Errorf("doc body not cached for offline read: %q", d.body)
+	}
+}
+
+// TestNestedTreeMirrorsDirs is the fix for the "folders aren't under ISO 27001"
+// report: the tree must mirror the real documents/<template>/<subfolder>/ layout,
+// not flatten everything under the top folder.
+func TestNestedTreeMirrorsDirs(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001/clauses", "4-1.md", "iso27001-4-1", "Context")
+	writeDoc(t, root, "iso27001/annex-a", "a-5-1.md", "iso27001-a-5-1", "Policies")
+
+	m := New(root)
+
+	top, ok := folderItem(m, "iso27001")
+	if !ok || top.depth != 0 {
+		t.Fatalf("iso27001 should be a depth-0 folder; got %+v ok=%v", top, ok)
+	}
+	clauses, ok := folderItem(m, "clauses")
+	if !ok || clauses.depth != 1 {
+		t.Fatalf("clauses should nest under iso27001 at depth 1; got %+v ok=%v", clauses, ok)
+	}
+	annex, ok := folderItem(m, "annex-a")
+	if !ok || annex.depth != 1 {
+		t.Fatalf("annex-a should nest at depth 1; got %+v ok=%v", annex, ok)
+	}
+	d, ok := docItem(m, "iso27001-4-1")
+	if !ok || d.depth != 2 {
+		t.Fatalf("the doc should sit under clauses at depth 2; got %+v ok=%v", d, ok)
+	}
+
+	// Lone top folder opens, but its subfolders stay collapsed — so the visible
+	// rows are the template + its two subfolders, NOT the docs.
+	rows := m.visibleRows()
+	if len(rows) != 3 {
+		t.Fatalf("expected template + 2 subfolders visible (subfolders collapsed), got %d rows", len(rows))
+	}
+	for _, r := range rows {
+		if !m.items[r].isFolder {
+			t.Fatalf("no doc rows should show while subfolders are collapsed: %+v", m.items[r])
+		}
+	}
+}
+
+// TestDocRowShowsTitleNotID verifies rows label by the frontmatter title (like the
+// web viewer), falling back to the id only when there is no title.
+func TestDocRowShowsTitleNotID(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Understanding the organization")
+
+	m := New(root)
+	d, _ := docItem(m, "iso27001-4-1")
+	if d.display() != "Understanding the organization" {
+		t.Errorf("doc should display its title, got %q", d.display())
+	}
+	d.label = ""
+	if d.display() != "iso27001-4-1" {
+		t.Errorf("empty title should fall back to id, got %q", d.display())
+	}
+}
+
+// TestFolderHeaderUsesDotTitle verifies folder labels honor a .title file's
+// display name (#130 review), not the raw directory name.
 func TestFolderHeaderUsesDotTitle(t *testing.T) {
 	root := t.TempDir()
-	docDir := filepath.Join(root, "documents", "iso27001")
-	if err := os.MkdirAll(docDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(docDir, ".title"), []byte("ISO 27001:2022\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	md := "---\ndocument_id: iso27001-4-1\ntitle: Context\nstatus: approved\nversion: \"1\"\n---\n\nbody\n"
-	if err := os.WriteFile(filepath.Join(docDir, "4-1.md"), []byte(md), 0o644); err != nil {
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+	if err := os.WriteFile(filepath.Join(root, "documents", "iso27001", ".title"),
+		[]byte("ISO 27001:2022\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	m := New(root)
+	if _, ok := folderItem(m, "ISO 27001:2022"); !ok {
+		t.Errorf("folder should use .title display name; items=%+v", m.items)
+	}
+}
 
-	want := strings.ToUpper("ISO 27001:2022")
-	var found bool
-	for _, it := range m.items {
-		if it.isFolder && it.title == want {
-			found = true
+// TestFoldersCollapsedByDefault verifies multiple top-level folders open closed.
+func TestFoldersCollapsedByDefault(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+	writeDoc(t, root, "policies", "acc.md", "policies-access", "Access Policy")
+
+	m := New(root)
+	rows := m.visibleRows()
+	if len(rows) != 2 {
+		t.Fatalf("collapsed tree should show only 2 folder rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if !m.items[r].isFolder {
+			t.Fatalf("no document rows should be visible while collapsed: %+v", m.items[r])
 		}
 	}
-	if !found {
-		t.Errorf("folder header should use .title display name %q; got items=%+v", want, m.items)
+}
+
+// TestLoneFolderExpanded verifies a single top-level folder opens by default.
+func TestLoneFolderExpanded(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+	m := New(root)
+	if !m.items[0].isFolder || !m.items[0].expanded {
+		t.Errorf("a lone top folder should start expanded; got %+v", m.items[0])
+	}
+}
+
+// TestFilterShowsMatchingDocs verifies the filter surfaces matching docs and
+// their ancestor folders, across nesting.
+func TestFilterShowsMatchingDocs(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001/clauses", "4-1.md", "iso27001-4-1", "Context of the organization")
+	writeDoc(t, root, "iso27001/clauses", "5-1.md", "iso27001-5-1", "Leadership")
+
+	m := New(root)
+	m.filter = "leadership"
+	rows := m.visibleRows()
+	// iso27001 + clauses + the one matching doc
+	if len(rows) != 3 {
+		t.Fatalf("filter should show ancestors + 1 match, got %d rows", len(rows))
+	}
+	last := m.items[rows[len(rows)-1]]
+	if last.isFolder || last.docID != "iso27001-5-1" {
+		t.Errorf("filter matched the wrong row: %+v", last)
+	}
+}
+
+// TestDocPathPopulated verifies each doc carries its working-tree path so it can
+// be opened in $EDITOR.
+func TestDocPathPopulated(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+	m := New(root)
+	d, _ := docItem(m, "iso27001-4-1")
+	want := filepath.Join(root, "documents", "iso27001", "4-1.md")
+	if d.path != want {
+		t.Errorf("doc path = %q, want %q", d.path, want)
+	}
+}
+
+// TestEditNoEditorIsNoOp verifies pressing edit without $EDITOR set does nothing
+// destructive — no exec command, and a hint is surfaced.
+func TestEditNoEditorIsNoOp(t *testing.T) {
+	t.Setenv("EDITOR", "")
+	root := t.TempDir()
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+	m := New(root)
+	m.cursor = 1 // the doc (lone folder is expanded, folder at row 0)
+	nm, cmd := m.editCurrent()
+	if cmd != nil {
+		t.Error("no $EDITOR → no exec command")
+	}
+	if !strings.Contains(nm.(Model).loadErr, "EDITOR") {
+		t.Errorf("expected an $EDITOR hint, got %q", nm.(Model).loadErr)
 	}
 }
 
 // TestBadDocSurfacesError verifies a malformed doc surfaces a load error instead
-// of silently zeroing the folder with a misleading "no documents" message (#130 review).
+// of silently hiding the folder (#130 review).
 func TestBadDocSurfacesError(t *testing.T) {
 	root := t.TempDir()
-	docDir := filepath.Join(root, "documents", "iso27001")
-	if err := os.MkdirAll(docDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	good := "---\ndocument_id: iso27001-4-1\ntitle: Context\nstatus: approved\nversion: \"1\"\n---\n\nbody\n"
-	if err := os.WriteFile(filepath.Join(docDir, "4-1.md"), []byte(good), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// No frontmatter delimiters → LoadDocumentsFromDir errors for the folder.
-	if err := os.WriteFile(filepath.Join(docDir, "4-2.md"), []byte("just text, no frontmatter\n"), 0o644); err != nil {
+	writeDoc(t, root, "iso27001", "4-1.md", "iso27001-4-1", "Context")
+	bad := filepath.Join(root, "documents", "iso27001", "4-2.md")
+	if err := os.WriteFile(bad, []byte("just text, no frontmatter\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	m := New(root)
-
-	if !strings.Contains(m.loadErr, "Failed to load") || !strings.Contains(m.loadErr, "iso27001") {
-		t.Errorf("expected a surfaced load error naming the folder, got loadErr=%q", m.loadErr)
+	if !strings.Contains(m.loadErr, "Failed to load") {
+		t.Errorf("expected a surfaced load error, got loadErr=%q", m.loadErr)
 	}
 }


### PR DESCRIPTION
Closes #53

The local-clone reader (#126/#130) rendered docs but the **browser** was unusable — everything **flattened under the template folder** (subfolders like clauses/annex-a disappeared), always open, the sidebar jumped while navigating, and rows showed the raw id/filename instead of the title. This rebuilds the left pane into a real file tree:

- **Mirrors the real `documents/<template>/<subfolder>/` layout** — recursive, with `.title` display names at every level, the same structure the web viewer shows.
- **The tree always stays visible.** The selected document renders live in the right pane; `enter`/`→` moves focus into the document to scroll it, `esc`/`←`/`h` returns to the tree. (The old full-screen reader that hid the sidebar is gone — the reported bug.)
- **Collapsible folders** (`▸`/`▾`), **closed by default**; `enter`/`→` expand, `←`/`h` collapse. A lone top folder opens so the reader isn't a single dead row.
- **Titles, not ids**: document rows show the frontmatter title (fallback to id).
- **Stable scroll**: a `listOffset` that follows the cursor only when it would leave the pane (no more jumping).
- Filter surfaces matching docs with their ancestor folders, across nesting.
- **Vim page keys** in the reader: `ctrl+f`/`ctrl+b` (page), `ctrl+d`/`ctrl+u` (half-page).
- **`e` to edit**: opens the selected doc in `$EDITOR` (a working-tree edit in the local clone, consistent with clone→edit→sync); re-read on return. No-op with a hint if `$EDITOR` is unset.

## Test plan
- [ ] `just test-go` green (nested tree, collapse/expand, title display, .title labels, filter, doc path, no-editor no-op, bad-doc error)
- [ ] `isms tui` in a clone → subfolders nest under the template; folders start closed; enter/→ opens, ←/h closes; no sidebar jump on j/k
- [ ] selecting a document keeps the tree visible; enter scrolls it, esc back to tree
- [ ] `ctrl+f`/`ctrl+b` page through a long doc; `ctrl+d`/`ctrl+u` half-page
- [ ] `e` opens the doc in $EDITOR; on save+quit the reader shows the edit
- [ ] rows show titles; folder with a .title shows the pretty name
- [ ] `/` filter finds a doc; enter reads it; esc back