### PR TITLE
fix(#127): Programs register + repo-wide status-badge consistency

### DIFF
--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -144,11 +145,26 @@ func (s *Server) handleCreateProgram(c echo.Context) error {
 	return c.JSON(http.StatusCreated, p)
 }
 
+// resolveProgramID accepts either a numeric program id or a program key (e.g.
+// "AWARE"). Cross-entity reference chips link programs by key, while the register's
+// own list links by id — both must reach these endpoints. Mirrors the id-or-key
+// fallback the reference title resolver already uses.
+func (s *Server) resolveProgramID(ctx context.Context, orgID int, raw string) (int64, error) {
+	if id, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return id, nil
+	}
+	p, err := s.db.GetProgramByKey(ctx, orgID, raw)
+	if err != nil {
+		return 0, err
+	}
+	return p.ID, nil
+}
+
 func (s *Server) handleGetProgram(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	id, err := s.resolveProgramID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return echo.NewHTTPError(http.StatusNotFound, "program not found")
 	}
 	p, err := s.db.GetProgram(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -163,9 +179,9 @@ func (s *Server) handleUpdateProgram(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	id, err := s.resolveProgramID(ctx, orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return echo.NewHTTPError(http.StatusNotFound, "program not found")
 	}
 
 	old, err := s.db.GetProgram(ctx, orgID, id)
@@ -217,9 +233,9 @@ func (s *Server) handleDeleteProgram(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	id, err := s.resolveProgramID(ctx, orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return echo.NewHTTPError(http.StatusNotFound, "program not found")
 	}
 
 	if err := s.db.DeleteProgram(ctx, orgID, id); err != nil {

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -112,6 +112,7 @@ class TestSmoke:
         ("Corrective Actions", "Corrective"),
         ("Incidents", "Incident"),
         ("Objectives", "Objectives"),
+        ("Programs", "Program Register"),
         ("Tasks", "Tasks"),
         ("Inbox", "Inbox"),
         ("Admin", "Members"),

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -37,6 +37,25 @@ class TestPrograms:
         })
         assert r.status_code == 403
 
+    def test_get_resolves_id_or_key(self, api_url, admin_headers):
+        """#149: program endpoints accept a numeric id OR the program key —
+        cross-entity reference chips deep-link programs by key."""
+        key = "BYKEY2026"
+        requests.post(f"{api_url}/programs", headers=admin_headers,
+                      json={"title": "By-key resolver test", "key": key})  # idempotent
+        progs = requests.get(f"{api_url}/programs", headers=admin_headers).json().get("data") or []
+        p = next((x for x in progs if x.get("key") == key), None)
+        assert p is not None, "program missing from list after create"
+        # by key
+        rk = requests.get(f"{api_url}/programs/{key}", headers=admin_headers)
+        assert rk.status_code == 200 and rk.json().get("key") == key, rk.text
+        # by numeric id
+        ri = requests.get(f"{api_url}/programs/{p['id']}", headers=admin_headers)
+        assert ri.status_code == 200 and ri.json().get("id") == p["id"], ri.text
+        # unknown key → 404 (not 400)
+        r404 = requests.get(f"{api_url}/programs/NOSUCHKEY999", headers=admin_headers)
+        assert r404.status_code == 404, f"expected 404, got {r404.status_code}: {r404.text}"
+
 
 class TestObjectives:
     def test_create(self, api_url, admin_headers):

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -226,6 +226,15 @@
               </svg>
               <span v-if="!sidebarCollapsed">Objectives</span>
             </router-link>
+            <router-link v-if="hasOrg" :to="orgPath('/programs')"
+              class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
+              :class="[route.path.startsWith(orgPath('/programs')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
+              :title="sidebarCollapsed ? 'Programs' : undefined">
+              <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+              </svg>
+              <span v-if="!sidebarCollapsed">Programs</span>
+            </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/audit')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/audit')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
@@ -579,9 +588,13 @@ const nav = computed(() => {
     { path: orgPath('/assets'), label: 'Assets' },
     { path: orgPath('/systems'), label: 'Systems' },
     { path: orgPath('/objectives'), label: 'Objectives' },
+    { path: orgPath('/programs'), label: 'Programs' },
     { path: orgPath('/audit'), label: 'Audit' },
     { path: orgPath('/corrective-actions'), label: 'Corrective Actions' },
     { path: orgPath('/incidents'), label: 'Incidents' },
+    { path: orgPath('/changes'), label: 'Change Management' },
+    { path: orgPath('/tasks'), label: 'Tasks' },
+    { path: orgPath('/reviews'), label: 'Reviews' },
   ]
   if (currentUserData.value?.role === 'admin') {
     base.push({ path: orgPath('/admin'), label: 'Admin' })

--- a/web/src/components/EntityReferences.vue
+++ b/web/src/components/EntityReferences.vue
@@ -98,7 +98,7 @@ const typeRoutes = {
   corrective_action: 'corrective-actions',
   control: 'documents',
   objective: 'objectives',
-  program: 'objectives',
+  program: 'programs',
   task: 'tasks',
 }
 
@@ -130,7 +130,7 @@ function refRoute(r) {
     return orgPath(`/documents/${other.id}`)
   }
   // Deep link for entity types that support /:id routes
-  const deepLinkTypes = ['change', 'incident', 'corrective_action', 'supplier', 'asset', 'task', 'risk', 'legal', 'system']
+  const deepLinkTypes = ['change', 'incident', 'corrective_action', 'supplier', 'asset', 'task', 'risk', 'legal', 'system', 'program']
   if (deepLinkTypes.includes(other.type) && other.id) {
     const numId = other.id.replace(/^[A-Z]+-/, '')
     return orgPath(`/${routeBase}/${numId}`)
@@ -138,7 +138,7 @@ function refRoute(r) {
   // Objective deep-links need tab prefix
   if (other.type === 'objective' && other.id) {
     const numId = other.id.replace(/^[A-Z]+-/, '')
-    return orgPath(`/objectives/objectives/${numId}`)
+    return orgPath(`/objectives/${numId}`)
   }
   // Audit deep-links need tab prefix
   if (other.type === 'audit' && other.id) {

--- a/web/src/components/GlobalSearch.vue
+++ b/web/src/components/GlobalSearch.vue
@@ -136,7 +136,7 @@ const typeRoutes = {
   corrective_action: 'corrective-actions',
   objective: 'objectives',
   task: 'tasks',
-  program: 'objectives',
+  program: 'programs',
 }
 
 function open() {

--- a/web/src/components/ReferenceManager.vue
+++ b/web/src/components/ReferenceManager.vue
@@ -120,7 +120,7 @@ const typeRoutes = {
   risk: 'risks', legal: 'legal', document: 'documents', asset: 'assets',
   supplier: 'suppliers', system: 'systems', incident: 'incidents', change: 'changes',
   audit: 'audit', corrective_action: 'corrective-actions',
-  objective: 'objectives', program: 'objectives', task: 'tasks',
+  objective: 'objectives', program: 'programs', task: 'tasks',
 }
 
 function otherSide(r) {

--- a/web/src/components/StatusBadge.vue
+++ b/web/src/components/StatusBadge.vue
@@ -38,6 +38,8 @@ const classes = computed(() => {
     // Task statuses
     in_progress: 'bg-blue-900/60 text-blue-300',
     done: 'bg-emerald-900/60 text-emerald-300',
+    cancelled: 'bg-slate-700 text-slate-400',
+    todo: 'bg-red-900/60 text-red-300',
 
     // Change management
     proposed: 'bg-amber-900/60 text-amber-300',

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -23,6 +23,7 @@ const Changes = () => import('./views/Changes.vue')
 const Tasks = () => import('./views/Tasks.vue')
 const Legal = () => import('./views/Legal.vue')
 const Objectives = () => import('./views/Objectives.vue')
+const Programs = () => import('./views/Programs.vue')
 const Reviews = () => import('./views/Reviews.vue')
 const Settings = () => import('./views/Settings.vue')
 const Admin = () => import('./views/Admin.vue')
@@ -48,8 +49,9 @@ const orgScopedRoutes = [
   { path: '/legal', component: Legal },
   { path: '/legal/:id', component: Legal },
   { path: '/objectives', component: Objectives },
-  { path: '/objectives/:tab', component: Objectives },
-  { path: '/objectives/:tab/:objId', component: Objectives },
+  { path: '/objectives/:objId', component: Objectives },
+  { path: '/programs', component: Programs },
+  { path: '/programs/:id', component: Programs },
   { path: '/audit', component: Audit },
   { path: '/audit/:tab', component: Audit },
   { path: '/audit/:tab/:itemId', component: Audit },

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -125,11 +125,7 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-sm font-medium text-slate-200">{{ cr.title }}</span>
-                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                  :class="statusClass(cr.status)">
-                  <span class="w-1.5 h-1.5 rounded-full" :class="statusDot(cr.status)"></span>
-                  {{ cr.status }}
-                </span>
+                <StatusBadge :status="cr.status" />
                 <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(cr.priority)">{{ cr.priority }}</span>
                 <span class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ cr.category }}</span>
               </div>
@@ -505,29 +501,6 @@ const statusStats = computed(() => {
     { key: 'closed', label: 'Closed', count: stats.value.closed || 0, color: 'text-slate-500' },
   ]
 })
-
-function statusClass(s) {
-  switch (s) {
-    case 'proposed': return 'bg-blue-500/15 text-blue-400'
-    case 'approved': return 'bg-emerald-500/15 text-emerald-400'
-    case 'in_progress': return 'bg-amber-500/15 text-amber-400'
-    case 'rejected': return 'bg-red-500/15 text-red-400'
-    case 'implemented': return 'bg-purple-500/15 text-purple-400'
-    case 'closed': return 'bg-slate-500/15 text-slate-400'
-    default: return 'bg-slate-500/15 text-slate-400'
-  }
-}
-
-function statusDot(s) {
-  switch (s) {
-    case 'proposed': return 'bg-blue-400'
-    case 'approved': return 'bg-emerald-400'
-    case 'in_progress': return 'bg-amber-400'
-    case 'rejected': return 'bg-red-400'
-    case 'implemented': return 'bg-purple-400'
-    default: return 'bg-slate-400'
-  }
-}
 
 function priorityClass(p) {
   switch (p) {

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -177,10 +177,7 @@
               {{ sourceLabel(ca.source) }}
             </span>
             <!-- Status badge -->
-            <span class="inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-full whitespace-nowrap"
-              :class="statusClass(ca.status)">
-              {{ statusLabel(ca.status) }}
-            </span>
+            <StatusBadge :status="ca.status" />
             <!-- Title -->
             <span class="text-sm font-medium text-slate-200 flex-1 truncate">{{ ca.title }}</span>
             <!-- Assignee -->
@@ -209,10 +206,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedCA.title }}</h2>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
-              <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded-full whitespace-nowrap"
-                :class="statusClass(selectedCA.status)">
-                {{ statusLabel(selectedCA.status) }}
-              </span>
+              <StatusBadge :status="selectedCA.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -431,6 +425,7 @@ import { useRoute, useRouter } from 'vue-router'
 import api from '../api'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
+import StatusBadge from '../components/StatusBadge.vue'
 import EntityReferences from '../components/EntityReferences.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
@@ -890,18 +885,6 @@ function severityClass(sev) {
     case 'observation': return 'bg-blue-900/60 text-blue-300 border border-blue-800'
     case 'opportunity': return 'bg-emerald-900/60 text-emerald-300 border border-emerald-800'
     default: return 'bg-slate-800 text-slate-400 border border-slate-700'
-  }
-}
-
-function statusClass(status) {
-  switch (status) {
-    case 'todo': return 'bg-red-900/40 text-red-400'
-    case 'assessment': return 'bg-amber-900/40 text-amber-400'
-    case 'awaiting_approval': return 'bg-purple-900/40 text-purple-400'
-    case 'implementation': return 'bg-blue-900/40 text-blue-400'
-    case 'monitoring': return 'bg-cyan-900/40 text-cyan-400'
-    case 'resolved': return 'bg-emerald-900/40 text-emerald-400'
-    default: return 'bg-slate-800 text-slate-400'
   }
 }
 

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -153,10 +153,7 @@
               :class="typeClass(inc.incident_type)">
               {{ inc.incident_type }}
             </span>
-            <span class="inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-full"
-              :class="statusClass(inc.status)">
-              {{ inc.status }}
-            </span>
+            <StatusBadge :status="inc.status" />
             <span class="text-sm font-medium text-slate-200 flex-1 truncate">{{ inc.title }}</span>
             <span class="text-xs text-slate-600 font-mono">{{ inc.identifier }}</span>
             <span class="text-xs text-slate-600">{{ formatDate(inc.created_at) }}</span>
@@ -879,17 +876,6 @@ function typeClass(type_) {
     case 'incident': return 'bg-red-900/40 text-red-400'
     case 'event': return 'bg-amber-900/40 text-amber-400'
     case 'weakness': return 'bg-purple-900/40 text-purple-400'
-    default: return 'bg-slate-800 text-slate-400'
-  }
-}
-
-function statusClass(status) {
-  switch (status) {
-    case 'open': return 'bg-red-900/40 text-red-400'
-    case 'investigating': return 'bg-amber-900/40 text-amber-400'
-    case 'contained': return 'bg-blue-900/40 text-blue-400'
-    case 'resolved': return 'bg-emerald-900/40 text-emerald-400'
-    case 'closed': return 'bg-slate-800 text-slate-500'
     default: return 'bg-slate-800 text-slate-400'
   }
 }

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -21,139 +21,17 @@
           <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Objectives</h1>
           <p class="text-sm text-slate-500 mt-1">Track measurable ISMS objectives and KPI performance</p>
         </div>
-      </div>
-
-      <!-- Tabs + actions -->
-      <div class="flex items-center border-b border-slate-800">
-        <div class="flex gap-1 flex-1">
-          <button
-            v-for="t in tabs" :key="t.key"
-            @click="switchTab(t.key)"
-            class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px"
-            :class="activeTab === t.key ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'"
-          >{{ t.label }}</button>
-        </div>
-        <div class="flex gap-2 pb-1">
-          <button v-if="canWrite" @click="activeTab === 'programs' ? (showCreateProgram = !showCreateProgram) : (showCreateObjective = !showCreateObjective)"
+        <div class="flex gap-2">
+          <button v-if="canWrite" @click="showCreateObjective = !showCreateObjective"
             class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ activeTab === 'programs' ? 'Add Program' : 'Add Objective' }}
+            Add Objective
           </button>
-          <SuggestNewButton :entityType="activeTab === 'programs' ? 'program' : 'objective'" :typeLabel="activeTab === 'programs' ? 'Program' : 'Objective'" />
+          <SuggestNewButton entityType="objective" typeLabel="Objective" />
         </div>
       </div>
 
-      <!-- Create program form (modal) -->
-      <Teleport to="body">
-      <Transition name="modal">
-      <div v-if="showCreateProgram" class="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] px-4">
-        <div class="absolute inset-0 bg-black/60" @click="showCreateProgram = false" />
-        <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
-          <h3 class="text-sm font-semibold text-slate-300">Add Program</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label class="block text-xs text-slate-500 mb-1">Key (uppercase) *</label>
-              <input v-model="newProgram.key" @input="newProgram.key = newProgram.key.toUpperCase().replace(/[^A-Z0-9]/g, '')"
-                class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 uppercase"
-                placeholder="AWARE" />
-            </div>
-            <div>
-              <label class="block text-xs text-slate-500 mb-1">Title *</label>
-              <input v-model="newProgram.title"
-                class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                placeholder="Security Awareness" />
-            </div>
-          </div>
-          <div class="text-[10px] text-slate-600 mt-1">You can add description and notes after creating.</div>
-          <div class="flex justify-end gap-2 pt-2">
-            <button @click="showCreateProgram = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200">Cancel</button>
-            <button @click="createProgram" :disabled="!newProgram.key || !newProgram.title"
-              class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors">
-              Add
-            </button>
-          </div>
-        </div>
-      </div>
-      </Transition>
-      </Teleport>
-
-      <!-- Edit program modal -->
-      <Teleport to="body">
-      <Transition name="modal">
-      <div v-if="showEditProgram" class="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] px-4">
-        <div class="absolute inset-0 bg-black/60" @click="showEditProgram = false" />
-        <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
-          <h3 class="text-sm font-semibold text-slate-300">Edit Program</h3>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label class="block text-xs text-slate-500 mb-1">Key (uppercase)</label>
-              <input v-model="editProgramData.key" @input="editProgramData.key = editProgramData.key.toUpperCase().replace(/[^A-Z0-9]/g, '')"
-                class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 uppercase"
-                placeholder="AWARE" />
-            </div>
-            <div>
-              <label class="block text-xs text-slate-500 mb-1">Title</label>
-              <input v-model="editProgramData.title"
-                class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                placeholder="Security Awareness" />
-            </div>
-            <div class="sm:col-span-2">
-              <label class="block text-xs text-slate-500 mb-1">Description</label>
-              <MarkdownField v-model="editProgramData.description" :rows="2" placeholder="Program description" />
-            </div>
-            <div class="sm:col-span-2">
-              <label class="block text-xs text-slate-500 mb-1">Notes</label>
-              <MarkdownField v-model="editProgramData.notes" :rows="2" placeholder="Additional notes..." />
-            </div>
-          </div>
-          <div class="flex justify-end gap-2 pt-2">
-            <button @click="showEditProgram = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200">Cancel</button>
-            <button @click="saveProgram" :disabled="!editProgramData.key || !editProgramData.title"
-              class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors">
-              Save
-            </button>
-          </div>
-        </div>
-      </div>
-      </Transition>
-      </Teleport>
-
-      <!-- Programs Tab -->
-      <div v-if="activeTab === 'programs'" class="space-y-6">
-        <!-- Programs list -->
-        <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-slate-800">
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Key</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Objectives</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Description</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider w-20"></th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-800/50">
-              <tr v-for="p in programs" :key="p.id" class="hover:bg-slate-800/30 transition-colors">
-                <td class="px-4 py-3 font-mono text-blue-400 font-medium">{{ p.key }}</td>
-                <td class="px-4 py-3 text-slate-200">{{ p.title }}</td>
-                <td class="px-4 py-3 text-slate-400 tabular-nums">{{ objectiveCountByProgram(p.id) }}</td>
-                <td class="px-4 py-3 text-slate-500 truncate max-w-xs">{{ p.description || '-' }}</td>
-                <td class="px-4 py-3">
-                  <div class="flex items-center gap-2">
-                    <button @click="editProgram(p)" class="text-xs text-blue-400 hover:text-blue-300">Edit</button>
-                    <button @click="deleteProgram(p)" class="text-xs text-red-400 hover:text-red-300">Delete</button>
-                  </div>
-                </td>
-              </tr>
-              <tr v-if="programs.length === 0">
-                <td colspan="5" class="px-4 py-8 text-center text-slate-600 text-sm">No programs yet</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <!-- Objectives Tab -->
-      <div v-if="activeTab === 'objectives'" class="space-y-6">
+      <!-- Objectives -->
+      <div class="space-y-6">
         <!-- Stats cards -->
         <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
           <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
@@ -274,10 +152,7 @@
                   <span v-else class="text-slate-600">-</span>
                 </td>
                 <td class="px-4 py-3">
-                  <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                    :class="statusClass(o.status)">
-                    {{ statusLabel(o.status) }}
-                  </span>
+                  <StatusBadge :status="o.status" />
                 </td>
                 <td class="px-4 py-3 text-slate-400 text-xs">{{ resolveUserName(o.owner) }}</td>
                 <td class="px-4 py-3" @click.stop>
@@ -318,9 +193,7 @@
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedObjective.title }}</h2>
           </div>
           <div class="flex items-center gap-2 flex-shrink-0">
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium" :class="statusClass(selectedObjective.status)">
-              {{ statusLabel(selectedObjective.status) }}
-            </span>
+            <StatusBadge :status="selectedObjective.status" />
             <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
               <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -648,6 +521,7 @@ import HistoryPanel from '../components/HistoryPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import Pagination from '../components/Pagination.vue'
 import ListSkeleton from '../components/ListSkeleton.vue'
+import StatusBadge from '../components/StatusBadge.vue'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
@@ -668,11 +542,7 @@ const objectives = ref([])
 const checkins = ref([])
 const selectedObjective = ref(null)
 const showCreateObjective = ref(false)
-const showCreateProgram = ref(false)
-const showEditProgram = ref(false)
-useModalEscape(showCreateProgram)
 useModalEscape(showCreateObjective)
-useModalEscape(showEditProgram)
 useModalEscape(computed(() => !!selectedObjective.value), () => closeDetail())
 const pendingRefs = ref([])
 const evidenceByCheckin = ref({})
@@ -709,19 +579,6 @@ const total = ref(0)
 const stats = ref({ total: 0, draft: 0, active: 0, at_risk: 0, paused: 0, complete: 0, archived: 0 })
 const orgMembers = ref([])
 
-const tabs = [
-  { key: 'programs', label: 'Programs' },
-  { key: 'objectives', label: 'Objectives' },
-]
-
-const activeTab = computed(() => route.params.tab || 'objectives')
-
-function switchTab(tab) {
-  router.push(orgPath(`/objectives/${tab}`))
-}
-
-const newProgram = reactive({ key: '', title: '' })
-const editProgramData = reactive({ id: null, key: '', title: '', description: '', notes: '' })
 const newObjective = reactive({
   program_id: '',
   title: '',
@@ -733,22 +590,6 @@ const newCheckin = reactive({
   message: '',
   public_note: '',
 })
-
-function objectiveCountByProgram(programId) {
-  // Best-effort: only counts objectives on the current page. Programs table is for navigation only.
-  return (Array.isArray(objectives.value) ? objectives.value : []).filter(o => o.program_id === programId).length
-}
-
-function statusClass(status) {
-  const map = {
-    draft: 'bg-slate-500/20 text-slate-400',
-    active: 'bg-emerald-500/20 text-emerald-300',
-    at_risk: 'bg-red-500/20 text-red-300',
-    paused: 'bg-amber-500/20 text-amber-300',
-    complete: 'bg-blue-500/20 text-blue-300',
-  }
-  return map[status] || 'bg-slate-500/20 text-slate-400'
-}
 
 function statusLabel(status) {
   const map = { draft: 'Draft', active: 'Active', at_risk: 'At Risk', paused: 'Paused', complete: 'Complete' }
@@ -857,7 +698,7 @@ async function selectObjective(o) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/objectives/objectives/${o.id}`))
+  router.push(orgPath(`/objectives/${o.id}`))
 }
 
 async function switchDetailTab(key) {
@@ -882,7 +723,7 @@ async function closeDetail() {
     })
     if (!ok) return
   }
-  router.push(orgPath('/objectives/objectives'))
+  router.push(orgPath('/objectives'))
 }
 
 async function openObjectiveFromRoute(id) {
@@ -965,64 +806,6 @@ async function deleteSelectedObjective() {
   }
 }
 
-async function createProgram() {
-  try {
-    const created = await api.createProgram({
-      key: newProgram.key,
-      title: newProgram.title,
-    })
-    newProgram.key = ''
-    newProgram.title = ''
-    showCreateProgram.value = false
-    await loadAll()
-    // Drop user into program edit modal so they can keep filling things in.
-    if (created && created.id) {
-      let fresh = created
-      try { fresh = await api.getProgram(created.id) } catch { /* fall back */ }
-      Object.assign(editProgramData, {
-        id: fresh.id,
-        key: fresh.key || '',
-        title: fresh.title || '',
-        description: fresh.description || '',
-        notes: fresh.notes || '',
-      })
-      showEditProgram.value = true
-    }
-  } catch (e) {
-    error.value = e.message
-  }
-}
-
-async function deleteProgram(p) {
-  if (!await confirmAsk(`Delete program "${p.key}"? All objectives under it will also be deleted.`, { confirm: 'Delete', variant: 'danger' })) return
-  try {
-    await api.deleteProgram(p.id)
-    await loadAll()
-  } catch (e) {
-    error.value = e.message
-  }
-}
-
-function editProgram(p) {
-  Object.assign(editProgramData, { id: p.id, key: p.key, title: p.title, description: p.description || '', notes: p.notes || '' })
-  showEditProgram.value = true
-}
-
-async function saveProgram() {
-  try {
-    await api.updateProgram(editProgramData.id, {
-      key: editProgramData.key,
-      title: editProgramData.title,
-      description: editProgramData.description,
-      notes: editProgramData.notes,
-    })
-    showEditProgram.value = false
-    await loadAll()
-  } catch (e) {
-    error.value = e.message
-  }
-}
-
 async function createObjective() {
   try {
     const payload = { ...newObjective }
@@ -1050,7 +833,7 @@ async function createObjective() {
       startEditObjective(fresh)
       editingSection.value = 'overview'
       loadCheckins()
-      router.push(orgPath(`/objectives/objectives/${fresh.id}`))
+      router.push(orgPath(`/objectives/${fresh.id}`))
     }
   } catch (e) {
     error.value = e.message

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -1,0 +1,447 @@
+<template>
+  <div class="min-h-full">
+    <div class="overflow-y-auto">
+    <!-- Loading -->
+    <div v-if="loading" class="max-w-6xl mx-auto px-8 py-10">
+      <ListSkeleton :rows="5" />
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="max-w-6xl mx-auto px-8 py-12">
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
+        {{ error }}
+      </div>
+    </div>
+
+    <!-- Main content -->
+    <div v-else class="max-w-6xl mx-auto px-8 py-10 space-y-6">
+      <!-- Header -->
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Program Register</h1>
+          <p class="text-sm text-slate-500 mt-1">Group ISMS objectives into programs of work</p>
+        </div>
+        <div class="flex gap-2">
+          <button v-if="canWrite" @click="showCreateForm = !showCreateForm"
+            class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
+            Add Program
+          </button>
+          <SuggestNewButton entityType="program" typeLabel="Program" />
+        </div>
+      </div>
+
+      <!-- Filter/search bar -->
+      <div class="flex items-center gap-3 flex-wrap">
+        <div class="relative flex-1 max-w-xs">
+          <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+          </svg>
+          <input v-model="searchQuery" type="text" placeholder="Search..."
+            class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
+        </div>
+        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ filtered.length }} total</div>
+      </div>
+
+      <!-- Create program form (modal) -->
+      <Teleport to="body">
+      <Transition name="modal">
+      <div v-if="showCreateForm" class="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] px-4">
+        <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
+        <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
+          <h3 class="text-sm font-semibold text-slate-300">Add Program</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-xs text-slate-500 mb-1">Key (uppercase) *</label>
+              <input v-model="newProgram.key" @input="newProgram.key = newProgram.key.toUpperCase().replace(/[^A-Z0-9]/g, '')"
+                class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 uppercase"
+                placeholder="AWARE" />
+            </div>
+            <div>
+              <label class="block text-xs text-slate-500 mb-1">Title *</label>
+              <input v-model="newProgram.title"
+                class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                placeholder="Security Awareness" />
+            </div>
+          </div>
+          <div class="text-[10px] text-slate-600 mt-1">You can add description and notes after creating.</div>
+          <div class="flex justify-end gap-2 pt-2">
+            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200">Cancel</button>
+            <button @click="createProgram" :disabled="!newProgram.key || !newProgram.title"
+              class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors">
+              Add
+            </button>
+          </div>
+        </div>
+      </div>
+      </Transition>
+      </Teleport>
+
+      <!-- Programs table -->
+      <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-slate-800">
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Key</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Description</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-800/50">
+            <tr v-for="p in paged" :key="p.id"
+              @click="selectProgram(p)"
+              class="hover:bg-slate-800/30 transition-colors cursor-pointer"
+              :class="selected?.id === p.id ? 'bg-slate-800/50' : ''">
+              <td class="px-4 py-3 font-mono text-blue-400 font-medium whitespace-nowrap">{{ p.key }}</td>
+              <td class="px-4 py-3 text-slate-200">{{ p.title }}</td>
+              <td class="px-4 py-3 text-slate-500 truncate max-w-md">{{ p.description || '—' }}</td>
+            </tr>
+            <tr v-if="filtered.length === 0">
+              <td colspan="3" class="px-4 py-8 text-center text-slate-600 text-sm">No programs yet</td>
+            </tr>
+          </tbody>
+        </table>
+        <Pagination :page="page" :pageSize="pageSize" :total="filtered.length" @update:page="page = $event" @update:pageSize="pageSize = $event" />
+      </div>
+    </div>
+
+    <!-- Detail slide-over -->
+    <Teleport to="body">
+    <Transition name="modal">
+    <div v-if="selected" class="fixed inset-0 z-50 flex items-start justify-center pt-[3vh] px-4">
+      <div class="absolute inset-0 bg-black/60" @click="closeDetail" />
+      <div class="relative w-full max-w-4xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl max-h-[90vh] flex flex-col">
+        <!-- Header -->
+        <div class="flex-shrink-0 border-b border-slate-800 px-6 py-3 flex items-center justify-between gap-4">
+          <div class="flex items-center gap-6 min-w-0">
+            <span class="text-[10px] font-mono uppercase tracking-wider text-blue-400 flex-shrink-0">{{ selected.key }}</span>
+            <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selected.title }}</h2>
+          </div>
+          <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
+            <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Body: sidebar nav + content -->
+        <div class="flex flex-1 min-h-0">
+          <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
+            <div class="space-y-0.5">
+              <button v-for="t in detailTabs" :key="t.key" @click="detailTab = t.key"
+                class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
+                :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                {{ t.label }}
+              </button>
+            </div>
+          </nav>
+
+          <div class="flex-1 overflow-y-auto min-h-0">
+            <!-- OVERVIEW -->
+            <template v-if="detailTab === 'overview'">
+              <div class="px-6 py-5 space-y-5">
+                <div class="flex items-center justify-between">
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
+                  <button v-if="canWrite && !editing" @click="startEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                </div>
+                <template v-if="editing">
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">Key</label>
+                      <input v-model="editForm.key" @input="editForm.key = editForm.key.toUpperCase().replace(/[^A-Z0-9]/g, '')"
+                        class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 uppercase" />
+                    </div>
+                    <div>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                      <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
+                    </div>
+                    <div class="sm:col-span-2">
+                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
+                      <MarkdownField v-model="editForm.description" :rows="3" placeholder="What is this program?" />
+                    </div>
+                  </div>
+                </template>
+                <template v-else>
+                  <div class="space-y-4">
+                    <div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                      <div v-if="selected.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-html="renderMd(selected.description)"></div>
+                      <div v-else class="text-sm text-slate-600">—</div>
+                    </div>
+                    <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
+                      <div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Key</div>
+                        <div class="text-sm text-slate-300 font-mono">{{ selected.key }}</div>
+                      </div>
+                      <div v-if="selected.created_at">
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                        <div class="text-sm text-slate-300">{{ formatDate(selected.created_at) }}</div>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </template>
+
+            <!-- NOTES -->
+            <template v-if="detailTab === 'notes'">
+              <div class="px-6 py-5 space-y-5">
+                <div class="flex items-center justify-between">
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
+                  <button v-if="canWrite && !editing" @click="startEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                </div>
+                <template v-if="editing">
+                  <MarkdownField v-model="editForm.notes" :rows="12" placeholder="Add notes..." />
+                </template>
+                <template v-else>
+                  <div v-if="selected.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-html="renderMd(selected.notes)"></div>
+                  <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                </template>
+              </div>
+            </template>
+
+            <!-- LINKS -->
+            <template v-if="detailTab === 'links'">
+              <div class="px-6 py-5">
+                <ReferenceManager entityType="program" :entityId="selected.key" :editable="canWrite" />
+              </div>
+            </template>
+
+            <!-- SUGGESTIONS -->
+            <template v-if="detailTab === 'suggestions'">
+              <div class="px-6 py-5">
+                <SuggestionPanel entityType="program" :entityId="selected.key" :canReview="canWrite" @applied="loadAll" />
+              </div>
+            </template>
+
+            <!-- COMMENTS -->
+            <template v-if="detailTab === 'comments'">
+              <div class="px-6 py-5">
+                <CommentsPanel entityType="program" :entityId="selected.key" />
+              </div>
+            </template>
+
+            <!-- HISTORY -->
+            <template v-if="detailTab === 'history'">
+              <div class="px-6 py-5 space-y-6">
+                <HistoryPanel entityType="program" :entityId="String(selected.id)" />
+                <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
+                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
+                  <div class="text-xs text-slate-400">Deleting this program also deletes all objectives under it. This cannot be undone.</div>
+                  <button @click="deleteSelected" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
+                    Delete program
+                  </button>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+
+        <!-- Footer (edit mode) -->
+        <div v-if="editing" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
+          <button @click="cancelEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="saveEdit" :disabled="saving || !editForm.key || !editForm.title" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+        </div>
+      </div>
+    </div>
+    </Transition>
+    </Teleport>
+
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { api } from '../api'
+import { renderMarkdown } from '../composables/useRenderMd.js'
+import { useToast } from '../composables/useToast'
+import { useConfirm } from '../composables/useConfirm.js'
+import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { useModalEscape } from '../composables/useModalEscape.js'
+import MarkdownField from '../components/MarkdownField.vue'
+import ReferenceManager from '../components/ReferenceManager.vue'
+import SuggestionPanel from '../components/SuggestionPanel.vue'
+import SuggestNewButton from '../components/SuggestNewButton.vue'
+import CommentsPanel from '../components/CommentsPanel.vue'
+import HistoryPanel from '../components/HistoryPanel.vue'
+import Pagination from '../components/Pagination.vue'
+import ListSkeleton from '../components/ListSkeleton.vue'
+
+const route = useRoute()
+const router = useRouter()
+const { orgPath } = useCurrentOrg()
+const { success: showSaved, error: showError } = useToast()
+const { ask: confirmAsk } = useConfirm()
+
+const userRole = ref('')
+const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
+
+const loading = ref(true)
+const error = ref(null)
+const programs = ref([])
+const selected = ref(null)
+const showCreateForm = ref(false)
+const searchQuery = ref('')
+const page = ref(1)
+const pageSize = ref(50)
+
+const detailTab = ref('overview')
+const editing = ref(false)
+const saving = ref(false)
+const editForm = reactive({ key: '', title: '', description: '', notes: '' })
+const newProgram = reactive({ key: '', title: '' })
+
+useModalEscape(showCreateForm)
+useModalEscape(computed(() => !!selected.value), () => closeDetail())
+
+const detailTabs = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'notes', label: 'Notes' },
+  { key: 'links', label: 'Links' },
+  { key: 'suggestions', label: 'Suggestions' },
+  { key: 'comments', label: 'Comments' },
+  { key: 'history', label: 'History' },
+]
+
+const renderMd = renderMarkdown
+
+const filtered = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return programs.value
+  return programs.value.filter(p =>
+    (p.key || '').toLowerCase().includes(q) ||
+    (p.title || '').toLowerCase().includes(q) ||
+    (p.description || '').toLowerCase().includes(q))
+})
+
+const paged = computed(() => {
+  const start = (page.value - 1) * pageSize.value
+  return filtered.value.slice(start, start + pageSize.value)
+})
+
+watch([searchQuery, pageSize], () => { page.value = 1 })
+
+function formatDate(dateStr) {
+  if (!dateStr && dateStr !== 0) return ''
+  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
+  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+async function loadAll() {
+  loading.value = true
+  error.value = null
+  try {
+    const progs = await api.getPrograms()
+    programs.value = Array.isArray(progs) ? progs : (progs?.data || [])
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+function selectProgram(p) {
+  if (selected.value?.id === p.id) { closeDetail(); return }
+  router.push(orgPath(`/programs/${p.id}`))
+}
+
+function closeDetail() {
+  router.push(orgPath('/programs'))
+}
+
+async function openFromRoute(id) {
+  const numId = parseInt(id)
+  let p = programs.value.find(x => x.id === numId)
+  if (!p) {
+    try { p = await api.getProgram(numId) } catch { return }
+  }
+  if (!p) return
+  selected.value = p
+  detailTab.value = 'overview'
+  editing.value = false
+}
+
+function startEdit() {
+  Object.assign(editForm, {
+    key: selected.value.key || '',
+    title: selected.value.title || '',
+    description: selected.value.description || '',
+    notes: selected.value.notes || '',
+  })
+  editing.value = true
+}
+
+function cancelEdit() {
+  editing.value = false
+}
+
+async function saveEdit() {
+  if (!selected.value) return
+  saving.value = true
+  try {
+    await api.updateProgram(selected.value.id, {
+      key: editForm.key,
+      title: editForm.title,
+      description: editForm.description,
+      notes: editForm.notes,
+    })
+    await loadAll()
+    const fresh = programs.value.find(p => p.id === selected.value.id)
+    if (fresh) selected.value = fresh
+    editing.value = false
+    showSaved('Saved')
+  } catch (e) {
+    showError('Failed to save: ' + e.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function createProgram() {
+  try {
+    const created = await api.createProgram({ key: newProgram.key, title: newProgram.title })
+    newProgram.key = ''
+    newProgram.title = ''
+    showCreateForm.value = false
+    await loadAll()
+    // Drop the user into the new program's detail in edit mode to keep filling it in
+    // (matches Risks/Objectives). The route watcher early-returns on the same id, so
+    // the edit state set here survives the navigation.
+    if (created && created.id) {
+      let fresh = created
+      try { fresh = await api.getProgram(created.id) } catch { /* fall back */ }
+      selected.value = fresh
+      detailTab.value = 'overview'
+      startEdit()
+      router.push(orgPath(`/programs/${created.id}`))
+    }
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function deleteSelected() {
+  if (!selected.value) return
+  if (!await confirmAsk(`Delete program "${selected.value.key}"? All objectives under it will also be deleted.`, { confirm: 'Delete', variant: 'danger' })) return
+  try {
+    await api.deleteProgram(selected.value.id)
+    closeDetail()
+    await loadAll()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+onMounted(async () => {
+  try { const me = await api.getMe(); userRole.value = me?.role || '' } catch {}
+  await loadAll()
+  if (route.params.id) await openFromRoute(route.params.id)
+})
+
+watch(() => route.params.id, (id) => {
+  if (!id) { selected.value = null; editing.value = false; return }
+  if (selected.value?.id === parseInt(id)) return
+  openFromRoute(id)
+})
+</script>

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -351,10 +351,13 @@ function closeDetail() {
 }
 
 async function openFromRoute(id) {
+  // id may be a numeric program id (register list links) or a program key like
+  // "AWARE" (cross-entity reference chips link by key). Match either, and pass the
+  // raw value to the API — the backend resolves id-or-key.
   const numId = parseInt(id)
-  let p = programs.value.find(x => x.id === numId)
+  let p = programs.value.find(x => x.id === numId || x.key === id)
   if (!p) {
-    try { p = await api.getProgram(numId) } catch { return }
+    try { p = await api.getProgram(id) } catch { return }
   }
   if (!p) return
   selected.value = p

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -140,11 +140,7 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-sm font-medium text-slate-200">{{ task.title }}</span>
-                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                  :class="statusClass(task.status)">
-                  <span class="w-1.5 h-1.5 rounded-full" :class="statusDot(task.status)"></span>
-                  {{ task.status.replace(/_/g, ' ') }}
-                </span>
+                <StatusBadge :status="task.status" />
                 <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(task.priority)">{{ task.priority }}</span>
                 <span v-if="task.task_type && task.task_type !== 'general'" class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ task.task_type.replace(/_/g, ' ') }}</span>
               </div>
@@ -529,25 +525,6 @@ function priorityClass(p) {
     case 'high': return 'bg-amber-500/15 text-amber-400'
     case 'medium': return 'bg-blue-500/15 text-blue-400'
     default: return 'bg-slate-500/15 text-slate-400'
-  }
-}
-
-function statusClass(s) {
-  switch (s) {
-    case 'open': return 'bg-blue-500/15 text-blue-400'
-    case 'in_progress': return 'bg-amber-500/15 text-amber-400'
-    case 'done': return 'bg-emerald-500/15 text-emerald-400'
-    case 'cancelled': return 'bg-slate-500/15 text-slate-400'
-    default: return 'bg-slate-500/15 text-slate-400'
-  }
-}
-
-function statusDot(s) {
-  switch (s) {
-    case 'open': return 'bg-blue-400'
-    case 'in_progress': return 'bg-amber-400'
-    case 'done': return 'bg-emerald-400'
-    default: return 'bg-slate-400'
   }
 }
 


### PR DESCRIPTION
Closes #127.

## Programs -> its own register
Programs lived as a tab inside `Objectives.vue` - no left-nav entry, no route, a bare table with inline Edit/Delete. Now:
- **New `Programs.vue`** - register header + Add + SuggestNewButton, search, standard table, detail slide-over (overview/notes/links/suggestions/comments/history + delete), create modal. Modeled on `Suppliers.vue`.
- **Routes** `/programs` + `/programs/:id`; **sidebar** entry; e2e smoke.
- **Objectives.vue** de-tabbed into a single clean register (Add in header, deep-link `/objectives/:objId`).
- Reuses existing `api.js` program CRUD; references key on the program `key`.

## Repo-wide status-badge consistency
A consistency audit found five views rendering status with local `statusClass` maps that drifted from the shared `<StatusBadge>` in their own detail panels - worst: **Incidents showed `open` red in the list but blue in the detail** (same status, two colours, one screen).
- `<StatusBadge>` is now the single source of truth: Incidents, Corrective Actions, Objectives, Tasks, Changes list rows all use it.
- Added the two missing cases (`todo`, `cancelled`) so nothing greys out.
- Removed the dead local `statusClass`/`statusDot` functions; completed the App.vue nav list.
- **Table-vs-card layouts are intentional** (registers vs operations modules) and left unchanged.

## Verify
`just build-web` green across all touched views; Programs chunk emitted; no dangling status refs. e2e runs in CI.