### PR TITLE
fix(#26): suggestion-apply create matches HTTP defaults (slice A)

### DIFF
--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -124,18 +124,7 @@ func (s *Server) handleCreateLegal(c echo.Context) error {
 		Completion:        req.Completion,
 	}
 
-	if lr.Jurisdiction == "" {
-		lr.Jurisdiction = "EU"
-	}
-	if lr.Category == "" {
-		lr.Category = "privacy"
-	}
-	if lr.Owner == "" {
-		lr.Owner = getUserEmail(c)
-	}
-	if lr.Status == "" {
-		lr.Status = "open"
-	}
+	applyLegalDefaults(&lr, getUserEmail(c))
 	if err := validateEnum("status", lr.Status, db.LegalStatuses); err != nil {
 		return err
 	}

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -125,13 +125,7 @@ func (s *Server) handleCreateLegal(c echo.Context) error {
 	}
 
 	applyLegalDefaults(&lr, getUserEmail(c))
-	if err := validateEnum("status", lr.Status, db.LegalStatuses); err != nil {
-		return err
-	}
-	if err := validateEnum("treatment", lr.Treatment, db.LegalTreatments); err != nil {
-		return err
-	}
-	if err := validateEnum("category", lr.Category, db.LegalCategories); err != nil {
+	if err := validateLegalCreate(&lr); err != nil {
 		return err
 	}
 

--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -309,12 +309,6 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 	if req.Title == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
 	}
-	if err := validateEnum("status", req.Status, db.ObjectiveStatuses); err != nil {
-		return err
-	}
-	if err := validateEnum("target_operator", req.TargetOperator, db.ObjectiveTargetOperators); err != nil {
-		return err
-	}
 	// Cross-org parent guard: confirm the program belongs to this org.
 	if _, err := s.db.GetProgram(ctx, orgID, req.ProgramID); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "program not found in this organization")
@@ -337,6 +331,9 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 		Notes:             req.Notes,
 	}
 	applyObjectiveDefaults(&o, getUserEmail(c))
+	if err := validateObjectiveCreate(&o); err != nil {
+		return err
+	}
 
 	if err := s.db.CreateObjective(ctx, orgID, &o); err != nil {
 		return pgxHTTPError(err)

--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -336,6 +336,7 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 		StartedAt:         req.StartedAt,
 		Notes:             req.Notes,
 	}
+	applyObjectiveDefaults(&o, getUserEmail(c))
 
 	if err := s.db.CreateObjective(ctx, orgID, &o); err != nil {
 		return pgxHTTPError(err)

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -872,18 +872,8 @@ func applySupplierCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 		Criticality:  payload.Criticality,
 		Owner:        payload.Owner,
 		Notes:        payload.Notes,
-		Status:       "active",
 	}
-	if sup.SupplierType == "" {
-		sup.SupplierType = "other"
-	}
-	if sup.Criticality == "" {
-		sup.Criticality = "medium"
-	}
-	// Services description seeded into notes (## Services heading).
-	if sup.Notes == "" {
-		sup.Notes = "## Services\n\n"
-	}
+	applySupplierDefaults(&sup, actor)
 
 	if err := db.CreateSupplierTx(ctx, tx, orgID, &sup); err != nil {
 		return "", err
@@ -963,13 +953,7 @@ func applyLegalCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 		Owner:        payload.Owner,
 		Notes:        payload.Notes,
 	}
-	// Defaults for required fields when web UI sends minimal payload
-	if lr.Jurisdiction == "" {
-		lr.Jurisdiction = "EU"
-	}
-	if lr.Category == "" {
-		lr.Category = "privacy"
-	}
+	applyLegalDefaults(&lr, actor)
 
 	if err := db.CreateLegalRequirementTx(ctx, tx, orgID, &lr); err != nil {
 		return "", err
@@ -1302,11 +1286,8 @@ func applyObjectiveCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, 
 		MeasurementMethod: payload.MeasurementMethod,
 		TargetValue:       payload.TargetValue,
 		Unit:              payload.Unit,
-		Status:            "draft",
 	}
-	if o.Owner == "" {
-		o.Owner = actor
-	}
+	applyObjectiveDefaults(&o, actor)
 	if err := db.CreateObjectiveTx(ctx, tx, orgID, &o); err != nil {
 		return "", err
 	}
@@ -1393,23 +1374,7 @@ func applySystemCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 		Department:     payload.Department,
 		Owner:          payload.Owner,
 	}
