### PR TITLE
fix(#26): change_request status via suggestion-apply (slice C) — completes the epic

### DIFF
--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1102,6 +1102,20 @@ func applyChangeUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 			cr.AssignedTo = sv
 		}
 	}
+	// Status transitions go through the shared enforced path so approved_at/by and
+	// implemented_at are derived exactly as the HTTP handler does — a plain field
+	// write (UpdateChangeRequestTx doesn't touch status) would skip that metadata.
+	if v, ok := payload.Fields["status"]; ok {
+		if sv, ok := v.(string); ok && sv != cr.Status {
+			if err := validateEnum("status", sv, db.ChangeStatuses); err != nil {
+				return "", err
+			}
+			if err := db.UpdateChangeRequestStatusTx(ctx, tx, orgID, cr.ID, sv, actor); err != nil {
+				return "", err
+			}
+			cr.Status = sv
+		}
+	}
 	if err := db.UpdateChangeRequestTx(ctx, tx, orgID, cr.ID, cr); err != nil {
 		return "", err
 	}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -337,6 +337,21 @@ func (s *Server) handleClaimEntitySuggestion(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": newStatus})
 }
 
+// applyPostCommitKey carries a queue of side-effect callbacks that must run only
+// AFTER the apply transaction commits. Apply handlers use registerApplyPostCommit
+// for effects that touch the pool directly or send mail (e.g. auto-created tasks),
+// which must not fire inside WithOrgTx — mirroring how the HTTP handlers run their
+// post-commit work. Keeps the HTTP and suggestion-apply paths behaving identically.
+type applyPostCommitKey struct{}
+
+// registerApplyPostCommit queues fn to run after the enclosing apply tx commits.
+// A no-op if the context carries no queue (defensive; the apply path always sets one).
+func registerApplyPostCommit(ctx context.Context, fn func()) {
+	if q, ok := ctx.Value(applyPostCommitKey{}).(*[]func()); ok {
+		*q = append(*q, fn)
+	}
+}
+
 func (s *Server) handleApplyEntitySuggestion(c echo.Context) error {
 	if err := requireRole(c, "admin", "manager"); err != nil {
 		return err
@@ -344,6 +359,11 @@ func (s *Server) handleApplyEntitySuggestion(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
+
+	// Callbacks registered by apply handlers for side effects that must run only
+	// after the tx commits (task auto-creation, mail). Drained below on success.
+	var postCommit []func()
+	ctx = context.WithValue(ctx, applyPostCommitKey{}, &postCommit)
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -419,7 +439,12 @@ func (s *Server) handleApplyEntitySuggestion(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "apply failed: "+txErr.Error())
 	}
 
-	// Post-commit: activity log + notifications (non-transactional, OK to fail)
+	// Post-commit: run side effects handlers deferred until the tx committed
+	// (auto-created tasks, mail), then the activity log + notifications. All
+	// non-transactional and OK to fail — the entity mutation is already durable.
+	for _, fn := range postCommit {
+		fn()
+	}
 	s.logAndNotify(ctx, orgID, &db.Activity{
 		Actor:  actor,
 		Action: "suggestion_applied",
@@ -1114,6 +1139,15 @@ func applyChangeUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 				return "", err
 			}
 			cr.Status = sv
+			// The HTTP status paths auto-create the "Implement <CR>" task on
+			// approval; keep suggestion-apply identical (#26 acceptance criterion).
+			// Deferred to post-commit — createChangeFollowupTask writes via the pool
+			// and sends mail, neither safe inside this transaction.
+			if sv == "approved" {
+				registerApplyPostCommit(ctx, func() {
+					s.createChangeFollowupTask(context.Background(), orgID, cr, actor)
+				})
+			}
 		}
 	}
 	if err := db.UpdateChangeRequestTx(ctx, tx, orgID, cr.ID, cr); err != nil {

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -478,6 +478,43 @@ func UpdateChangeRequestTx(ctx context.Context, tx pgx.Tx, orgID int, id int, cr
 	return err
 }
 
+// UpdateChangeRequestStatusTx is the tx variant of DB.UpdateChangeRequestStatus —
+// transitions status and derives approved_at/by + implemented_at consistently
+// (cleared on reverse transitions), so suggestion-apply changes status exactly
+// like the HTTP status handler (#26).
+func UpdateChangeRequestStatusTx(ctx context.Context, tx pgx.Tx, orgID int, id int, status, approvedBy string) error {
+	clearApproved := status == "proposed" || status == "in_progress" || status == "rejected"
+	clearImplemented := status != "implemented" && status != "closed"
+
+	query := `UPDATE change_requests SET status = $2, updated_at = now()`
+	args := []interface{}{id, status}
+	switch {
+	case status == "approved" && approvedBy != "":
+		query += `, approved_by = $3, approved_by_user_id = (SELECT id FROM users WHERE email = $3), approved_at = now()`
+		args = append(args, approvedBy)
+		if clearImplemented {
+			query += `, implemented_at = NULL`
+		}
+		query += ` WHERE id = $1 AND organization_id = $4 AND deleted_at IS NULL`
+		args = append(args, orgID)
+	case status == "implemented":
+		query += `, implemented_at = COALESCE(implemented_at, now())`
+		query += ` WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`
+		args = append(args, orgID)
+	default:
+		if clearApproved {
+			query += `, approved_at = NULL, approved_by = NULL, approved_by_user_id = NULL`
+		}
+		if clearImplemented {
+			query += `, implemented_at = NULL`
+		}
+		query += ` WHERE id = $1 AND organization_id = $3 AND deleted_at IS NULL`
+		args = append(args, orgID)
+	}
+	_, err := tx.Exec(ctx, query, args...)
+	return err
+}
+
 // CreateCorrectiveActionTx creates a corrective action within an existing transaction.
 func CreateCorrectiveActionTx(ctx context.Context, tx pgx.Tx, orgID int, ca *CorrectiveAction) error {
 	ca.OrganizationID = orgID

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -149,6 +149,25 @@ class TestChangeType:
         })
         assert r.status_code == 400, r.text
 
+    def test_suggestion_apply_status_stamps_approved(self, api_url, admin_headers):
+        """#26 slice C: status via suggestion-apply derives approved_at/by like HTTP."""
+        r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+            "title": "Approve via suggestion", "description": "x"})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+        sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+            "entity_type": "change_request", "suggestion_type": "update",
+            "entity_id": str(cid),
+            "payload": {"fields": {"status": "approved"}},
+            "rationale": "ready", "title": "approve"})
+        assert sg.status_code in (200, 201), sg.text
+        ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                           headers=admin_headers, json={"force": True})
+        assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+        got = requests.get(f"{api_url}/changes/{cid}", headers=admin_headers).json()
+        assert got["status"] == "approved", got
+        assert got.get("approved_at"), "apply→approved must stamp approved_at like HTTP"
+
     def test_suggestion_apply_change_type(self, api_url, admin_headers):
         """The suggestion-apply path (agents/MCP) can reclassify type too."""
         r = requests.post(f"{api_url}/changes", headers=admin_headers, json={

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -168,6 +168,63 @@ class TestChangeType:
         assert got["status"] == "approved", got
         assert got.get("approved_at"), "apply→approved must stamp approved_at like HTTP"
 
+    def test_suggestion_apply_approval_creates_followup_task(self, api_url, admin_headers):
+        """#26 finding 1: approving via suggestion-apply must auto-create the
+        'Implement <CR>' follow-up task, exactly like the HTTP status endpoint —
+        the two paths must not diverge on this side effect."""
+        r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+            "title": "Approve creates followup", "description": "x"})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+        ident = r.json()["identifier"]
+        sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+            "entity_type": "change_request", "suggestion_type": "update",
+            "entity_id": str(cid),
+            "payload": {"fields": {"status": "approved"}},
+            "rationale": "ready", "title": "approve"})
+        assert sg.status_code in (200, 201), sg.text
+        ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                           headers=admin_headers, json={"force": True})
+        assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+        # Search by the CR identifier so pagination on the persistent stack can't hide it.
+        tr = requests.get(f"{api_url}/tasks",
+                          headers=admin_headers,
+                          params={"q": ident, "task_type": "change_followup"})
+        assert tr.status_code == 200, tr.text
+        tasks = tr.json().get("data") or []
+        followups = [t for t in tasks if ident in (t.get("title") or "")]
+        assert followups, f"approve via suggestion-apply must create the Implement {ident} task"
+
+    def test_suggestion_apply_status_clears_approved_on_reverse_transition(self, api_url, admin_headers):
+        """#26 finding 2: a reverse transition via suggestion-apply clears
+        approved_at/by, matching UpdateChangeRequestStatusTx's clearApproved branch —
+        locks in parity between the hand-duplicated tx and pool status functions."""
+        r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+            "title": "Reverse via suggestion", "description": "x"})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+
+        def apply_status(status):
+            sg = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+                "entity_type": "change_request", "suggestion_type": "update",
+                "entity_id": str(cid),
+                "payload": {"fields": {"status": status}},
+                "rationale": status, "title": status})
+            assert sg.status_code in (200, 201), sg.text
+            ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                               headers=admin_headers, json={"force": True})
+            assert ap.status_code == 200 and ap.json().get("status") == "applied", ap.text
+
+        apply_status("approved")
+        got = requests.get(f"{api_url}/changes/{cid}", headers=admin_headers).json()
+        assert got["status"] == "approved" and got.get("approved_at"), got
+
+        apply_status("rejected")
+        got = requests.get(f"{api_url}/changes/{cid}", headers=admin_headers).json()
+        assert got["status"] == "rejected", got
+        assert not got.get("approved_at"), "reverse transition must clear approved_at"
+        assert not got.get("approved_by"), "reverse transition must clear approved_by"
+
     def test_suggestion_apply_change_type(self, api_url, admin_headers):
         """The suggestion-apply path (agents/MCP) can reclassify type too."""
         r = requests.post(f"{api_url}/changes", headers=admin_headers, json={


### PR DESCRIPTION
Closes #143. **Final slice of the #26 enforced-write-path epic.**

`applyChangeUpdate` silently ignored a `status` field (UpdateChangeRequestTx doesn't touch status), so a suggestion could never transition a change and `approved_at`/`approved_by` / `implemented_at` were never derived. Now a `status` field routes through `UpdateChangeRequestStatusTx` (tx variant of the HTTP path's `UpdateChangeRequestStatus`).

**#26 coverage after this:**
| entity | where |
|---|---|
| incident, corrective_action | #123 |
| asset, supplier, legal, system, objective (create) | slice A (#142) |
| audit_finding (update) | slice B |
| change_request (status) | this |
| risk, task | no change needed (verified) |

## Test plan
- [ ] `just test-restart` then `just test tests/test_changes.py` — incl. `test_suggestion_apply_status_stamps_approved` (green ×2 verified)
- [ ] apply a change suggestion with `{"status":"approved"}` → `approved_at` set (was ignored before)