### PR TITLE
fix(db): allow supplier CIA readings (#161) + migration-name guardrail

### DIFF
--- a/migrations/20260713000000_v0.7.1.sql
+++ b/migrations/20260713000000_v0.7.1.sql
@@ -1,0 +1,13 @@
+-- 0.7.1 release migration. One migration file per release (see v0.7.0.sql).
+-- All schema changes shipping in 0.7.1 accumulate here until it releases.
+--
+-- #161: saving a CIA reading for a Supplier failed with
+--   entity_readings_entity_type_check violated (SQLSTATE 23514)
+-- The supplier reading path (POST /suppliers/:id/readings -> entity_type
+-- 'supplier') shipped, but entity_readings' entity_type CHECK never listed
+-- 'supplier' — even though the status CHECK on the same table already carries
+-- supplier statuses. This widens it (full set kept explicit).
+-- DROP IF EXISTS + re-ADD is safe on fresh DBs too; all existing rows satisfy it.
+ALTER TABLE entity_readings DROP CONSTRAINT IF EXISTS entity_readings_entity_type_check;
+ALTER TABLE entity_readings ADD CONSTRAINT entity_readings_entity_type_check
+    CHECK (entity_type IN ('risk', 'legal_requirement', 'asset', 'system', 'supplier'));

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,38 @@
+"""Migration hygiene — fail `just test` / CI on a badly-named migration.
+
+Convention: ONE migration file per release, named after the version —
+<14-digit-timestamp>_vX.Y.Z.sql (see migrations/v0.7.0.sql). The runner records
+applied migrations by FILENAME (schema_migrations.version), so a shipped file can
+never be renamed or amended without re-running or silently skipping it on live
+DBs. Version-pinned names keep migration history 1:1 with releases and stop
+descriptive one-off files from scattering it.
+
+This is a pure filesystem check — no server/fixtures — so it runs (and fails)
+in `just test` locally and in the CI pytest suite.
+"""
+import re
+from pathlib import Path
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
+
+# <14-digit timestamp>_vX.Y.Z.sql
+VERSION_NAME = re.compile(r"^\d{14}_v\d+\.\d+\.\d+\.sql$")
+
+# Grandfathered: these shipped before the rule and their names are already locked
+# into schema_migrations on live DBs (renaming would re-run or skip them). FROZEN
+# — do NOT extend this set; every new migration must be <timestamp>_vX.Y.Z.sql.
+GRANDFATHERED = {
+    "20260327000000_initial_schema.sql",
+    "20260707120000_change_type_check.sql",
+}
+
+
+def test_migration_files_named_after_version():
+    files = sorted(p.name for p in MIGRATIONS_DIR.glob("*.sql"))
+    assert files, f"no migrations found in {MIGRATIONS_DIR}"
+    offenders = [f for f in files if f not in GRANDFATHERED and not VERSION_NAME.match(f)]
+    assert not offenders, (
+        "migration file(s) must be named <timestamp>_vX.Y.Z.sql — one migration "
+        "per release, named after the version (e.g. 20260713000000_v0.7.1.sql). "
+        "Offending: " + ", ".join(offenders)
+    )

--- a/tests/test_readings.py
+++ b/tests/test_readings.py
@@ -239,6 +239,76 @@ class TestSupplierReview:
         assert sup.get("last_review"), "last_review should be set after review"
 
 
+class TestSupplierReadings:
+    """Supplier CIA reading lifecycle — regression for #161.
+
+    The supplier reading path shipped but entity_readings' entity_type CHECK
+    constraint never listed 'supplier', so POST /suppliers/:id/readings failed
+    with entity_readings_entity_type_check (SQLSTATE 23514). This is the exact
+    flow from the report: create supplier -> save CIA reading -> verify.
+    """
+
+    supplier_id = None
+    reading_id = None
+
+    def test_01_create_supplier(self, api_url, admin_headers):
+        r = requests.post(f"{api_url}/suppliers", headers=admin_headers, json={
+            "name": "Reading test - Managed Hosting Provider",
+            "supplier_type": "cloud",
+            "criticality": "high",
+        })
+        assert r.status_code in [200, 201], f"Create supplier failed: {r.text}"
+        TestSupplierReadings.supplier_id = r.json()["id"]
+
+    def test_02_submit_cia_reading(self, api_url, admin_headers):
+        """POST /suppliers/:id/readings with CIA values should return 201 (#161)."""
+        sid = TestSupplierReadings.supplier_id
+        r = requests.post(f"{api_url}/suppliers/{sid}/readings", headers=admin_headers, json={
+            "confidentiality": 4,
+            "integrity": 3,
+            "availability": 5,
+            "notes": "Initial supplier CIA assessment",
+        })
+        assert r.status_code in [200, 201], f"Submit supplier reading failed: {r.text}"
+        data = r.json()
+        assert data.get("id"), "Expected reading ID"
+        assert data["confidentiality"] == 4
+        assert data["integrity"] == 3
+        assert data["availability"] == 5
+        TestSupplierReadings.reading_id = data["id"]
+
+    def test_03_supplier_updated(self, api_url, admin_headers):
+        """Supplier CIA classification + last_review updated from the reading."""
+        sid = TestSupplierReadings.supplier_id
+        r = requests.get(f"{api_url}/suppliers/{sid}", headers=admin_headers)
+        assert r.status_code == 200, r.text
+        sup = r.json()
+        assert sup["confidentiality"] == 4
+        assert sup["integrity"] == 3
+        assert sup["availability"] == 5
+        assert sup.get("last_review"), "Expected last_review to be set after reading"
+
+    def test_04_list_readings(self, api_url, admin_headers):
+        sid = TestSupplierReadings.supplier_id
+        r = requests.get(f"{api_url}/suppliers/{sid}/readings", headers=admin_headers)
+        assert r.status_code == 200
+        data = r.json()
+        readings = data.get("data") if isinstance(data, dict) else data
+        assert isinstance(readings, list)
+        assert any(rd["id"] == TestSupplierReadings.reading_id for rd in readings)
+
+    def test_05_reader_cannot_submit(self, api_url, reader_headers):
+        """Reader role gets 403 when submitting a supplier reading."""
+        sid = TestSupplierReadings.supplier_id
+        r = requests.post(f"{api_url}/suppliers/{sid}/readings", headers=reader_headers, json={
+            "confidentiality": 1,
+            "integrity": 1,
+            "availability": 1,
+            "notes": "Should be rejected",
+        })
+        assert r.status_code == 403, f"Expected 403, got {r.status_code}: {r.text}"
+
+
 class TestReadingSuggestion:
     """Reading via suggestion workflow: suggest reading -> apply -> verify."""
 


### PR DESCRIPTION
Two related changes for 0.7.1 — closes #161 and #162.

### 1. Fix: supplier CIA readings (#161)
Saving a CIA reading for a Supplier failed with `entity_readings_entity_type_check` (SQLSTATE 23514). The supplier reading path shipped (`POST /suppliers/:id/readings` forces `entity_type = "supplier"` server-side), but the `entity_readings` `entity_type` CHECK only listed `risk`, `legal_requirement`, `asset`, `system`. The `status` CHECK on the same table already carried supplier statuses — the `entity_type` set was just never updated.

The **0.7.1 release migration** (`v0.7.1.sql` — one migration file per release) widens the constraint. A migration in a patch is the documented exception: a DB CHECK constraint has no non-schema fix. `DROP … IF EXISTS` + re-`ADD` is safe on fresh DBs too. Regression test `TestSupplierReadings` covers the exact reported flow (the gap that let it ship — we had supplier *review* tests, not supplier *reading* tests).

### 2. Guardrail: migration naming (#162)
So this can't recur: `tests/test_migrations.py` (pure filesystem, no fixtures) fails `just test` and CI on any migration not named `<timestamp>_vX.Y.Z.sql`. Grandfathers `initial_schema.sql` and `change_type_check.sql`.

`just build-go` green. No API/handler change — the write path was already correct.