-	// Defaults for required fields when web UI sends minimal payload
-	if sys.Classification == "" {
-		sys.Classification = "internal"
-	}
-	if sys.Criticality == "" {
-		sys.Criticality = "medium"
-	}
-	if sys.Owner == "" {
-		sys.Owner = actor
-	}
-	// Seed description with ## Purpose and notes with ## Access control when empty.
-	if sys.Description == "" {
-		sys.Description = "## Purpose\n\n"
-	}
-	if sys.Notes == "" {
-		sys.Notes = "## Access control\n\n"
-	}
+	applySystemDefaults(&sys, actor)
 	if err := db.CreateSystemTx(ctx, tx, orgID, &sys); err != nil {
 		return "", err
 	}
@@ -1502,16 +1467,7 @@ func applyAssetCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 		AssetType:   payload.AssetType,
 		Owner:       payload.Owner,
 	}
-	// Defaults for required fields when web UI sends minimal payload
-	if a.AssetType == "" {
-		a.AssetType = "other"
-	}
-	if a.Status == "" {
-		a.Status = "active"
-	}
-	if a.Owner == "" {
-		a.Owner = actor
-	}
+	applyAssetDefaults(&a, actor)
 	if err := db.CreateAssetTx(ctx, tx, orgID, &a); err != nil {
 		return "", err
 	}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -416,7 +417,14 @@ func (s *Server) handleApplyEntitySuggestion(c echo.Context) error {
 		return nil
 	})
 	if txErr != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "apply failed: "+txErr.Error())
+		// Preserve an actionable status: validation returns *echo.HTTPError (400
+		// with the allowed list); a DB constraint violation maps to 400 via
+		// pgxHTTPError; anything else is a genuine 500.
+		var he *echo.HTTPError
+		if errors.As(txErr, &he) {
+			return he
+		}
+		return pgxHTTPError(txErr)
 	}
 
 	// Post-commit: activity log + notifications (non-transactional, OK to fail)
@@ -874,6 +882,9 @@ func applySupplierCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 		Notes:        payload.Notes,
 	}
 	applySupplierDefaults(&sup, actor)
+	if err := validateSupplierCreate(&sup); err != nil {
+		return "", err
+	}
 
 	if err := db.CreateSupplierTx(ctx, tx, orgID, &sup); err != nil {
 		return "", err
@@ -954,6 +965,9 @@ func applyLegalCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 		Notes:        payload.Notes,
 	}
 	applyLegalDefaults(&lr, actor)
+	if err := validateLegalCreate(&lr); err != nil {
+		return "", err
+	}
 
 	if err := db.CreateLegalRequirementTx(ctx, tx, orgID, &lr); err != nil {
 		return "", err
@@ -1288,6 +1302,9 @@ func applyObjectiveCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, 
 		Unit:              payload.Unit,
 	}
 	applyObjectiveDefaults(&o, actor)
+	if err := validateObjectiveCreate(&o); err != nil {
+		return "", err
+	}
 	if err := db.CreateObjectiveTx(ctx, tx, orgID, &o); err != nil {
 		return "", err
 	}
@@ -1375,6 +1392,9 @@ func applySystemCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 		Owner:          payload.Owner,
 	}
 	applySystemDefaults(&sys, actor)
+	if err := validateSystemCreate(&sys); err != nil {
+		return "", err
+	}
 	if err := db.CreateSystemTx(ctx, tx, orgID, &sys); err != nil {
 		return "", err
 	}
@@ -1468,6 +1488,9 @@ func applyAssetCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 		Owner:       payload.Owner,
 	}
 	applyAssetDefaults(&a, actor)
+	if err := validateAssetCreate(&a); err != nil {
+		return "", err
+	}
 	if err := db.CreateAssetTx(ctx, tx, orgID, &a); err != nil {
 		return "", err
 	}

--- a/internal/isms/api/api_writepath_defaults.go
+++ b/internal/isms/api/api_writepath_defaults.go
@@ -84,3 +84,53 @@ func applyObjectiveDefaults(o *db.Objective, actor string) {
 		o.Owner = actor
 	}
 }
