### PR TITLE
feat(ui): roll slim click-to-filter stat strip out to all registers

### DIFF
--- a/web/src/components/StatStrip.vue
+++ b/web/src/components/StatStrip.vue
@@ -2,26 +2,38 @@
   <!-- Slim, always-visible register stat strip. Each stat is click-to-filter:
        clicking toggles the active key via v-model. Replaces the tall stat-card
        grids at the top of the registers so the list gets the vertical space,
-       while counts + filtering stay glanceable. -->
+       while counts + filtering stay glanceable.
+
+       A stat with `static: true` renders as a display-only chip (no click) — for
+       derived metrics that aren't a filter dimension (e.g. Critical / Severe). -->
   <div class="flex flex-wrap gap-2">
-    <button
-      v-for="s in stats"
-      :key="s.key"
-      type="button"
-      @click="$emit('update:modelValue', modelValue === s.key ? '' : s.key)"
-      class="inline-flex items-baseline gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors"
-      :class="modelValue === s.key
-        ? 'border-blue-500/50 bg-blue-500/10 text-blue-200'
-        : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-300'"
-      :title="`Filter: ${s.label}`">
-      <span class="font-bold tabular-nums" :class="modelValue === s.key ? '' : (s.color || 'text-slate-100')">{{ s.count }}</span>
-      <span>{{ s.label }}</span>
-    </button>
+    <template v-for="s in stats" :key="s.key">
+      <button
+        v-if="!s.static"
+        type="button"
+        @click="$emit('update:modelValue', modelValue === s.key ? '' : s.key)"
+        class="inline-flex items-baseline gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors"
+        :class="modelValue === s.key
+          ? 'border-blue-500/50 bg-blue-500/10 text-blue-200'
+          : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-300'"
+        :title="`Filter: ${s.label}`">
+        <span class="font-bold tabular-nums" :class="modelValue === s.key ? '' : (s.color || 'text-slate-100')">{{ s.count }}</span>
+        <span>{{ s.label }}</span>
+      </button>
+      <span
+        v-else
+        class="inline-flex items-baseline gap-1.5 rounded-full border border-slate-800/60 bg-slate-900/50 px-3 py-1 text-xs text-slate-500"
+        :title="s.label">
+        <span class="font-bold tabular-nums" :class="s.color || 'text-slate-100'">{{ s.count }}</span>
+        <span>{{ s.label }}</span>
+      </span>
+    </template>
   </div>
 </template>
 
 <script setup>
-// stats: [{ key, label, count, color }] — color is a text-* class for the count.
+// stats: [{ key, label, count, color, static }] — color is a text-* class for
+// the count; static:true makes a non-clickable display-only chip.
 // key '' means "all / clear filter". modelValue is the active filter key.
 defineProps({
   stats: { type: Array, required: true },

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -74,29 +74,8 @@
       </Transition>
       </Teleport>
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ stats.total }}</div>
-          <div class="text-xs text-slate-500 mt-1">Total</div>
-        </button>
-        <button @click="filterStatus = 'draft'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'draft' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.draft || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Draft</div>
-        </button>
-        <button @click="filterStatus = 'open'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'open' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ stats.open }}</div>
-          <div class="text-xs text-slate-500 mt-1">Open</div>
-        </button>
-        <button @click="filterStatus = 'archived'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'archived' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-400 tabular-nums">{{ stats.archived }}</div>
-          <div class="text-xs text-slate-500 mt-1">Archived</div>
-        </button>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="stats.critical > 0 ? 'text-red-400' : 'text-slate-100'">{{ stats.critical }}</div>
-          <div class="text-xs text-slate-500 mt-1">Severe (CIA = 5)</div>
-        </div>
-      </div>
+      <!-- Summary strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" />
 
       <!-- Search + Filters -->
       <div class="space-y-3">
@@ -422,6 +401,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -457,6 +437,13 @@ const assets = ref([])
 const orgMembers = ref([])
 const saving = ref(false)
 const stats = ref({ total: 0, draft: 0, open: 0, archived: 0, critical: 0 })
