### PR TITLE
fix: collapse oversized gap in loose markdown lists

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -78,6 +78,13 @@
 .doc-prose ol > li {
   list-style-type: decimal;
 }
+/* Loose markdown lists (a blank line between items) make marked wrap each item
+   in a <p>, which would otherwise stack the 1rem paragraph margin on top of the
+   list-item spacing — a big gap between bullets. Collapse it so loose and tight
+   lists share the same rhythm. */
+.doc-prose li > p {
+  margin: 0;
+}
 .doc-prose code {
   color: rgb(147 197 253);
   background: rgb(30 41 59);


### PR DESCRIPTION
Closes #154.

Loose markdown lists (a blank line between items) rendered with a big gap between bullets — `marked` wraps each item in a `<p>`, which stacked `.doc-prose p`'s 1rem margin on top of the list-item spacing (~22px between bullets). Live example: TASK-2's SW-CORE list.

One rule in `src/style.css`, everywhere doc-prose is used:
```css
.doc-prose li > p { margin: 0; }
```
Loose lists now match the tidy ~6px rhythm of tight lists. `just build-web` green.