### PR TITLE
feat(ui): slim click-to-filter stat strip on Tasks (reference)

### DIFF
--- a/web/src/components/StatStrip.vue
+++ b/web/src/components/StatStrip.vue
@@ -1,0 +1,31 @@
+<template>
+  <!-- Slim, always-visible register stat strip. Each stat is click-to-filter:
+       clicking toggles the active key via v-model. Replaces the tall stat-card
+       grids at the top of the registers so the list gets the vertical space,
+       while counts + filtering stay glanceable. -->
+  <div class="flex flex-wrap gap-2">
+    <button
+      v-for="s in stats"
+      :key="s.key"
+      type="button"
+      @click="$emit('update:modelValue', modelValue === s.key ? '' : s.key)"
+      class="inline-flex items-baseline gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors"
+      :class="modelValue === s.key
+        ? 'border-blue-500/50 bg-blue-500/10 text-blue-200'
+        : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-300'"
+      :title="`Filter: ${s.label}`">
+      <span class="font-bold tabular-nums" :class="modelValue === s.key ? '' : (s.color || 'text-slate-100')">{{ s.count }}</span>
+      <span>{{ s.label }}</span>
+    </button>
+  </div>
+</template>
+
+<script setup>
+// stats: [{ key, label, count, color }] — color is a text-* class for the count.
+// key '' means "all / clear filter". modelValue is the active filter key.
+defineProps({
+  stats: { type: Array, required: true },
+  modelValue: { type: String, default: '' },
+})
+defineEmits(['update:modelValue'])
+</script>

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -68,17 +68,8 @@
       </Transition>
       </Teleport>
 
-      <!-- Summary stats -->
-      <!-- Note: 'overdue' tile uses stats.overdue if backend provides it; otherwise 0. -->
-      <div class="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
-        <button v-for="s in statusStats" :key="s.key"
-          @click="filterStatus = filterStatus === s.key ? '' : s.key"
-          class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors"
-          :class="filterStatus === s.key ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold tabular-nums" :class="s.color">{{ s.count }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ s.label }}</div>
-        </button>
-      </div>
+      <!-- Summary stats — slim, always-visible, click to filter -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" class="mb-4" />
 
       <!-- Search + filters -->
       <div class="flex items-center gap-3 mb-4 flex-wrap">
@@ -399,6 +390,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'


### PR DESCRIPTION
Part of #156 — Tasks first, as the reference.

The tall stat-card grid at the top of the registers pushes the list down. This swaps it for a slim, always-visible **StatStrip**: chips (count + label), each click-to-filter, active chip highlighted. Counts + filtering stay glanceable (no discoverability loss) but take a fraction of the height — the list gets ~3× more rows above the fold.

- New shared `components/StatStrip.vue` (`:stats` + `v-model` for the active filter key) — reused by the other registers next.
- Tasks: the 5-card grid → `<StatStrip :stats="statusStats" v-model="filterStatus" />`. Same data, same click-to-filter behaviour.

Design approved from a before/after mock. `just build-web` green. Follow-up PRs roll this out to Risks/Suppliers/Assets/Legal/Systems/Incidents/CAs/Changes/Objectives/Programs (Risk heat-map stays in its collapsible "More").