+const statusStats = computed(() => [
+  { key: '', label: 'Total', count: stats.value.total, color: 'text-slate-100' },
+  { key: 'draft', label: 'Draft', count: stats.value.draft || 0, color: 'text-amber-400' },
+  { key: 'open', label: 'Open', count: stats.value.open, color: 'text-blue-400' },
+  { key: 'archived', label: 'Archived', count: stats.value.archived, color: 'text-slate-400' },
+  { key: 'critical', label: 'Severe (CIA = 5)', count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+])
 
 const selectedItem = ref(null)
 const detailTab = ref('overview')

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -72,16 +72,8 @@
       </Transition>
       </Teleport>
 
-      <!-- Summary stats -->
-      <div class="grid grid-cols-2 lg:grid-cols-6 gap-4 mb-6">
-        <button v-for="s in statusStats" :key="s.key"
-          @click="filterStatus = filterStatus === s.key ? '' : s.key"
-          class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors"
-          :class="filterStatus === s.key ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold tabular-nums" :class="s.color">{{ s.count }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ s.label }}</div>
-        </button>
-      </div>
+      <!-- Summary strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" class="mb-6" />
 
       <!-- Search + filters -->
       <div class="flex items-center gap-3 mb-4 flex-wrap">
@@ -413,6 +405,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -30,33 +30,8 @@
         </div>
       </div>
 
