### PR TITLE
chore(devenv): just test-setup + mount isms-python in dev container

### DIFF
--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -92,6 +92,22 @@ run +CMD:
 
 # ── Test environment ─────────────────────────────────────────────────────────
 
+# (Re)create the Python test venv from tests/requirements.txt — the same thing CI
+# does, so the .venv can't silently go stale (a hand-made, never-upgraded .venv is
+# what broke local e2e: it held an old playwright wanting a Chromium build the image
+# never had). `-U` pulls the current playwright, whose Chromium build matches the one
+# baked into the image (devenv/Dockerfile bakes it via the same-minor @playwright/test).
+#
+# If playwright ever ships a NEW minor before the image is rebuilt, its Chromium won't
+# be in the image yet — then fetch the exact matching build once, as root:
+#   just attach-root
+#   PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright /home/isms/workspace/isms/.venv/bin/playwright install --with-deps chromium && chmod -R a+rX /opt/ms-playwright
+# (No version is hard-coded anywhere — the browser is always whatever the venv's own
+# playwright asks for.)
+test-setup:
+    {{compose}} exec -u isms isms bash -lc \
+        "cd /home/isms/workspace/isms && python3 -m venv .venv && .venv/bin/pip install --quiet -U -r tests/requirements.txt && .venv/bin/playwright --version"
+
 # Run pytest from inside the dev container against the test server.
 # Rebuilds web/dist first: isms-test serves the bundle live from disk, so an
 # e2e test would otherwise silently run against a stale UI after a .vue change

--- a/devenv/Justfile
+++ b/devenv/Justfile
@@ -24,10 +24,12 @@ compose := env_var_or_default('COMPOSE_CMD', 'docker compose')
 # ── Lifecycle ────────────────────────────────────────────────────────────────
 
 # Ensure optional bind-mount sources exist (compose errors if they don't).
-# isms-demo is private prospect content — contributors without it get an
-# empty dir so the mount resolves and the container can still boot.
+# isms-demo is private prospect content; isms-python is the sibling client repo.
+# Contributors without either get an empty dir so the mount resolves and the
+# container can still boot.
 _ensure-paths:
     @mkdir -p "$ISMS_SRC_ROOT/isms-demo"
+    @mkdir -p "$ISMS_SRC_ROOT/isms-python"
 
 # Build the shared image
 build: _ensure-paths
@@ -106,7 +108,7 @@ run +CMD:
 # playwright asks for.)
 test-setup:
     {{compose}} exec -u isms isms bash -lc \
-        "cd /home/isms/workspace/isms && python3 -m venv .venv && .venv/bin/pip install --quiet -U -r tests/requirements.txt && .venv/bin/playwright --version"
+        "cd /home/isms/workspace/isms && python3 -m venv --clear .venv && .venv/bin/pip install --quiet -U -r tests/requirements.txt && .venv/bin/playwright --version"
 
 # Run pytest from inside the dev container against the test server.
 # Rebuilds web/dist first: isms-test serves the bundle live from disk, so an

--- a/devenv/compose.yml
+++ b/devenv/compose.yml
@@ -39,6 +39,7 @@ services:
       - "${ISMS_BIND_ADDRESS:-127.0.0.1}:9090:9090"
     volumes:
       - ${ISMS_SRC_ROOT}/isms:/home/isms/workspace/isms
+      - ${ISMS_SRC_ROOT}/isms-python:/home/isms/workspace/isms-python
       - ${ISMS_SRC_ROOT}/isms-templates:/home/isms/workspace/isms-templates
       # isms-demo is private prospect content. Contributors without it cloned
       # get an empty directory (created by `just up`/`just build`) so the mount


### PR DESCRIPTION
Two small devenv changes that were sitting outstanding.

- **`just test-setup`** — reproducibly (re)creates the Python test venv from `tests/requirements.txt`, exactly like CI does. A hand-made, never-upgraded `.venv` (old playwright wanting a Chromium build the image never had) is what broke local e2e; this is the missing "recreate it fresh" step. Nothing is version-pinned — the browser is always whatever the venv's own playwright resolves, which matches the image's baked build.
- **compose.yml** — mount `${ISMS_SRC_ROOT}/isms-python` into `isms-dev` so cross-repo work on the Python client is available in the container (same pattern as the isms / isms-templates mounts).

No app code touched.