### PR TITLE
feat(ui): refresh button on all list pages

### DIFF
--- a/web/src/components/RefreshButton.vue
+++ b/web/src/components/RefreshButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <!-- Reload the current page's list(s) without a full F5. Icon spins + button
+       disables while loading. Wire @refresh to the view's loader and :loading to
+       its loading ref. -->
+  <button
+    type="button"
+    :disabled="loading"
+    @click="$emit('refresh')"
+    class="inline-flex items-center justify-center rounded-lg border border-slate-800 bg-slate-900 p-1.5 text-slate-400 transition-colors hover:border-slate-700 hover:text-slate-200 disabled:opacity-60 disabled:cursor-not-allowed"
+    :title="loading ? 'Refreshing…' : 'Refresh'"
+    aria-label="Refresh">
+    <svg class="h-4 w-4" :class="{ 'animate-spin': loading }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+    </svg>
+  </button>
+</template>
+
+<script setup>
+defineProps({ loading: { type: Boolean, default: false } })
+defineEmits(['refresh'])
+</script>

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -437,8 +438,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await loadAssets()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -80,6 +80,7 @@
       <!-- Search + Filters -->
       <div class="space-y-3">
         <div class="flex flex-wrap items-center gap-3">
+          <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -402,6 +403,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -432,6 +434,15 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadAssets()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const assets = ref([])
 const orgMembers = ref([])

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        Failed to load audit module. {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>Failed to load audit module. {{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -1198,9 +1199,12 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await Promise.all([loadProgrammes(), loadAudits()])
     await refreshFindingCounts()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -22,6 +22,7 @@
           <p class="text-sm text-slate-500 mt-1">Audit programmes, schedule, and findings</p>
         </div>
         <div class="flex gap-2">
+          <RefreshButton :loading="refreshing" @refresh="reload" />
           <button v-if="canWrite && activeTab === 'programmes'"
             @click="openCreateProgramme"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
@@ -1133,6 +1134,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -1193,6 +1195,16 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await Promise.all([loadProgrammes(), loadAudits()])
+    await refreshFindingCounts()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const orgMembers = ref([])
 

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -77,6 +77,7 @@
 
       <!-- Search + filters -->
       <div class="flex items-center gap-3 mb-4 flex-wrap">
+        <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
         <div class="relative flex-1 max-w-xs">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -406,6 +407,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -432,6 +434,15 @@ const { success: showSaved, show: showError } = useToast()
 const renderMd = renderMarkdown
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadChanges()
+  } finally {
+    refreshing.value = false
+  }
+}
 const changes = ref([])
 const filterStatus = ref('')
 const filterPriority = ref('')

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -7,8 +7,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-6xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -437,8 +438,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
-    await loadAll()
+    await fetchAll()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }
@@ -572,12 +576,18 @@ async function loadAll() {
   loading.value = true
   error.value = null
   try {
-    await Promise.all([loadActions(), loadStats()])
+    await fetchAll()
   } catch (e) {
     error.value = e.message
   } finally {
     loading.value = false
   }
+}
+
+// Fetch body without the loading toggle, so reload() refreshes in place
+// (no full-list skeleton flicker) — see #165 review.
+async function fetchAll() {
+  await Promise.all([loadActions(), loadStats()])
 }
 
 async function loadActions() {

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -35,6 +35,7 @@
 
       <!-- Actions bar -->
       <div class="flex items-center gap-3 flex-wrap">
+        <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
         <div class="relative flex-1 max-w-xs">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -402,6 +403,7 @@ import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import EntityReferences from '../components/EntityReferences.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
@@ -432,6 +434,15 @@ const canWrite = computed(() => userRole.value === 'admin' || userRole.value ===
 const orgMembers = ref([])
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadAll()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const actions = ref([])
 const stats = ref({})

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -7,8 +7,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-4xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -737,6 +738,7 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await Promise.all([
       loadOpenComments(),
@@ -747,6 +749,8 @@ async function reload() {
       loadCAs(),
       loadSuggestions(),
     ])
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -20,10 +20,13 @@
           <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Inbox</h1>
           <p class="text-sm text-slate-500 mt-1">{{ totalActionItems }} action item{{ totalActionItems !== 1 ? 's' : '' }} requiring attention</p>
         </div>
-        <button @click="markAllNotificationsRead"
-          class="px-3 py-1.5 text-xs text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg border border-slate-800 transition-colors">
-          Mark all read
-        </button>
+        <div class="flex items-center gap-2">
+          <RefreshButton :loading="refreshing" @refresh="reload" />
+          <button @click="markAllNotificationsRead"
+            class="px-3 py-1.5 text-xs text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg border border-slate-800 transition-colors">
+            Mark all read
+          </button>
+        </div>
       </div>
 
       <!-- Tab bar -->
@@ -716,6 +719,7 @@ import { api, getCurrentUser } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import ListSkeleton from '../components/ListSkeleton.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import { useConfirm } from '../composables/useConfirm'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import { useToast } from '../composables/useToast.js'
@@ -730,6 +734,23 @@ const { success: showSaved, error: showError } = useToast()
 
 // ---------- State ----------
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await Promise.all([
+      loadOpenComments(),
+      loadReviews(),
+      loadTasks(),
+      loadChanges(),
+      loadIncidents(),
+      loadCAs(),
+      loadSuggestions(),
+    ])
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 
 const reviews = ref([])

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -7,8 +7,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -554,8 +555,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
-    await loadAll()
+    await fetchAll()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }
@@ -645,12 +649,18 @@ async function loadAll() {
   loading.value = true
   error.value = null
   try {
-    await Promise.all([loadIncidents(), loadStats()])
+    await fetchAll()
   } catch (e) {
     error.value = e.message
   } finally {
     loading.value = false
   }
+}
+
+// Fetch body without the loading toggle, so reload() refreshes in place
+// (no full-list skeleton flicker) — see #165 review.
+async function fetchAll() {
+  await Promise.all([loadIncidents(), loadStats()])
 }
 
 async function loadIncidents() {

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -35,6 +35,7 @@
 
       <!-- Actions bar -->
       <div class="flex items-center gap-3 flex-wrap">
+        <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
         <div class="relative flex-1 max-w-xs">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -519,6 +520,7 @@ import { useRoute, useRouter } from 'vue-router'
 import api from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -549,6 +551,15 @@ const canReport = computed(() => userRole.value === 'admin' || userRole.value ==
 
 const orgMembers = ref([])
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadAll()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const incidents = ref([])
 const stats = ref({})

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -519,8 +520,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await loadItems()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -95,6 +95,7 @@
       <!-- Search + Filters -->
       <div class="space-y-3">
         <div class="flex flex-wrap items-center gap-3">
+          <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -482,6 +483,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import HeatMap from '../components/HeatMap.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -514,6 +516,15 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadItems()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const items = ref([])
 const orgMembers = ref([])

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -37,6 +37,7 @@
 
         <!-- Filters + Create -->
         <div class="flex items-center gap-3 flex-wrap">
+          <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -493,6 +494,7 @@ import { api, getCurrentUser } from '../api'
 import { renderMarkdown } from '../composables/useRenderMd.js'
 import MemberPicker from '../components/MemberPicker.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
@@ -516,6 +518,15 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadAll()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const programs = ref([])
 const objectives = ref([])

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-6xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -521,8 +522,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
-    await loadAll()
+    await fetchAll()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }
@@ -624,14 +628,20 @@ async function loadAll() {
   loading.value = true
   error.value = null
   try {
-    const progs = await api.getPrograms()
-    programs.value = Array.isArray(progs) ? progs : []
-    await loadObjectives()
+    await fetchAll()
   } catch (e) {
     error.value = e.message
   } finally {
     loading.value = false
   }
+}
+
+// Fetch body without the loading toggle, so reload() refreshes in place
+// (no full-list skeleton flicker) — see #165 review.
+async function fetchAll() {
+  const progs = await api.getPrograms()
+  programs.value = Array.isArray(progs) ? progs : []
+  await loadObjectives()
 }
 
 async function loadObjectives() {

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-6xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -283,8 +284,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
-    await loadAll()
+    await fetchAll()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }
@@ -343,13 +347,19 @@ async function loadAll() {
   loading.value = true
   error.value = null
   try {
-    const progs = await api.getPrograms()
-    programs.value = Array.isArray(progs) ? progs : (progs?.data || [])
+    await fetchAll()
   } catch (e) {
     error.value = e.message
   } finally {
     loading.value = false
   }
+}
+
+// Fetch body without the loading toggle, so reload() refreshes in place
+// (no full-list skeleton flicker) — see #165 review.
+async function fetchAll() {
+  const progs = await api.getPrograms()
+  programs.value = Array.isArray(progs) ? progs : (progs?.data || [])
 }
 
 function selectProgram(p) {

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -32,6 +32,7 @@
 
       <!-- Filter/search bar -->
       <div class="flex items-center gap-3 flex-wrap">
+        <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
         <div class="relative flex-1 max-w-xs">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -267,6 +268,7 @@ import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
 import Pagination from '../components/Pagination.vue'
 import ListSkeleton from '../components/ListSkeleton.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -278,6 +280,15 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadAll()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const programs = ref([])
 const selected = ref(null)

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -7,8 +7,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -899,8 +900,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await Promise.all([loadReviews(), loadReviewStats()])
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -697,6 +697,7 @@
           <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Reviews</h1>
           <p class="text-sm text-slate-500 mt-1">Document review requests</p>
         </div>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
 
       <!-- Stats tiles -->
@@ -846,6 +847,7 @@ import SideBySideReview from '../components/SideBySideReview.vue'
 import DocumentViewer from '../components/DocumentViewer.vue'
 import Pagination from '../components/Pagination.vue'
 import ListSkeleton from '../components/ListSkeleton.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 const DocumentEditor = defineAsyncComponent(() => import('../components/DocumentEditor.vue'))
@@ -894,6 +896,15 @@ const userCanReview = computed(() => {
 })
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await Promise.all([loadReviews(), loadReviewStats()])
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const reviews = ref([])
 const statusFilter = ref('open')

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        Failed to load risks. {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>Failed to load risks. {{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -761,9 +762,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await loadRisks()
-    loadAllAdvisories()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -98,6 +98,7 @@
       <!-- Search + Filters -->
       <div class="space-y-3">
         <div class="flex flex-wrap items-center gap-3">
+          <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -706,6 +707,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import HeatMap from '../components/HeatMap.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -756,6 +758,16 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadRisks()
+    loadAllAdvisories()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const risks = ref([])
 // Risk Map must aggregate across the full register, not just the current page.

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -499,8 +500,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await loadSuppliers()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -90,6 +90,7 @@
       <!-- Search + Filters -->
       <div class="space-y-3">
         <div class="flex flex-wrap items-center gap-3">
+          <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -463,6 +464,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -494,6 +496,15 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadSuppliers()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const suppliers = ref([])
 const orgMembers = ref([])

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -8,8 +8,9 @@
 
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
-      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm">
-        {{ error }}
+      <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
+        <span>{{ error }}</span>
+        <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
 
@@ -545,8 +546,11 @@ const loading = ref(true)
 const refreshing = ref(false)
 async function reload() {
   refreshing.value = true
+  error.value = null
   try {
     await loadSystems()
+  } catch (e) {
+    error.value = e.message
   } finally {
     refreshing.value = false
   }

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -97,6 +97,7 @@
       <!-- Search + Filters -->
       <div class="space-y-3">
         <div class="flex flex-wrap items-center gap-3">
+          <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
           <div class="relative flex-1 max-w-xs">
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -510,6 +511,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -540,6 +542,15 @@ const userRole = ref('')
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadSystems()
+  } finally {
+    refreshing.value = false
+  }
+}
 const error = ref(null)
 const systems = ref([])
 const suppliers = ref([])

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -73,6 +73,7 @@
 
       <!-- Search + filters -->
       <div class="flex items-center gap-3 mb-4 flex-wrap">
+        <RefreshButton :loading="refreshing" @refresh="reload" class="shrink-0" />
         <div class="relative flex-1 max-w-xs">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -391,6 +392,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
+import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
@@ -417,6 +419,15 @@ const { orgSlug, orgPath } = useCurrentOrg()
 const renderMd = renderMarkdown
 
 const loading = ref(true)
+const refreshing = ref(false)
+async function reload() {
+  refreshing.value = true
+  try {
+    await loadTasks()
+  } finally {
+    refreshing.value = false
+  }
+}
 const tasks = ref([])
 // Default to "active" (open + in_progress) so completed/cancelled tasks don't
 // clutter the working list; remember the user's choice across visits.


### PR DESCRIPTION
Closes #164 — there's no way to refresh a list without F5 (which reloads the whole SPA and loses scroll/selection/filters).

Adds a shared **`components/RefreshButton.vue`** and wires it into every list page:
- **Registers:** Tasks, Risks, Suppliers, Assets, Legal, Systems, Incidents, Corrective Actions, Changes, Objectives, Programs, Audit.
- **Also:** Reviews, Inbox.

Each view gets a `reload()` that re-fetches its list (the register loaders already cascade to stats) using a dedicated `refreshing` ref — the icon spins, the button disables, and the list updates in place. No full reload, no auth round-trip, scroll/selection/filters preserved.

**Dashboard** is intentionally deferred — it's a summary that loads on navigation, not a stale-list surface. Easy follow-up if wanted.

`just build-web` green.