-      <!-- Stats cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-6 gap-4">
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-red-400 tabular-nums">{{ stats.todo || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Todo</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.assessment || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Assessment</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-purple-400 tabular-nums">{{ stats.awaiting_approval || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Awaiting Approval</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ stats.implementation || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Implementation</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-cyan-400 tabular-nums">{{ stats.monitoring || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Monitoring</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ stats.resolved || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Resolved</div>
-        </div>
-      </div>
+      <!-- Stats strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" />
 
       <!-- Actions bar -->
       <div class="flex items-center gap-3 flex-wrap">
@@ -426,6 +401,7 @@ import api from '../api'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import EntityReferences from '../components/EntityReferences.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
@@ -459,6 +435,14 @@ const loading = ref(true)
 const error = ref(null)
 const actions = ref([])
 const stats = ref({})
+const statusStats = computed(() => [
+  { key: 'todo', label: 'Todo', count: stats.value.todo || 0, color: 'text-red-400' },
+  { key: 'assessment', label: 'Assessment', count: stats.value.assessment || 0, color: 'text-amber-400' },
+  { key: 'awaiting_approval', label: 'Awaiting Approval', count: stats.value.awaiting_approval || 0, color: 'text-purple-400' },
+  { key: 'implementation', label: 'Implementation', count: stats.value.implementation || 0, color: 'text-blue-400' },
+  { key: 'monitoring', label: 'Monitoring', count: stats.value.monitoring || 0, color: 'text-cyan-400' },
+  { key: 'resolved', label: 'Resolved', count: stats.value.resolved || 0, color: 'text-emerald-400' },
+])
 const selectedCA = ref(null)
 const showCreateForm = ref(false)
 

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -30,33 +30,8 @@
         </div>
       </div>
 
-      <!-- Stats cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-6 gap-4">
-        <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ stats.total || total || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Total</div>
-        </button>
-        <button @click="filterStatus = 'open'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'open' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-red-400 tabular-nums">{{ stats.open || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Open</div>
-        </button>
-        <button @click="filterStatus = 'investigating'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'investigating' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.investigating || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Investigating</div>
-        </button>
-        <button @click="filterStatus = 'contained'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'contained' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ stats.contained || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Contained</div>
-        </button>
-        <button @click="filterStatus = 'resolved'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'resolved' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ stats.resolved || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Resolved</div>
-        </button>
-        <button @click="filterStatus = 'closed'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'closed' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-400 tabular-nums">{{ stats.closed || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Closed</div>
-        </button>
-      </div>
+      <!-- Stats strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" />
 
       <!-- Actions bar -->
       <div class="flex items-center gap-3 flex-wrap">
@@ -543,6 +518,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import api from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -576,6 +552,14 @@ const loading = ref(true)
 const error = ref(null)
 const incidents = ref([])
 const stats = ref({})
+const statusStats = computed(() => [
+  { key: '', label: 'Total', count: stats.value.total || total.value || 0, color: 'text-slate-100' },
+  { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-red-400' },
+  { key: 'investigating', label: 'Investigating', count: stats.value.investigating || 0, color: 'text-amber-400' },
+  { key: 'contained', label: 'Contained', count: stats.value.contained || 0, color: 'text-blue-400' },
+  { key: 'resolved', label: 'Resolved', count: stats.value.resolved || 0, color: 'text-emerald-400' },
+  { key: 'closed', label: 'Closed', count: stats.value.closed || 0, color: 'text-slate-400' },
+])
 const selectedIncident = ref(null)
 const showCreateForm = ref(false)
 const filterStatus = ref('')

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -76,33 +76,8 @@
       </Transition>
       </Teleport>
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-6 gap-4">
-        <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ stats.total || items.length }}</div>
-          <div class="text-xs text-slate-500 mt-1">Total</div>
-        </button>
-        <button @click="filterStatus = 'open'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'open' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ stats.open || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Open</div>
-        </button>
-        <button @click="filterStatus = 'draft'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'draft' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.draft || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Draft</div>
-        </button>
-        <button @click="filterStatus = 'closed'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'closed' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-400 tabular-nums">{{ stats.closed || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Closed</div>
-        </button>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="criticalCount > 0 ? 'text-red-400' : 'text-slate-100'">{{ criticalCount }}</div>
-          <div class="text-xs text-slate-500 mt-1">Critical</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="highCount > 0 ? 'text-orange-400' : 'text-slate-100'">{{ highCount }}</div>
-          <div class="text-xs text-slate-500 mt-1">High</div>
-        </div>
-      </div>
+      <!-- Summary strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" />
 
       <!-- Risk Map (collapsible) -->
       <details class="group">
@@ -506,6 +481,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import HeatMap from '../components/HeatMap.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -600,6 +576,14 @@ useModalEscape(computed(() => !!selectedItem.value), closeDetail)
 const stats = ref({ total: 0, critical: 0, high: 0, medium: 0, low: 0, not_assessed: 0, open: 0, closed: 0, draft: 0 })
 const criticalCount = computed(() => stats.value.critical)
 const highCount = computed(() => stats.value.high)
+const statusStats = computed(() => [
+  { key: '', label: 'Total', count: stats.value.total || items.value.length, color: 'text-slate-100' },
+  { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-blue-400' },
+  { key: 'draft', label: 'Draft', count: stats.value.draft || 0, color: 'text-amber-400' },
+  { key: 'closed', label: 'Closed', count: stats.value.closed || 0, color: 'text-slate-400' },
+  { key: 'critical', label: 'Critical', count: criticalCount.value, color: criticalCount.value > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: 'high', label: 'High', count: highCount.value, color: highCount.value > 0 ? 'text-orange-400' : 'text-slate-100', static: true },
+])
 const notAssessedCount = computed(() => stats.value.not_assessed)
 
 const heatMapItems = computed(() => items.value.filter(i => i.current_likelihood > 0 && i.current_impact > 0))

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -32,29 +32,8 @@
 
       <!-- Objectives -->
       <div class="space-y-6">
-        <!-- Stats cards -->
-        <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
-          <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
-            <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ stats.total || 0 }}</div>
-            <div class="text-xs text-slate-500 mt-1">Total</div>
-          </button>
-          <button @click="filterStatus = 'active'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'active' ? 'ring-1 ring-blue-500/40' : ''">
-            <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ stats.active || 0 }}</div>
-            <div class="text-xs text-slate-500 mt-1">Active</div>
-          </button>
-          <button @click="filterStatus = 'at_risk'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'at_risk' ? 'ring-1 ring-blue-500/40' : ''">
-            <div class="text-2xl font-bold text-red-400 tabular-nums">{{ stats.at_risk || 0 }}</div>
-            <div class="text-xs text-slate-500 mt-1">At Risk</div>
-          </button>
-          <button @click="filterStatus = 'paused'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'paused' ? 'ring-1 ring-blue-500/40' : ''">
-            <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.paused || 0 }}</div>
-            <div class="text-xs text-slate-500 mt-1">Paused</div>
-          </button>
-          <button @click="filterStatus = 'complete'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'complete' ? 'ring-1 ring-blue-500/40' : ''">
-            <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ stats.complete || 0 }}</div>
-            <div class="text-xs text-slate-500 mt-1">Complete</div>
-          </button>
-        </div>
+        <!-- Stats strip -->
+        <StatStrip :stats="statusStats" v-model="filterStatus" />
 
         <!-- Filters + Create -->
         <div class="flex items-center gap-3 flex-wrap">
