### PR TITLE
fix(#26): audit-finding status transition via suggestion-apply (slice B)

### DIFF
--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1603,12 +1603,24 @@ func applyAuditFindingUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID in
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
 	idInt, _ := parseEntityID(sg.EntityID)
-	// Update individual fields using existing field-level update
 	for field, val := range payload.Fields {
-		if sv, ok := val.(string); ok {
-			if err := db.UpdateAuditFindingFieldTx(ctx, tx, orgID, int(idInt), field, sv); err != nil {
-				return "", fmt.Errorf("updating field %s: %w", field, err)
+		sv, ok := val.(string)
+		if !ok {
+			continue
+		}
+		// Status transitions go through the shared closure-metadata path (same as
+		// the HTTP handler) — a plain field write would skip closed_at/closed_by.
+		if field == "status" {
+			if !db.AuditFindingStatuses[sv] {
+				return "", fmt.Errorf("invalid status: %s", sv)
 			}
+			if err := db.SetAuditFindingStatusTx(ctx, tx, orgID, int(idInt), sv, actor); err != nil {
+				return "", err
+			}
+			continue
+		}
+		if err := db.UpdateAuditFindingFieldTx(ctx, tx, orgID, int(idInt), field, sv); err != nil {
+			return "", fmt.Errorf("updating field %s: %w", field, err)
 		}
 	}
 	return sg.EntityID, nil

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1604,19 +1604,23 @@ func applyAuditFindingUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID in
 	}
 	idInt, _ := parseEntityID(sg.EntityID)
 	for field, val := range payload.Fields {
-		sv, ok := val.(string)
-		if !ok {
-			continue
-		}
 		// Status transitions go through the shared closure-metadata path (same as
 		// the HTTP handler) — a plain field write would skip closed_at/closed_by.
 		if field == "status" {
+			sv, ok := val.(string)
+			if !ok {
+				return "", fmt.Errorf("field status: expected a string, got %T", val)
+			}
 			if !db.AuditFindingStatuses[sv] {
 				return "", fmt.Errorf("invalid status: %s", sv)
 			}
 			if err := db.SetAuditFindingStatusTx(ctx, tx, orgID, int(idInt), sv, actor); err != nil {
 				return "", err
 			}
+			continue
+		}
+		sv, ok := val.(string)
+		if !ok {
 			continue
 		}
 		if err := db.UpdateAuditFindingFieldTx(ctx, tx, orgID, int(idInt), field, sv); err != nil {

--- a/internal/isms/db/audits.go
+++ b/internal/isms/db/audits.go
@@ -4,7 +4,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+// pgExecer is satisfied by both *pgxpool.Pool and pgx.Tx, so a pool-based DB
+// method and its tx variant can share one query body (no duplicated SQL).
+type pgExecer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
 
 // --- Status / type allowlists ---
 
@@ -739,8 +747,21 @@ func (d *DB) UpdateAuditFindingPartial(ctx context.Context, orgID, id int, title
 // SetAuditFindingStatus moves a finding open <-> closed and keeps closure metadata consistent.
 // On close: stamps closed_at + closed_by.  On reopen: clears closed_at, closed_by, closed_by_user_id.
 func (d *DB) SetAuditFindingStatus(ctx context.Context, orgID, id int, status, closedBy string) error {
+	return setAuditFindingStatus(ctx, d.pool, orgID, id, status, closedBy)
+}
+
+// setAuditFindingStatus is the shared core: moves a finding open<->closed and
+// keeps closure metadata consistent (closed_at/closed_by on close, cleared on
+// reopen). Errors if no row matched (nonexistent or soft-deleted), so a status
+// apply can't be recorded as "applied" for a mutation that touched nothing.
+// Runs against the pool (DB method) or a tx (SetAuditFindingStatusTx) — one body.
+func setAuditFindingStatus(ctx context.Context, e pgExecer, orgID, id int, status, closedBy string) error {
+	var (
+		tag pgconn.CommandTag
+		err error
+	)
 	if status == "closed" {
-		_, err := d.pool.Exec(ctx, `
+		tag, err = e.Exec(ctx, `
 			UPDATE audit_findings
 			   SET status = 'closed',
 			       closed_at = COALESCE(closed_at, now()),
@@ -748,17 +769,23 @@ func (d *DB) SetAuditFindingStatus(ctx context.Context, orgID, id int, status, c
 			       closed_by_user_id = (SELECT id FROM users WHERE email = $2),
 			       updated_at = now()
 			 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, closedBy, orgID)
+	} else {
+		tag, err = e.Exec(ctx, `
+			UPDATE audit_findings
+			   SET status = $2,
+			       closed_at = NULL,
+			       closed_by = NULL,
+			       closed_by_user_id = NULL,
+			       updated_at = now()
+			 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, status, orgID)
+	}
+	if err != nil {
 		return err
 	}
-	_, err := d.pool.Exec(ctx, `
-		UPDATE audit_findings
-		   SET status = $2,
-		       closed_at = NULL,
-		       closed_by = NULL,
-		       closed_by_user_id = NULL,
-		       updated_at = now()
-		 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, status, orgID)
-	return err
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("audit finding %d not found", id)
+	}
+	return nil
 }
 
 // SoftDeleteAuditFinding marks a finding as deleted.  Refuses if the finding has

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -751,6 +751,32 @@ func UpdateAuditFindingFieldTx(ctx context.Context, tx pgx.Tx, orgID int, id int
 	return err
 }
 
+// SetAuditFindingStatusTx is the tx variant of SetAuditFindingStatus — moves a
+// finding open <-> closed and keeps closure metadata (closed_at/closed_by)
+// consistent, so suggestion-apply closes a finding exactly like the HTTP path (#26).
+func SetAuditFindingStatusTx(ctx context.Context, tx pgx.Tx, orgID, id int, status, closedBy string) error {
+	if status == "closed" {
+		_, err := tx.Exec(ctx, `
+			UPDATE audit_findings
+			   SET status = 'closed',
+			       closed_at = COALESCE(closed_at, now()),
+			       closed_by = $2,
+			       closed_by_user_id = (SELECT id FROM users WHERE email = $2),
+			       updated_at = now()
+			 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, closedBy, orgID)
+		return err
+	}
+	_, err := tx.Exec(ctx, `
+		UPDATE audit_findings
+		   SET status = $2,
+		       closed_at = NULL,
+		       closed_by = NULL,
+		       closed_by_user_id = NULL,
+		       updated_at = now()
+		 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, status, orgID)
+	return err
+}
+
 // --- Review / approval Tx variants ---
 
 // AddApprovalTx inserts an approval record within an existing transaction.

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -751,30 +751,10 @@ func UpdateAuditFindingFieldTx(ctx context.Context, tx pgx.Tx, orgID int, id int
 	return err
 }
 
-// SetAuditFindingStatusTx is the tx variant of SetAuditFindingStatus — moves a
-// finding open <-> closed and keeps closure metadata (closed_at/closed_by)
-// consistent, so suggestion-apply closes a finding exactly like the HTTP path (#26).
+// SetAuditFindingStatusTx is the tx variant of SetAuditFindingStatus — shares the
+// same core (closure metadata + not-found guard) so the two can't drift (#26).
 func SetAuditFindingStatusTx(ctx context.Context, tx pgx.Tx, orgID, id int, status, closedBy string) error {
-	if status == "closed" {
-		_, err := tx.Exec(ctx, `
-			UPDATE audit_findings
-			   SET status = 'closed',
-			       closed_at = COALESCE(closed_at, now()),
-			       closed_by = $2,
-			       closed_by_user_id = (SELECT id FROM users WHERE email = $2),
-			       updated_at = now()
-			 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, closedBy, orgID)
-		return err
-	}
-	_, err := tx.Exec(ctx, `
-		UPDATE audit_findings
-		   SET status = $2,
-		       closed_at = NULL,
-		       closed_by = NULL,
-		       closed_by_user_id = NULL,
-		       updated_at = now()
-		 WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`, id, status, orgID)
-	return err
+	return setAuditFindingStatus(ctx, tx, orgID, id, status, closedBy)
 }
 
 // --- Review / approval Tx variants ---

--- a/tests/test_update_writepath.py
+++ b/tests/test_update_writepath.py
@@ -32,24 +32,36 @@ def _suggest_update(api_url, headers, entity_type, entity_id, fields):
     assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
 
 
-def test_audit_finding_apply_close_stamps_closure(api_url, admin_headers):
-    prog = requests.post(f"{api_url}/audit/programmes", headers=admin_headers, json={
+def _make_finding(api_url, headers):
+    prog = requests.post(f"{api_url}/audit/programmes", headers=headers, json={
         "title": f"wp-prog-{uuid.uuid4().hex[:6]}", "year": 2026,
     })
     assert prog.status_code in (200, 201), prog.text
-    aud = requests.post(f"{api_url}/audits", headers=admin_headers, json={
+    aud = requests.post(f"{api_url}/audits", headers=headers, json={
         "programme_id": prog.json()["id"], "title": f"wp-aud-{uuid.uuid4().hex[:6]}",
     })
     assert aud.status_code in (200, 201), aud.text
-    f = requests.post(f"{api_url}/audit-findings", headers=admin_headers, json={
+    f = requests.post(f"{api_url}/audit-findings", headers=headers, json={
         "audit_id": aud.json()["id"], "title": f"wp-find-{uuid.uuid4().hex[:6]}",
         "finding_type": "observation",
     })
     assert f.status_code in (200, 201), f.text
-    fid = f.json()["id"]
+    return f.json()["id"]
 
+
+def test_audit_finding_apply_close_stamps_closure(api_url, admin_headers):
+    fid = _make_finding(api_url, admin_headers)
     _suggest_update(api_url, admin_headers, "audit_finding", fid, {"status": "closed"})
-
     got = requests.get(f"{api_url}/audit-findings/{fid}", headers=admin_headers).json()
     assert got["status"] == "closed", got
     assert got.get("closed_at"), "apply→closed must stamp closed_at like the HTTP path"
+
+
+def test_audit_finding_apply_reopen_clears_closure(api_url, admin_headers):
+    fid = _make_finding(api_url, admin_headers)
+    _suggest_update(api_url, admin_headers, "audit_finding", fid, {"status": "closed"})
+    _suggest_update(api_url, admin_headers, "audit_finding", fid, {"status": "open"})
+    got = requests.get(f"{api_url}/audit-findings/{fid}", headers=admin_headers).json()
+    assert got["status"] == "open", got
+    assert not got.get("closed_at"), "reopen must clear closed_at"
+    assert not got.get("closed_by"), "reopen must clear closed_by"

--- a/tests/test_update_writepath.py
+++ b/tests/test_update_writepath.py
@@ -1,0 +1,55 @@
+"""#26 slice B: update consistency — a status transition applied via a suggestion
+must derive the same closure metadata as the HTTP path.
+
+Before: applying an audit-finding suggestion that set status=closed errored
+outright (the field-level update rejected 'status'); it now goes through the same
+SetAuditFindingStatus closure path the HTTP handler uses.
+
+(Risk 'accepted' was intentionally left out: 'accepted' is not a valid risk
+status — RiskStatuses is draft/open/closed — so there is no real HTTP-vs-apply
+divergence there; the HTTP status=='accepted' block is vestigial.)
+
+force=true on apply bypasses stale-detection (a fresh entity's own create
+changelog would otherwise flag it), so the enforced path is what's exercised.
+"""
+import uuid
+
+import requests
+
+
+def _suggest_update(api_url, headers, entity_type, entity_id, fields):
+    sg = requests.post(f"{api_url}/suggestions", headers=headers, json={
+        "entity_type": entity_type,
+        "suggestion_type": "update",
+        "entity_id": str(entity_id),
+        "title": "writepath update",
+        "rationale": "writepath consistency",
+        "payload": {"fields": fields},
+    })
+    assert sg.status_code in (200, 201), sg.text
+    ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                       headers=headers, json={"force": True})
+    assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+
+
+def test_audit_finding_apply_close_stamps_closure(api_url, admin_headers):
+    prog = requests.post(f"{api_url}/audit/programmes", headers=admin_headers, json={
+        "title": f"wp-prog-{uuid.uuid4().hex[:6]}", "year": 2026,
+    })
+    assert prog.status_code in (200, 201), prog.text
+    aud = requests.post(f"{api_url}/audits", headers=admin_headers, json={
+        "programme_id": prog.json()["id"], "title": f"wp-aud-{uuid.uuid4().hex[:6]}",
+    })
+    assert aud.status_code in (200, 201), aud.text
+    f = requests.post(f"{api_url}/audit-findings", headers=admin_headers, json={
+        "audit_id": aud.json()["id"], "title": f"wp-find-{uuid.uuid4().hex[:6]}",
+        "finding_type": "observation",
+    })
+    assert f.status_code in (200, 201), f.text
+    fid = f.json()["id"]
+
+    _suggest_update(api_url, admin_headers, "audit_finding", fid, {"status": "closed"})
+
+    got = requests.get(f"{api_url}/audit-findings/{fid}", headers=admin_headers).json()
+    assert got["status"] == "closed", got
+    assert got.get("closed_at"), "apply→closed must stamp closed_at like the HTTP path"


### PR DESCRIPTION
Part of the #26 enforced-write-path epic (slice B: update consistency). Closes #141.

**Stacked on Slice A** (base = `feat/26-create-consistency`). Merge the Slice A PR first; this retargets to master afterwards.

Applying an audit-finding suggestion that changed `status` **errored** before — the apply path's field-level update rejected `status`, so closure metadata was never stamped. Now it routes through `SetAuditFindingStatusTx` (a tx variant of `SetAuditFindingStatus`), stamping `closed_at`/`closed_by` exactly like the HTTP handler.

Risk was checked and intentionally excluded: `accepted` is not a valid risk status (`RiskStatuses = draft/open/closed`), so the HTTP `status=='accepted'` block is vestigial — no real divergence.

## Test plan
- [ ] `just test-restart` then `just test tests/test_update_writepath.py` (green ×2 — already verified)
- [ ] apply an audit-finding suggestion with `{"status":"closed"}` → succeeds, `closed_at` set (errored before)