### PR TITLE
fix(auth): style buttons/inputs on all auth screens, not just login

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -673,3 +673,30 @@
     page-break-after: avoid;
   }
 }
+
+/* ── Brand-colored auth controls ────────────────────────────────────────────
+   Shared by every auth screen (login, signup, forgot/reset password, email
+   verification). Previously scoped to Login.vue, so the OTHER auth screens
+   rendered their buttons/inputs unstyled ("ugly"). Global now; --brand-color
+   falls back to blue-500 when no org branding is configured. */
+.brand-focus:focus {
+  border-color: var(--brand-color, #3b82f6);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand-color, #3b82f6) 30%, transparent);
+}
+.brand-btn {
+  background-color: var(--brand-color, #3b82f6);
+}
+.brand-btn:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+.brand-text {
+  color: var(--brand-color, #3b82f6);
+}
+.brand-text-hover:hover {
+  color: var(--brand-color, #3b82f6);
+}
+.brand-info-box {
+  background-color: color-mix(in srgb, var(--brand-color, #3b82f6) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--brand-color, #3b82f6) 20%, transparent);
+  color: color-mix(in srgb, var(--brand-color, #3b82f6) 80%, white);
+}

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -509,33 +509,5 @@ onMounted(async () => {
 })
 </script>
 
-<style scoped>
-/* Brand-colored focus rings for inputs */
-.brand-focus:focus {
-  border-color: var(--brand-color);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand-color) 30%, transparent);
-}
-
-/* Brand-colored primary buttons */
-.brand-btn {
-  background-color: var(--brand-color);
-}
-.brand-btn:hover:not(:disabled) {
-  filter: brightness(1.15);
-}
-
-/* Brand-colored text */
-.brand-text {
-  color: var(--brand-color);
-}
-.brand-text-hover:hover {
-  color: var(--brand-color);
-}
-
-/* Brand info box (passkey status) */
-.brand-info-box {
-  background-color: color-mix(in srgb, var(--brand-color) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--brand-color) 20%, transparent);
-  color: color-mix(in srgb, var(--brand-color) 80%, white);
-}
-</style>
+<!-- brand-* auth controls now live globally in src/style.css so every auth
+     screen (not just Login) gets them — see #169. -->


### PR DESCRIPTION
Closes #169 — the reset/forgot-password button looked unstyled ("ugly").

**Root cause (not just that one button):** the brand-* auth classes — `.brand-btn`, `.brand-text`, `.brand-text-hover`, `.brand-focus`, `.brand-info-box` — were defined in `Login.vue`'s `<style scoped>`. Scoped styles only apply to Login, so **ForgotPassword, Signup, VerifyEmail and VerifyEmailChange** all use those classes but never received the CSS — their primary buttons rendered with white text and no background, and inputs had no brand focus ring.

**Fix:** move the shared brand-* rules to global `src/style.css` (with a `var(--brand-color, #3b82f6)` fallback so they work even when an org hasn't set a branding color), and remove the scoped block from Login. One change fixes all four screens; Login is unchanged visually.

`just build-web` green. No logic/API change.