@@ -513,6 +492,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api, getCurrentUser } from '../api'
 import { renderMarkdown } from '../composables/useRenderMd.js'
 import MemberPicker from '../components/MemberPicker.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
@@ -577,6 +557,13 @@ const page = ref(1)
 const pageSize = ref(50)
 const total = ref(0)
 const stats = ref({ total: 0, draft: 0, active: 0, at_risk: 0, paused: 0, complete: 0, archived: 0 })
+const statusStats = computed(() => [
+  { key: '', label: 'Total', count: stats.value.total || 0, color: 'text-slate-100' },
+  { key: 'active', label: 'Active', count: stats.value.active || 0, color: 'text-emerald-400' },
+  { key: 'at_risk', label: 'At Risk', count: stats.value.at_risk || 0, color: 'text-red-400' },
+  { key: 'paused', label: 'Paused', count: stats.value.paused || 0, color: 'text-amber-400' },
+  { key: 'complete', label: 'Complete', count: stats.value.complete || 0, color: 'text-blue-400' },
+])
 const orgMembers = ref([])
 
 const newObjective = reactive({

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -79,25 +79,8 @@
       </Teleport>
 
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ risks.length }}</div>
-          <div class="text-xs text-slate-500 mt-1">Total Risks</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="criticalCount > 0 ? 'text-red-400' : 'text-slate-100'">{{ criticalCount }}</div>
-          <div class="text-xs text-slate-500 mt-1">Critical</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="highCount > 0 ? 'text-orange-400' : 'text-slate-100'">{{ highCount }}</div>
-          <div class="text-xs text-slate-500 mt-1">High</div>
-        </div>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ treatedCount }}</div>
-          <div class="text-xs text-slate-500 mt-1">Closed</div>
-        </div>
-      </div>
+      <!-- Summary strip (display-only) -->
+      <StatStrip :stats="summaryStats" />
 
       <!-- Heat Map (collapsible) -->
       <details class="group">
@@ -722,6 +705,7 @@ import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import HeatMap from '../components/HeatMap.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -907,6 +891,15 @@ const stats = ref({ total: 0, critical: 0, high: 0, medium: 0, low: 0, open: 0, 
 const criticalCount = computed(() => stats.value.critical)
 const highCount = computed(() => stats.value.high)
 const treatedCount = computed(() => stats.value.closed)