+
+// Shared create-time enum validation (#26): both the HTTP create handler and the
+// applyXCreate suggestion handler call these (after applyXDefaults), so an invalid
+// value fails the same way on both paths — a clean 400 with the allowed list,
+// rather than HTTP 400 vs a raw CHECK-violation 500 on apply. Mirrors exactly the
+// validateEnum calls the HTTP handlers used inline.
+
+func validateAssetCreate(a *db.Asset) error {
+	if err := validateEnum("status", a.Status, db.AssetStatuses); err != nil {
+		return err
+	}
+	return validateEnum("asset_type", a.AssetType, db.AssetTypes)
+}
+
+func validateSupplierCreate(sup *db.Supplier) error {
+	if err := validateEnum("status", sup.Status, db.SupplierStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("supplier_type", sup.SupplierType, db.SupplierTypes); err != nil {
+		return err
+	}
+	return validateEnum("criticality", sup.Criticality, db.CriticalityLevels)
+}
+
+func validateLegalCreate(lr *db.LegalRequirement) error {
+	if err := validateEnum("status", lr.Status, db.LegalStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("treatment", lr.Treatment, db.LegalTreatments); err != nil {
+		return err
+	}
+	return validateEnum("category", lr.Category, db.LegalCategories)
+}
+
+func validateSystemCreate(sys *db.System) error {
+	if err := validateEnum("status", sys.Status, db.SystemStatuses); err != nil {
+		return err
+	}
+	if err := validateEnum("criticality", sys.Criticality, db.SystemCriticalities); err != nil {
+		return err
+	}
+	return validateEnum("classification", sys.Classification, db.SystemClassifications)
+}
+
+func validateObjectiveCreate(o *db.Objective) error {
+	if err := validateEnum("status", o.Status, db.ObjectiveStatuses); err != nil {
+		return err
+	}
+	return validateEnum("target_operator", o.TargetOperator, db.ObjectiveTargetOperators)
+}

--- a/internal/isms/api/api_writepath_defaults.go
+++ b/internal/isms/api/api_writepath_defaults.go
@@ -1,0 +1,86 @@
+package api
+
+import "isms.sh/internal/isms/db"
+
+// Shared create-time defaults (#26, slice A: create consistency). Each helper
+// encodes the canonical server-side defaults for a new entity so that a record
+// created via suggestion-apply lands in the SAME state as one created over HTTP —
+// both the HTTP create handler and the applyXCreate suggestion handler call these,
+// instead of each keeping its own (previously divergent) inline defaults.
+//
+// actor is the creating user's email, used for the owner fallback.
+
+func applyAssetDefaults(a *db.Asset, actor string) {
+	if a.Status == "" {
+		a.Status = "open"
+	}
+	if a.AssetType == "" {
+		a.AssetType = "other"
+	}
+	if a.Owner == "" {
+		a.Owner = actor
+	}
+}
+
+func applySupplierDefaults(sup *db.Supplier, actor string) {
+	if sup.Status == "" {
+		sup.Status = "active"
+	}
+	if sup.SupplierType == "" {
+		sup.SupplierType = "other"
+	}
+	if sup.Criticality == "" {
+		sup.Criticality = "medium"
+	}
+	if sup.Owner == "" {
+		sup.Owner = actor
+	}
+	if sup.Notes == "" {
+		sup.Notes = "## Services\n\n"
+	}
+}
+
+func applyLegalDefaults(lr *db.LegalRequirement, actor string) {
+	if lr.Jurisdiction == "" {
+		lr.Jurisdiction = "EU"
+	}
+	if lr.Category == "" {
+		lr.Category = "privacy"
+	}
+	if lr.Status == "" {
+		lr.Status = "open"
+	}
+	if lr.Owner == "" {
+		lr.Owner = actor
+	}
+}
+
+func applySystemDefaults(sys *db.System, actor string) {
+	if sys.Status == "" {
+		sys.Status = "active"
+	}
+	if sys.Classification == "" {
+		sys.Classification = "internal"
+	}
+	if sys.Criticality == "" {
+		sys.Criticality = "medium"
+	}
+	if sys.Owner == "" {
+		sys.Owner = actor
+	}
+	if sys.Description == "" {
+		sys.Description = "## Purpose\n\n"
+	}
+	if sys.Notes == "" {
+		sys.Notes = "## Access control\n\n"
+	}
+}
+
+func applyObjectiveDefaults(o *db.Objective, actor string) {
+	if o.Status == "" {
+		o.Status = "draft"
+	}
+	if o.Owner == "" {
+		o.Owner = actor
+	}
+}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1879,15 +1879,7 @@ func (s *Server) handleAddAsset(c echo.Context) error {
 		NextReview:      req.NextReview,
 		Notes:           req.Notes,
 	}
-	if a.Owner == "" {
-		a.Owner = getUserEmail(c)
-	}
-	if a.Status == "" {
-		a.Status = "open"
-	}
-	if a.AssetType == "" {
-		a.AssetType = "other"
-	}
+	applyAssetDefaults(&a, getUserEmail(c))
 	if err := validateEnum("status", a.Status, db.AssetStatuses); err != nil {
 		return err
 	}
@@ -2022,20 +2014,7 @@ func (s *Server) handleCreateSystem(c echo.Context) error {
 		Owner:           req.Owner,
 		Notes:           req.Notes,
 	}
-	if sys.Status == "" {
-		sys.Status = "active"
-	}
-	if sys.Owner == "" {
-		sys.Owner = getUserEmail(c)
-	}
-	// Seed description with ## Purpose heading; seed notes with ## Access control heading.
-	// Only when fields are empty so we never overwrite user input.
-	if sys.Description == "" {
-		sys.Description = "## Purpose\n\n"
-	}
-	if sys.Notes == "" {
-		sys.Notes = "## Access control\n\n"
-	}
+	applySystemDefaults(&sys, getUserEmail(c))
 	if err := validateEnum("status", sys.Status, db.SystemStatuses); err != nil {
 		return err
 	}
@@ -2440,22 +2419,7 @@ func (s *Server) handleAddSupplier(c echo.Context) error {
 		NextReview:      req.NextReview,
 		Notes:           req.Notes,
 	}
-	if sup.Status == "" {
-		sup.Status = "active"
-	}
-	if sup.SupplierType == "" {
-		sup.SupplierType = "other"
-	}
-	if sup.Criticality == "" {
-		sup.Criticality = "medium"
-	}
-	if sup.Owner == "" {
-		sup.Owner = getUserEmail(c)
-	}
-	// Seed notes with ## Services heading when empty.
-	if sup.Notes == "" {
-		sup.Notes = "## Services\n\n"
-	}
+	applySupplierDefaults(&sup, getUserEmail(c))
 	if err := validateEnum("status", sup.Status, db.SupplierStatuses); err != nil {
 		return err
 	}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1880,10 +1880,7 @@ func (s *Server) handleAddAsset(c echo.Context) error {
 		Notes:           req.Notes,
 	}
 	applyAssetDefaults(&a, getUserEmail(c))
-	if err := validateEnum("status", a.Status, db.AssetStatuses); err != nil {
-		return err
-	}
-	if err := validateEnum("asset_type", a.AssetType, db.AssetTypes); err != nil {
+	if err := validateAssetCreate(&a); err != nil {
 		return err
 	}
 	if err := s.db.CreateAsset(ctx, orgID, &a); err != nil {
@@ -2015,13 +2012,7 @@ func (s *Server) handleCreateSystem(c echo.Context) error {
 		Notes:           req.Notes,
 	}
 	applySystemDefaults(&sys, getUserEmail(c))
-	if err := validateEnum("status", sys.Status, db.SystemStatuses); err != nil {
-		return err
-	}
-	if err := validateEnum("criticality", sys.Criticality, db.SystemCriticalities); err != nil {
-		return err
-	}
-	if err := validateEnum("classification", sys.Classification, db.SystemClassifications); err != nil {
+	if err := validateSystemCreate(&sys); err != nil {
 		return err
 	}
 	// Verify supplier belongs to this org if referenced.
@@ -2420,13 +2411,7 @@ func (s *Server) handleAddSupplier(c echo.Context) error {
 		Notes:           req.Notes,
 	}
 	applySupplierDefaults(&sup, getUserEmail(c))
-	if err := validateEnum("status", sup.Status, db.SupplierStatuses); err != nil {
-		return err
-	}
-	if err := validateEnum("supplier_type", sup.SupplierType, db.SupplierTypes); err != nil {
-		return err
-	}
-	if err := validateEnum("criticality", sup.Criticality, db.CriticalityLevels); err != nil {
+	if err := validateSupplierCreate(&sup); err != nil {
 		return err
 	}
 	if err := s.db.CreateSupplier(ctx, orgID, &sup); err != nil {

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -385,18 +385,15 @@ func CreateLegalRequirementTx(ctx context.Context, tx pgx.Tx, orgID int, lr *Leg
 	lr.OrganizationID = orgID
 	lr.CalculateRiskScore(nil)
 
-	var seq int
-	err := tx.QueryRow(ctx, `
-		INSERT INTO identifier_sequences (organization_id, entity_type, next_value)
-		VALUES ($1, 'legal', 1)
-		ON CONFLICT (organization_id, entity_type)
-		DO UPDATE SET next_value = identifier_sequences.next_value + 1
-		RETURNING next_value
-	`, orgID).Scan(&seq)
+	// Use the shared identifier allocator with the SAME entity_type key as the
+	// HTTP path (NextIdentifier(..,"legal_requirement")). The old hardcoded
+	// 'legal' key violated identifier_sequences' CHECK, so applying a legal
+	// suggestion always failed — a #26 write-path divergence.
+	ident, err := nextIdentifierTx(ctx, tx, orgID, "legal_requirement")
 	if err != nil {
-		return fmt.Errorf("allocate identifier: %w", err)
+		return err
 	}
-	lr.Identifier = fmt.Sprintf("LEGAL-%d", seq)
+	lr.Identifier = ident
 
 	return tx.QueryRow(ctx, `
 		INSERT INTO legal_requirements (organization_id, identifier, `+legalCols+`)

--- a/tests/test_create_writepath.py
+++ b/tests/test_create_writepath.py
@@ -68,3 +68,51 @@ def test_supplier_apply_sets_owner(api_url, admin_headers):
     assert sup is not None, f"supplier {ident} not found"
     assert sup["status"] == "active", f"apply supplier status should be 'active', got {sup['status']!r}"
     assert sup.get("owner") == ADMIN_EMAIL, f"apply supplier should default owner to actor, got {sup.get('owner')!r}"
+
+
+def _ensure_program(api_url, headers):
+    r = requests.get(f"{api_url}/programs", headers=headers, params={"limit": 1})
+    data = r.json().get("data", r.json()) if isinstance(r.json(), dict) else r.json()
+    if data:
+        return data[0]["id"]
+    key = f"wp{uuid.uuid4().hex[:6]}"
+    r = requests.post(f"{api_url}/programs", headers=headers,
+                      json={"key": key, "title": f"wp-prog-{key}"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+def test_objective_apply_matches_http(api_url, admin_headers):
+    """Objective is the entity whose HTTP path changed (status/owner now defaulted)
+    — apply must land in the same state."""
+    program_id = _ensure_program(api_url, admin_headers)
+
+    r = requests.post(f"{api_url}/objectives", headers=admin_headers,
+                      json={"title": f"wp-obj-http-{uuid.uuid4().hex[:8]}", "program_id": program_id})
+    assert r.status_code in (200, 201), r.text
+    http_obj = r.json()
+    assert http_obj["status"] == "draft"
+    assert http_obj.get("owner") == ADMIN_EMAIL
+
+    ident, name = _apply_create(api_url, admin_headers, "objective", "title",
+                                {"program_id": program_id})
+    r = requests.get(f"{api_url}/objectives", headers=admin_headers,
+                     params={"q": name, "limit": 100})
+    items = r.json().get("data", r.json()) if isinstance(r.json(), dict) else r.json()
+    obj = next((x for x in (items or []) if x.get("display_id") == ident), None)
+    assert obj is not None, f"objective {ident} not found"
+    assert obj["status"] == "draft"
+    assert obj.get("owner") == ADMIN_EMAIL
+
+
+def test_apply_invalid_enum_is_400_not_500(api_url, admin_headers):
+    """Invalid enum via suggestion-apply returns a clean 4xx (validated on the
+    apply path too), not a raw 500 CHECK error (#140 review)."""
+    sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+        "entity_type": "asset", "suggestion_type": "create",
+        "title": f"wp-bad-{uuid.uuid4().hex[:8]}",
+        "payload": {"name": f"wp-bad-{uuid.uuid4().hex[:8]}", "asset_type": "laptop"},
+        "rationale": "bad enum"})
+    assert sg.status_code in (200, 201), sg.text
+    ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply", headers=admin_headers, json={})
+    assert ap.status_code == 400, f"invalid enum should be 400, got {ap.status_code}: {ap.text}"

--- a/tests/test_create_writepath.py
+++ b/tests/test_create_writepath.py
@@ -1,0 +1,70 @@
+"""#26 slice A: create consistency — an entity created via suggestion-apply must
+land in the same default state as one created over HTTP (shared applyXDefaults).
+
+The headline bug: assets created via apply started 'active' while HTTP created
+them 'open'. These tests assert the apply path now matches the HTTP defaults.
+
+Search by the unique name (?q=) rather than scanning page 1 — the test stack is
+persistent, so a freshly-created record can fall outside the first page.
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL
+
+
+def _apply_create(api_url, headers, entity_type, name_key, payload):
+    payload = dict(payload)
+    payload[name_key] = payload.get(name_key) or f"wp-{uuid.uuid4().hex[:8]}"
+    sg = requests.post(f"{api_url}/suggestions", headers=headers, json={
+        "entity_type": entity_type,
+        "suggestion_type": "create",
+        "title": payload[name_key],
+        "rationale": "writepath consistency",
+        "payload": payload,
+    })
+    assert sg.status_code in (200, 201), sg.text
+    ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply", headers=headers, json={})
+    assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+    return ap.json().get("applied_entity_id"), payload[name_key]
+
+
+def _find(api_url, headers, path, q, ident):
+    r = requests.get(f"{api_url}{path}", headers=headers, params={"q": q, "limit": 100})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    items = data.get("data", data) if isinstance(data, dict) else data
+    return next((x for x in (items or []) if x.get("identifier") == ident), None)
+
+
+def test_asset_apply_matches_http_status(api_url, admin_headers):
+    """Apply-created asset defaults to 'open' (HTTP default), not the old 'active'."""
+    ident, name = _apply_create(api_url, admin_headers, "asset", "name", {})
+    a = _find(api_url, admin_headers, "/assets", name, ident)
+    assert a is not None, f"asset {ident} not found"
+    assert a["status"] == "open", f"apply asset should default to 'open', got {a['status']!r}"
+    assert a.get("owner"), "apply asset should default owner to the actor"
+
+
+def test_legal_apply_sets_status_and_owner(api_url, admin_headers):
+    ident, name = _apply_create(api_url, admin_headers, "legal_requirement", "title", {})
+    lr = _find(api_url, admin_headers, "/legal", name, ident)
+    assert lr is not None, f"legal {ident} not found"
+    assert lr["status"] == "open", f"apply legal should default status 'open', got {lr['status']!r}"
+    assert lr.get("owner"), "apply legal should default owner to the actor"
+
+
+def test_system_apply_sets_status(api_url, admin_headers):
+    ident, name = _apply_create(api_url, admin_headers, "system", "name", {})
+    sysrec = _find(api_url, admin_headers, "/systems", name, ident)
+    assert sysrec is not None, f"system {ident} not found"
+    assert sysrec["status"] == "active", f"apply system should default status 'active', got {sysrec['status']!r}"
+    assert sysrec.get("owner"), "apply system should default owner to the actor"
+
+
+def test_supplier_apply_sets_owner(api_url, admin_headers):
+    ident, name = _apply_create(api_url, admin_headers, "supplier", "name", {})
+    sup = _find(api_url, admin_headers, "/suppliers", name, ident)
+    assert sup is not None, f"supplier {ident} not found"
+    assert sup["status"] == "active", f"apply supplier status should be 'active', got {sup['status']!r}"
+    assert sup.get("owner") == ADMIN_EMAIL, f"apply supplier should default owner to actor, got {sup.get('owner')!r}"


### PR DESCRIPTION
Part of the #26 enforced-write-path epic (slice A: create consistency). Closes #139.

Suggestion-apply created entities in a **different default state** than HTTP. Now one `applyXDefaults(x, actor)` per entity is called by **both** the HTTP create handler and `applyXCreate`:

| entity | was | now |
|---|---|---|
| asset | apply `active` vs HTTP `open` | both `open` |
| supplier | apply had no owner | both owner→actor |
| legal | apply no status/owner **+ apply always failed** (bad identifier key) | both `open`+owner; shared `nextIdentifierTx('legal_requirement')` |
| system | apply no status; HTTP no classification/criticality | union both ways |
| objective | HTTP no status/owner; apply had draft+actor | both `draft`+owner |

## Test plan
- [ ] `just test-restart` then `just test tests/test_create_writepath.py` (green ×2 — already verified locally)
- [ ] create asset via a suggestion → status `open` (not `active`)
- [ ] apply a legal suggestion → succeeds (was always failing) with a `LEGAL-N` id