### PR TITLE
fix(#147): partial supplier/asset edit no longer wipes unset fields

### DIFF
--- a/cmd/isms/asset.go
+++ b/cmd/isms/asset.go
@@ -125,6 +125,24 @@ func assetListCmd() *cobra.Command {
 	return cmd
 }
 
+// assetEditPayload is the partial-update wire shape for `asset edit` — pointer
+// fields with omitempty so an unset flag is omitted rather than sent as a zero
+// value the server would write over an existing value (#147). Mirrors the
+// server's assetUpdateRequest.
+type assetEditPayload struct {
+	Name            *string   `json:"name,omitempty"`
+	AssetType       *string   `json:"asset_type,omitempty"`
+	Owner           *string   `json:"owner,omitempty"`
+	Description     *string   `json:"description,omitempty"`
+	Status          *string   `json:"status,omitempty"`
+	PrimaryLocation *string   `json:"primary_location,omitempty"`
+	Confidentiality *int      `json:"confidentiality,omitempty"`
+	Integrity       *int      `json:"integrity,omitempty"`
+	Availability    *int      `json:"availability,omitempty"`
+	NextReview      *db.Epoch `json:"next_review,omitempty"`
+	Notes           *string   `json:"notes,omitempty"`
+}
+
 func assetEditCmd() *cobra.Command {
 	var (
 		name            string
@@ -148,24 +166,26 @@ func assetEditCmd() *cobra.Command {
 			id := args[0]
 
 			c := requireAPI()
-			update := &db.Asset{}
+			// Only fields whose flag was set go on the wire; everything else is
+			// omitted so a partial edit never blanks an untouched field (#147).
+			update := &assetEditPayload{}
 			if cmd.Flags().Changed("name") {
-				update.Name = name
+				update.Name = &name
 			}
 			if cmd.Flags().Changed("type") {
-				update.AssetType = assetType
+				update.AssetType = &assetType
 			}
 			if cmd.Flags().Changed("owner") {
-				update.Owner = owner
+				update.Owner = &owner
 			}
 			if cmd.Flags().Changed("desc") {
-				update.Description = description
+				update.Description = &description
 			}
 			if cmd.Flags().Changed("status") {
-				update.Status = status
+				update.Status = &status
 			}
 			if cmd.Flags().Changed("location") {
-				update.PrimaryLocation = primaryLocation
+				update.PrimaryLocation = &primaryLocation
 			}
 			if cmd.Flags().Changed("confidentiality") {
 				update.Confidentiality = &confidentiality
@@ -184,7 +204,7 @@ func assetEditCmd() *cobra.Command {
 				update.NextReview = rd
 			}
 			if cmd.Flags().Changed("notes") {
-				update.Notes = notes
+				update.Notes = &notes
 			}
 			if _, err := c.UpdateAsset(id, update); err != nil {
 				return err

--- a/cmd/isms/cli_relations_test.go
+++ b/cmd/isms/cli_relations_test.go
@@ -221,3 +221,59 @@ func TestSupplierAddRejectsNegativeCIA(t *testing.T) {
 		t.Error("expected an error for --confidentiality -1 (out of 0-5)")
 	}
 }
+
+func TestSupplierEditOmitsUnchangedFields(t *testing.T) {
+	// #147: a partial edit must only send the changed field, so the server never
+	// blanks name/type/status/data_access on an edit that didn't touch them.
+	srv, got := cliServer(t)
+	defer srv.Close()
+	cmd := supplierCmd()
+	cmd.SetArgs([]string{"edit", "SUP-001", "--criticality", "high"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	b := (*got)[len(*got)-1].body
+	if b["criticality"] != "high" {
+		t.Errorf("criticality not sent: %+v", b)
+	}
+	for _, k := range []string{"name", "supplier_type", "data_access", "contact", "notes"} {
+		if _, ok := b[k]; ok {
+			t.Errorf("unchanged field %q must be omitted, got %v", k, b[k])
+		}
+	}
+}
+
+func TestSupplierEditDataAccessFalseIsSent(t *testing.T) {
+	// *bool (not bool) so an explicit --data-access=false turns it off instead of
+	// being dropped as a zero value.
+	srv, got := cliServer(t)
+	defer srv.Close()
+	cmd := supplierCmd()
+	cmd.SetArgs([]string{"edit", "SUP-001", "--data-access=false"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	b := (*got)[len(*got)-1].body
+	if v, ok := b["data_access"]; !ok || v != false {
+		t.Errorf("explicit --data-access=false must be sent as false, got %v (present=%v)", v, ok)
+	}
+}
+
+func TestAssetEditOmitsUnchangedFields(t *testing.T) {
+	srv, got := cliServer(t)
+	defer srv.Close()
+	cmd := assetCmd()
+	cmd.SetArgs([]string{"edit", "AST-001", "--status", "archived"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	b := (*got)[len(*got)-1].body
+	if b["status"] != "archived" {
+		t.Errorf("status not sent: %+v", b)
+	}
+	for _, k := range []string{"name", "asset_type", "owner", "description", "primary_location"} {
+		if _, ok := b[k]; ok {
+			t.Errorf("unchanged field %q must be omitted, got %v", k, b[k])
+		}
+	}
+}

--- a/cmd/isms/supplier.go
+++ b/cmd/isms/supplier.go
@@ -153,6 +153,23 @@ func supplierListCmd() *cobra.Command {
 	return cmd
 }
 
+// supplierEditPayload is the partial-update wire shape for `supplier edit`: every
+// field is a pointer with omitempty, so an unset flag is omitted entirely rather
+// than sent as a zero value the server would write over an existing value (#147).
+// Mirrors the server's supplierUpdateRequest. data_access is *bool (not bool) so an
+// explicit --data-access=false still turns it off instead of being dropped.
+type supplierEditPayload struct {
+	Name            *string `json:"name,omitempty"`
+	SupplierType    *string `json:"supplier_type,omitempty"`
+	Criticality     *string `json:"criticality,omitempty"`
+	DataAccess      *bool   `json:"data_access,omitempty"`
+	Contact         *string `json:"contact,omitempty"`
+	Notes           *string `json:"notes,omitempty"`
+	Confidentiality *int    `json:"confidentiality,omitempty"`
+	Integrity       *int    `json:"integrity,omitempty"`
+	Availability    *int    `json:"availability,omitempty"`
+}
+
 func supplierEditCmd() *cobra.Command {
 	var (
 		name            string
@@ -177,27 +194,27 @@ func supplierEditCmd() *cobra.Command {
 			}
 
 			c := requireAPI()
-			update := &db.Supplier{}
+			// Only fields whose flag was set go on the wire; everything else is
+			// omitted so a partial edit never blanks an untouched field (#147).
+			update := &supplierEditPayload{}
 			if cmd.Flags().Changed("name") {
-				update.Name = name
+				update.Name = &name
 			}
 			if cmd.Flags().Changed("type") {
-				update.SupplierType = supplierType
+				update.SupplierType = &supplierType
 			}
 			if cmd.Flags().Changed("criticality") {
-				update.Criticality = criticality
+				update.Criticality = &criticality
 			}
 			if cmd.Flags().Changed("data-access") {
-				update.DataAccess = dataAccess
+				update.DataAccess = &dataAccess
 			}
 			if cmd.Flags().Changed("contact") {
-				update.Contact = contact
+				update.Contact = &contact
 			}
 			if cmd.Flags().Changed("notes") {
-				update.Notes = notes
+				update.Notes = &notes
 			}
-			// CIA sent only when supplied; the update DTO skips a nil/null rating,
-			// so unrelated edits never disturb an existing rating.
 			if cmd.Flags().Changed("confidentiality") {
 				update.Confidentiality = &confidentiality
 			}

--- a/internal/isms/client/client.go
+++ b/internal/isms/client/client.go
@@ -274,8 +274,8 @@ func (c *Client) AddAsset(asset *db.Asset) (*db.Asset, error) {
 	return &result, json.Unmarshal(data, &result)
 }
 
-func (c *Client) UpdateAsset(id string, asset *db.Asset) (*db.Asset, error) {
-	data, err := c.put("/v1/assets/"+id, asset)
+func (c *Client) UpdateAsset(id string, body any) (*db.Asset, error) {
+	data, err := c.put("/v1/assets/"+id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -369,8 +369,8 @@ func (c *Client) AddSupplier(supplier *db.Supplier) (*db.Supplier, error) {
 	return &result, json.Unmarshal(data, &result)
 }
 
-func (c *Client) UpdateSupplier(id string, supplier *db.Supplier) (*db.Supplier, error) {
-	data, err := c.put("/v1/suppliers/"+id, supplier)
+func (c *Client) UpdateSupplier(id string, body any) (*db.Supplier, error) {
+	data, err := c.put("/v1/suppliers/"+id, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #147. The pre-existing bug you flagged in #146's review (finding 3).

## Bug
`isms supplier edit <id> --criticality high` sent a zero-value `db.Supplier`; `name`/`supplier_type`/`status`/`data_access` have no omitempty, so the server wrote the blanks over existing data. `asset edit` had the identical `db.Asset{}` shape.

## Fix
- Dedicated pointer-payload structs (`supplierEditPayload` / `assetEditPayload`) with omitempty, populated only for `Changed()` flags → untouched fields are omitted from the wire.
- `client.UpdateSupplier`/`UpdateAsset` take `any`; the full-object import path and manager flow are unchanged.
- `data_access` is `*bool` so an explicit `--data-access=false` turns it off (not dropped) — the caveat you raised.

## Tests
`just test-go` green. New regression tests: a partial edit omits unchanged fields (supplier + asset), and `--data-access=false` is sent.

## Stacking
Based on **feat/supplier-cia-flags** (#146) since both touch `supplierEditCmd` — this keeps the diff clean. When #146 merges, this retargets to master and I'll rebuild it onto master (cherry-pick).