### PR TITLE
feat(change): editable, DB-constrained change-request type

### DIFF
--- a/cmd/isms/change.go
+++ b/cmd/isms/change.go
@@ -151,7 +151,7 @@ func changeCreateCmd() *cobra.Command {
 }
 
 func changeUpdateCmd() *cobra.Command {
-	var title, desc, justification, priority, category, risk, rollback, notes, assignedTo string
+	var changeType, title, desc, justification, priority, category, risk, rollback, notes, assignedTo string
 	cmd := &cobra.Command{
 		Use:   "update <id|ref>",
 		Short: "Update change request fields (only the flags you pass are changed)",
@@ -166,7 +166,7 @@ func changeUpdateCmd() *cobra.Command {
 			fields := map[string]interface{}{}
 			f := cmd.Flags()
 			for flag, val := range map[string]*string{
-				"title": &title, "desc": &desc, "justification": &justification,
+				"type": &changeType, "title": &title, "desc": &desc, "justification": &justification,
 				"priority": &priority, "category": &category, "risk": &risk,
 				"rollback": &rollback, "notes": &notes, "assigned-to": &assignedTo,
 			} {
@@ -185,6 +185,7 @@ func changeUpdateCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&changeType, "type", "", "Type ("+strings.Join(db.ChangeTypes, ", ")+")")
 	cmd.Flags().StringVar(&title, "title", "", "Change title")
 	cmd.Flags().StringVar(&desc, "desc", "", "Description")
 	cmd.Flags().StringVar(&justification, "justification", "", "Business justification")
@@ -199,6 +200,7 @@ func changeUpdateCmd() *cobra.Command {
 
 // changeFieldJSON maps update flag names to the API's JSON field names.
 var changeFieldJSON = map[string]string{
+	"type":  "type",
 	"title": "title", "desc": "description", "justification": "justification",
 	"priority": "priority", "category": "category", "risk": "risk_level",
 	"rollback": "rollback_plan", "notes": "notes", "assigned-to": "assigned_to",

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2378,6 +2378,7 @@ type changeCreateRequest struct {
 // metadata (approved_at, approved_by, implemented_at) is cleared correctly on
 // reverse transitions — never inline-set via UpdateChangeRequest.
 type changeUpdateRequest struct {
+	Type          *string    `json:"type"`
 	Title         *string    `json:"title"`
 	Description   *string    `json:"description"`
 	Justification *string    `json:"justification"`
@@ -2559,6 +2560,11 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
+	if req.Type != nil {
+		if err := validateEnum("type", *req.Type, db.ChangeTypes); err != nil {
+			return err
+		}
+	}
 	if req.Priority != nil {
 		if err := validateEnum("priority", *req.Priority, db.ChangePriorities); err != nil {
 			return err
@@ -2597,6 +2603,9 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 		}
 	}
 	cr := *old
+	if req.Type != nil {
+		cr.Type = *req.Type
+	}
 	if req.Title != nil {
 		cr.Title = *req.Title
 	}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1074,6 +1074,14 @@ func applyChangeUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 	if err != nil {
 		return "", fmt.Errorf("change request %s not found: %w", sg.EntityID, err)
 	}
+	if v, ok := payload.Fields["type"]; ok {
+		if sv, ok := v.(string); ok {
+			if err := validateEnum("type", sv, db.ChangeTypes); err != nil {
+				return "", err
+			}
+			cr.Type = sv
+		}
+	}
 	if v, ok := payload.Fields["priority"]; ok {
 		if sv, ok := v.(string); ok {
 			cr.Priority = sv

--- a/internal/isms/db/changes.go
+++ b/internal/isms/db/changes.go
@@ -143,9 +143,9 @@ func (d *DB) ListChangeRequests(ctx context.Context, orgID int, status string, l
 }
 
 func (d *DB) UpdateChangeRequest(ctx context.Context, orgID int, id int, cr *ChangeRequest) error {
-	if cr.Type == "" {
-		cr.Type = "change"
-	}
+	// No empty→'change' default here: on update the row already has a type, and
+	// silently rewriting an unset value would reclassify an access_request back to
+	// change instead of failing loudly on the DB CHECK (both callers load first).
 	_, err := d.pool.Exec(ctx, `
 		UPDATE change_requests SET title = $2, description = $3, justification = $4,
 			priority = $5, category = $6, risk_level = $7, rollback_plan = $8, notes = $9,

--- a/internal/isms/db/changes.go
+++ b/internal/isms/db/changes.go
@@ -143,16 +143,19 @@ func (d *DB) ListChangeRequests(ctx context.Context, orgID int, status string, l
 }
 
 func (d *DB) UpdateChangeRequest(ctx context.Context, orgID int, id int, cr *ChangeRequest) error {
+	if cr.Type == "" {
+		cr.Type = "change"
+	}
 	_, err := d.pool.Exec(ctx, `
 		UPDATE change_requests SET title = $2, description = $3, justification = $4,
 			priority = $5, category = $6, risk_level = $7, rollback_plan = $8, notes = $9,
 			assigned_to_id = (SELECT id FROM users WHERE email = $10),
-			planned_at = $11,
+			planned_at = $11, type = $13,
 			updated_at = now()
 		WHERE id = $1 AND organization_id = $12 AND deleted_at IS NULL
 	`, id, cr.Title, cr.Description, nilIfEmpty(cr.Justification),
 		cr.Priority, cr.Category, cr.RiskLevel, nilIfEmpty(cr.RollbackPlan), nilIfEmpty(cr.Notes),
-		nilIfEmpty(cr.AssignedTo), cr.PlannedAt, orgID)
+		nilIfEmpty(cr.AssignedTo), cr.PlannedAt, orgID, cr.Type)
 	return err
 }
 

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -463,16 +463,19 @@ func CreateChangeRequestTx(ctx context.Context, tx pgx.Tx, orgID int, cr *Change
 
 // UpdateChangeRequestTx updates a change request within an existing transaction.
 func UpdateChangeRequestTx(ctx context.Context, tx pgx.Tx, orgID int, id int, cr *ChangeRequest) error {
+	if cr.Type == "" {
+		cr.Type = "change"
+	}
 	_, err := tx.Exec(ctx, `
 		UPDATE change_requests SET title = $2, description = $3, justification = $4,
 			priority = $5, category = $6, risk_level = $7, rollback_plan = $8, notes = $9,
 			assigned_to_id = CASE WHEN $10 = '' THEN NULL ELSE (SELECT id FROM users WHERE email = $10) END,
-			planned_at = $11,
+			planned_at = $11, type = $13,
 			updated_at = now()
 		WHERE id = $1 AND organization_id = $12 AND deleted_at IS NULL
 	`, id, cr.Title, cr.Description, nilIfEmpty(cr.Justification),
 		cr.Priority, cr.Category, cr.RiskLevel, nilIfEmpty(cr.RollbackPlan), nilIfEmpty(cr.Notes),
-		cr.AssignedTo, cr.PlannedAt, orgID)
+		cr.AssignedTo, cr.PlannedAt, orgID, cr.Type)
 	return err
 }
 

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -463,9 +463,8 @@ func CreateChangeRequestTx(ctx context.Context, tx pgx.Tx, orgID int, cr *Change
 
 // UpdateChangeRequestTx updates a change request within an existing transaction.
 func UpdateChangeRequestTx(ctx context.Context, tx pgx.Tx, orgID int, id int, cr *ChangeRequest) error {
-	if cr.Type == "" {
-		cr.Type = "change"
-	}
+	// No empty→'change' default on update — see UpdateChangeRequest. Rely on the
+	// DB CHECK to reject a bad/blank type loudly rather than silently reclassify.
 	_, err := tx.Exec(ctx, `
 		UPDATE change_requests SET title = $2, description = $3, justification = $4,
 			priority = $5, category = $6, risk_level = $7, rollback_plan = $8, notes = $9,

--- a/migrations/20260707000000_v0.7.0.sql
+++ b/migrations/20260707000000_v0.7.0.sql
@@ -21,5 +21,10 @@ ALTER TABLE email_verifications ADD CONSTRAINT email_verifications_purpose_check
 
 -- Change requests can be a normal change or an access request. Same approval
 -- flow; specifics (system, grantee, duration) live in the existing notes — no
--- access-request-only structured fields.
+-- access-request-only structured fields. A CHECK constrains the value at the DB
+-- level (defense-in-depth, matching every other status/category column); add new
+-- kinds here + in db.ChangeTypes to extend.
 ALTER TABLE change_requests ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'change';
+ALTER TABLE change_requests DROP CONSTRAINT IF EXISTS change_requests_type_check;
+ALTER TABLE change_requests ADD CONSTRAINT change_requests_type_check
+    CHECK (type IN ('change', 'access_request'));

--- a/migrations/20260707000000_v0.7.0.sql
+++ b/migrations/20260707000000_v0.7.0.sql
@@ -21,10 +21,8 @@ ALTER TABLE email_verifications ADD CONSTRAINT email_verifications_purpose_check
 
 -- Change requests can be a normal change or an access request. Same approval
 -- flow; specifics (system, grantee, duration) live in the existing notes — no
--- access-request-only structured fields. A CHECK constrains the value at the DB
--- level (defense-in-depth, matching every other status/category column); add new
--- kinds here + in db.ChangeTypes to extend.
+-- access-request-only structured fields.
+-- NB: the DB CHECK for this column lives in 20260707120000_change_type_check.sql,
+-- NOT here — this file already shipped on master (#133), so amending it would be
+-- skipped (runner tracks by filename) on any DB that already ran it.
 ALTER TABLE change_requests ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'change';
-ALTER TABLE change_requests DROP CONSTRAINT IF EXISTS change_requests_type_check;
-ALTER TABLE change_requests ADD CONSTRAINT change_requests_type_check
-    CHECK (type IN ('change', 'access_request'));

--- a/migrations/20260707120000_change_type_check.sql
+++ b/migrations/20260707120000_change_type_check.sql
@@ -1,0 +1,12 @@
+-- DB-level backstop for change_requests.type (defense-in-depth, matching every
+-- other status/category column). This is a SEPARATE migration, not an amendment
+-- to 20260707000000_v0.7.0.sql, because that file already shipped on master (#133)
+-- and the runner skips already-applied files by name — so amending it would never
+-- reach databases that already ran v0.7.0. This new file runs everywhere.
+--
+-- DROP IF EXISTS makes it safe on fresh DBs too; existing rows all satisfy it
+-- (type is NOT NULL DEFAULT 'change' and every write path is enum-validated).
+-- Extend by adding a value here + in db.ChangeTypes.
+ALTER TABLE change_requests DROP CONSTRAINT IF EXISTS change_requests_type_check;
+ALTER TABLE change_requests ADD CONSTRAINT change_requests_type_check
+    CHECK (type IN ('change', 'access_request'));

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -149,6 +149,25 @@ class TestChangeType:
         })
         assert r.status_code == 400, r.text
 
+    def test_suggestion_apply_change_type(self, api_url, admin_headers):
+        """The suggestion-apply path (agents/MCP) can reclassify type too."""
+        r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+            "title": "Reclassify via suggestion", "description": "x"})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+        sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+            "entity_type": "change_request", "suggestion_type": "update",
+            "entity_id": str(cid),
+            "payload": {"fields": {"type": "access_request"}},
+            "rationale": "misclassified", "title": "reclassify"})
+        assert sg.status_code in (200, 201), sg.text
+        # force=true bypasses the fresh entity's own create-changelog stale flag.
+        ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                           headers=admin_headers, json={"force": True})
+        assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+        r = requests.get(f"{api_url}/changes/{cid}", headers=admin_headers)
+        assert r.json()["type"] == "access_request", r.text
+
     def test_type_editable_after_create(self, api_url, admin_headers):
         """Type is settable on an existing change (misclassification is fixable)."""
         r = requests.post(f"{api_url}/changes", headers=admin_headers, json={

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -149,6 +149,29 @@ class TestChangeType:
         })
         assert r.status_code == 400, r.text
 
+    def test_type_editable_after_create(self, api_url, admin_headers):
+        """Type is settable on an existing change (misclassification is fixable)."""
+        r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+            "title": "Reclassify me", "description": "starts as change",
+        })
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+        assert r.json()["type"] == "change"
+        r = requests.put(f"{api_url}/changes/{cid}", headers=admin_headers,
+                         json={"type": "access_request"})
+        assert r.status_code == 200, r.text
+        r = requests.get(f"{api_url}/changes/{cid}", headers=admin_headers)
+        assert r.json()["type"] == "access_request"
+
+    def test_update_invalid_type_rejected(self, api_url, admin_headers):
+        r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+            "title": "Reclassify bad", "description": "x",
+        })
+        cid = r.json()["id"]
+        r = requests.put(f"{api_url}/changes/{cid}", headers=admin_headers,
+                         json={"type": "bogus"})
+        assert r.status_code == 400, r.text
+
 
 class TestChangesRBAC:
     """Reader cannot create or change status."""

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -28,8 +28,7 @@
           <div>
             <label class="block text-xs text-slate-500 mb-1">Type</label>
             <select v-model="form.type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
-              <option value="change">Change</option>
-              <option value="access_request">Access request</option>
+              <option v-for="t in CHANGE_TYPES" :key="t.value" :value="t.value">{{ t.label }}</option>
             </select>
           </div>
           <div>
@@ -201,8 +200,7 @@
                       <div>
                         <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
                         <select v-model="editForm.type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="change">Change</option>
-                          <option value="access_request">Access request</option>
+                          <option v-for="t in CHANGE_TYPES" :key="t.value" :value="t.value">{{ t.label }}</option>
                         </select>
                       </div>
                       <div>
@@ -269,7 +267,7 @@
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3">
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
-                          <div class="text-sm text-slate-300">{{ selectedChange.type === 'access_request' ? 'Access request' : 'Change' }}</div>
+                          <div class="text-sm text-slate-300">{{ typeLabel(selectedChange.type) }}</div>
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Priority</div>
@@ -484,6 +482,16 @@ const canCreate = computed(() => ['admin', 'manager', 'contributor'].includes(us
 // so only managers/admins see the status control (#24).
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 const pendingRefs = ref([])
+
+// Change-request types — single source for the create/edit selects and the
+// read-view label. Extend here (+ db.ChangeTypes + the DB CHECK) to add a kind.
+const CHANGE_TYPES = [
+  { value: 'change', label: 'Change' },
+  { value: 'access_request', label: 'Access request' },
+]
+function typeLabel(t) {
+  return (CHANGE_TYPES.find((x) => x.value === t) || CHANGE_TYPES[0]).label
+}
 
 const form = ref({ type: 'change', title: '', priority: 'medium', category: 'process' })
 

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -199,6 +199,13 @@
                         <MarkdownField v-model="editForm.description" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" placeholder="Describe the change..." />
                       </div>
                       <div>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                        <select v-model="editForm.type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
+                          <option value="change">Change</option>
+                          <option value="access_request">Access request</option>
+                        </select>
+                      </div>
+                      <div>
                         <label class="block text-xs font-medium text-slate-500 mb-1">Priority</label>
                         <select v-model="editForm.priority" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
                           <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option><option value="critical">Critical</option>
@@ -260,6 +267,10 @@
                       </div>
 
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3">
+                        <div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
+                          <div class="text-sm text-slate-300">{{ selectedChange.type === 'access_request' ? 'Access request' : 'Change' }}</div>
+                        </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Priority</div>
                           <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(selectedChange.priority)">{{ selectedChange.priority }}</span>
@@ -660,6 +671,7 @@ async function changeStatus(id, status) {
 
 function startEdit(cr) {
   editForm.value = {
+    type: cr.type || 'change',
     title: cr.title || '',
     description: cr.description || '',
     justification: cr.justification || '',


### PR DESCRIPTION
Closes #137
From the access-request discussion #129 (decision recorded there).

The change-request `type` shipped create-only in #131 — you could set it when creating but not view or change it afterwards. This makes it **editable** and constrains it at the DB level.

- **Migration:** a `CHECK` on `change_requests.type` ('change','access_request') — defense-in-depth matching every other status/category column. Extend by adding a value here **and** in `db.ChangeTypes` (stays `TEXT` + Go enum; no lookup table, no access-request-only fields — specifics live in notes).
- **Editable everywhere:** `PUT /changes/:id` (validateEnum first-line guard), suggestion-apply, the Changes detail/edit UI (select + shown in the read view), CLI `change update --type`.

## Test plan
- [ ] `just test-reset` (fresh DB → migration incl. the new CHECK) then `just test tests/test_changes.py` — incl. edit-type + reject-invalid-type
- [ ] UI: open a change → Overview → Edit → change Type → save; type shows in the read view
- [ ] `isms change update <ref> --type access_request`
- [ ] DB rejects an invalid type (CHECK) even if a caller bypasses validateEnum