+// Risk summary chips are display-only (derived metrics across different filter
+// dimensions), so they render as static StatStrip chips — the tall stat-card
+// grid was reclaimed for the list; the Risk Map stays in its collapsible "More".
+const summaryStats = computed(() => [
+  { key: 'total', label: 'Total Risks', count: risks.value.length, color: 'text-slate-100', static: true },
+  { key: 'critical', label: 'Critical', count: criticalCount.value, color: criticalCount.value > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: 'high', label: 'High', count: highCount.value, color: highCount.value > 0 ? 'text-orange-400' : 'text-slate-100', static: true },
+  { key: 'closed', label: 'Closed', count: treatedCount.value, color: 'text-emerald-400', static: true },
+])
 
 // Refetch on filter/search/page change
 let searchTimer = null

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -84,29 +84,8 @@
       </Transition>
       </Teleport>
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ stats.total }}</div>
-          <div class="text-xs text-slate-500 mt-1">Total</div>
-        </button>
-        <button @click="filterStatus = 'active'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'active' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ stats.active }}</div>
-          <div class="text-xs text-slate-500 mt-1">Active</div>
-        </button>
-        <button @click="filterStatus = 'under_review'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'under_review' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.under_review }}</div>
-          <div class="text-xs text-slate-500 mt-1">Under Review</div>
-        </button>
-        <button @click="filterStatus = 'suspended'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'suspended' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-orange-400 tabular-nums">{{ stats.suspended || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Suspended</div>
-        </button>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="stats.critical > 0 ? 'text-red-400' : 'text-slate-100'">{{ stats.critical }}</div>
-          <div class="text-xs text-slate-500 mt-1">Critical</div>
-        </div>
-      </div>
+      <!-- Summary strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" />
 
       <!-- Search + Filters -->
       <div class="space-y-3">
@@ -483,6 +462,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -519,6 +499,13 @@ const suppliers = ref([])
 const orgMembers = ref([])
 const saving = ref(false)
 const stats = ref({ total: 0, active: 0, under_review: 0, suspended: 0, terminated: 0, critical: 0, high: 0, medium: 0, low: 0 })
+const statusStats = computed(() => [
+  { key: '', label: 'Total', count: stats.value.total, color: 'text-slate-100' },
+  { key: 'active', label: 'Active', count: stats.value.active, color: 'text-emerald-400' },
+  { key: 'under_review', label: 'Under Review', count: stats.value.under_review, color: 'text-amber-400' },
+  { key: 'suspended', label: 'Suspended', count: stats.value.suspended || 0, color: 'text-orange-400' },
+  { key: 'critical', label: 'Critical', count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+])
 
 const selectedItem = ref(null)
 const detailTab = ref('overview')

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -91,29 +91,8 @@
       </Transition>
       </Teleport>
 
-      <!-- Summary cards -->
-      <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <button @click="filterStatus = ''" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="!filterStatus ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-100 tabular-nums">{{ stats.total }}</div>
-          <div class="text-xs text-slate-500 mt-1">Total</div>
-        </button>
-        <button @click="filterStatus = 'active'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'active' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ stats.active }}</div>
-          <div class="text-xs text-slate-500 mt-1">Active</div>
-        </button>
-        <button @click="filterStatus = 'under_review'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'under_review' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ stats.under_review }}</div>
-          <div class="text-xs text-slate-500 mt-1">Under Review</div>
-        </button>
-        <button @click="filterStatus = 'decommissioned'" class="bg-slate-900 border border-slate-800 rounded-xl p-4 text-left hover:border-slate-700 transition-colors" :class="filterStatus === 'decommissioned' ? 'ring-1 ring-blue-500/40' : ''">
-          <div class="text-2xl font-bold text-slate-400 tabular-nums">{{ stats.decommissioned || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Decommissioned</div>
-        </button>
-        <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-          <div class="text-2xl font-bold tabular-nums" :class="stats.critical > 0 ? 'text-red-400' : 'text-slate-100'">{{ stats.critical }}</div>
-          <div class="text-xs text-slate-500 mt-1">Critical</div>
-        </div>
-      </div>
+      <!-- Summary strip -->
+      <StatStrip :stats="statusStats" v-model="filterStatus" />
 
       <!-- Search + Filters -->
       <div class="space-y-3">
@@ -530,6 +509,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import StatStrip from '../components/StatStrip.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -566,6 +546,13 @@ const suppliers = ref([])
 const orgMembers = ref([])
 const saving = ref(false)
 const stats = ref({ total: 0, active: 0, under_review: 0, decommissioned: 0, critical: 0, high: 0, medium: 0, low: 0 })
+const statusStats = computed(() => [
+  { key: '', label: 'Total', count: stats.value.total, color: 'text-slate-100' },
+  { key: 'active', label: 'Active', count: stats.value.active, color: 'text-emerald-400' },
+  { key: 'under_review', label: 'Under Review', count: stats.value.under_review, color: 'text-amber-400' },
+  { key: 'decommissioned', label: 'Decommissioned', count: stats.value.decommissioned || 0, color: 'text-slate-400' },
+  { key: 'critical', label: 'Critical', count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+])
 
 const selectedItem = ref(null)
 const detailTab = ref('overview')


### PR DESCRIPTION
Rolls the slim, always-visible **StatStrip** (introduced for Tasks in #157) out to the remaining registers, closing #156.

Each register opened with a grid of big stat cards that pushed the list well below the fold. This swaps them for the shared chip strip: count + label, click-to-filter, active chip highlighted — same data, same filtering, a fraction of the height.

**Converted:** Suppliers, Assets, Legal, Systems, Incidents, Corrective Actions, Objectives, Changes, Risks.

**Notes**
- `StatStrip` gains an optional per-chip `static` flag — display-only chips for derived metrics that aren't a filter dimension (Critical / Severe / High).
- **Risks:** the four summary chips span different filter dimensions (level vs status), so they're display-only; the Risk Map stays in its collapsible "More".
- **Corrective Actions:** its summary cards were plain (non-clickable) before — they're now click-to-filter, consistent with the rest.
- **Audit** is intentionally left out: it has two stat sections plus a boolean "overdue" toggle mixed into the chips, which doesn't fit the single-`v-model` strip. Can follow up separately if wanted.

`just build-web` green. No API/logic changes beyond wiring the existing filter refs to the strip.