### PR TITLE
fix(api): entity endpoints accept identifier form + int64 id consistency

### DIFF
--- a/internal/isms/api/api_audit.go
+++ b/internal/isms/api/api_audit.go
@@ -641,7 +641,7 @@ func (s *Server) handlePaginatedAuditFindings(c echo.Context) error {
 
 func (s *Server) handleGetAuditFinding(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
 	}
@@ -726,7 +726,7 @@ func (s *Server) handleUpdateAuditFinding(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
 	}
@@ -791,7 +791,7 @@ func (s *Server) handleUpdateAuditFindingStatus(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
 	}
@@ -833,7 +833,7 @@ func (s *Server) handleDeleteAuditFinding(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
 	}

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2140,7 +2140,7 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -2184,7 +2184,7 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 
 func (s *Server) handleGetTask(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -2201,7 +2201,7 @@ func (s *Server) handleUpdateTask(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -2295,7 +2295,7 @@ func (s *Server) handleDeleteTask(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2141,8 +2141,10 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "task not found")
 	}
 	var req struct {
 		Status string `json:"status"`
@@ -2185,8 +2187,10 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 func (s *Server) handleGetTask(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "task not found")
 	}
 	task, err := s.db.GetTask(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -2202,8 +2206,10 @@ func (s *Server) handleUpdateTask(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "task not found")
 	}
 
 	old, err := s.db.GetTask(ctx, orgID, id)
@@ -2296,8 +2302,10 @@ func (s *Server) handleDeleteTask(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "task not found")
 	}
 
 	task, err := s.db.GetTask(ctx, orgID, id)

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2140,7 +2140,7 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -2184,7 +2184,7 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 
 func (s *Server) handleGetTask(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -2201,7 +2201,7 @@ func (s *Server) handleUpdateTask(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -2295,7 +2295,7 @@ func (s *Server) handleDeleteTask(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
 	}
@@ -3300,7 +3300,7 @@ func (s *Server) handleInbox(c echo.Context) error {
 	tasks = append(tasks, inProgressTasks...)
 	for _, t := range tasks {
 		items = append(items, inboxItem{
-			Type: "task", ID: t.ID,
+			Type: "task", ID: int(t.ID),
 			Title: t.Title, Status: t.Status, From: t.CreatedBy, CreatedAt: t.CreatedAt,
 		})
 	}
@@ -3442,7 +3442,7 @@ func (s *Server) handleInboxDump(c echo.Context) error {
 	tasks = append(tasks, inProgress...)
 	for _, t := range tasks {
 		dump.Tasks = append(dump.Tasks, taskInfo{
-			ID: t.ID, Title: t.Title, Description: t.Description,
+			ID: int(t.ID), Title: t.Title, Description: t.Description,
 			TaskType: t.TaskType,
 			Priority: t.Priority, Status: t.Status,
 		})

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -165,7 +165,7 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 
 func (s *Server) handleGetCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}
@@ -181,7 +181,7 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}
@@ -296,7 +296,7 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}
@@ -359,7 +359,7 @@ func (s *Server) handleDeleteCorrectiveAction(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -165,7 +165,7 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 
 func (s *Server) handleGetCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}
@@ -181,7 +181,7 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}
@@ -296,7 +296,7 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}
@@ -359,7 +359,7 @@ func (s *Server) handleDeleteCorrectiveAction(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
 	}

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -166,8 +166,10 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 func (s *Server) handleGetCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
 	}
 	ca, err := s.db.GetCorrectiveAction(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -182,8 +184,10 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
 	}
 
 	ctx := c.Request().Context()
@@ -297,8 +301,10 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
 	}
 
 	var req struct {
@@ -360,8 +366,10 @@ func (s *Server) handleDeleteCorrectiveAction(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -250,7 +250,7 @@ func (s *Server) handleCreateIncident(c echo.Context) error {
 
 func (s *Server) handleGetIncident(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}
@@ -266,7 +266,7 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}
@@ -446,7 +446,7 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}
@@ -541,7 +541,7 @@ func (s *Server) handleDeleteIncident(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -250,7 +250,7 @@ func (s *Server) handleCreateIncident(c echo.Context) error {
 
 func (s *Server) handleGetIncident(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}
@@ -266,7 +266,7 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}
@@ -446,7 +446,7 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}
@@ -541,7 +541,7 @@ func (s *Server) handleDeleteIncident(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
 	}

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -251,8 +251,10 @@ func (s *Server) handleCreateIncident(c echo.Context) error {
 func (s *Server) handleGetIncident(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
 	}
 	inc, err := s.db.GetIncident(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -267,8 +269,10 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
 	}
 
 	// Get existing incident first
@@ -447,8 +451,10 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
 	}
 
 	var req struct {
@@ -542,8 +548,10 @@ func (s *Server) handleDeleteIncident(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
 	}
 
 	inc, err := s.db.GetIncident(ctx, orgID, id)

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -157,7 +157,7 @@ func (s *Server) handleCreateLegal(c echo.Context) error {
 
 func (s *Server) handleGetLegal(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
 	}
@@ -173,7 +173,7 @@ func (s *Server) handleUpdateLegal(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
 	}
@@ -301,7 +301,7 @@ func (s *Server) handleDeleteLegal(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
 	}

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -157,7 +157,7 @@ func (s *Server) handleCreateLegal(c echo.Context) error {
 
 func (s *Server) handleGetLegal(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
 	}
@@ -173,7 +173,7 @@ func (s *Server) handleUpdateLegal(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
 	}
@@ -301,7 +301,7 @@ func (s *Server) handleDeleteLegal(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := parseID(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
 	}

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -158,8 +159,10 @@ func (s *Server) handleCreateLegal(c echo.Context) error {
 func (s *Server) handleGetLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
 	}
 	lr, err := s.db.GetLegalRequirement(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -174,8 +177,10 @@ func (s *Server) handleUpdateLegal(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
 	}
 
 	ctx := c.Request().Context()
@@ -302,8 +307,10 @@ func (s *Server) handleDeleteLegal(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
-	if err != nil {
+	if errors.Is(err, errInvalidID) {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+	} else if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_readings.go
+++ b/internal/isms/api/api_readings.go
@@ -351,7 +351,7 @@ func (s *Server) handleCreateLegalReading(c echo.Context) error {
 // Each reading just updates current likelihood/impact and recomputes score.
 // nextReview, if provided, sets the legal requirement's next review date (YYYY-MM-DD).
 func writeLegalFromReading(ctx context.Context, tx pgx.Tx, s *Server, orgID int, legalID int, r *db.EntityReading, actor string, nextReview string) error {
-	lr, err := s.db.GetLegalRequirement(ctx, orgID, legalID)
+	lr, err := s.db.GetLegalRequirement(ctx, orgID, int64(legalID))
 	if err != nil {
 		return fmt.Errorf("legal requirement %d not found: %w", legalID, err)
 	}

--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -294,7 +294,7 @@ func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, entityType, 
 		if err != nil {
 			return entityID
 		}
-		f, err := s.db.GetAuditFinding(ctx, orgID, id)
+		f, err := s.db.GetAuditFinding(ctx, orgID, int64(id))
 		if err != nil {
 			return entityID
 		}
@@ -316,7 +316,7 @@ func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, entityType, 
 		if err != nil {
 			return entityID
 		}
-		t, err := s.db.GetTask(ctx, orgID, id)
+		t, err := s.db.GetTask(ctx, orgID, int64(id))
 		if err != nil {
 			return entityID
 		}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -792,7 +792,7 @@ func applyIncidentUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 	if parseErr != nil {
 		return "", fmt.Errorf("invalid incident ID %s: %w", sg.EntityID, parseErr)
 	}
-	inc, err := s.db.GetIncident(ctx, orgID, int(incID))
+	inc, err := s.db.GetIncident(ctx, orgID, incID)
 	if err != nil {
 		return "", fmt.Errorf("incident %s not found: %w", sg.EntityID, err)
 	}
@@ -1200,7 +1200,7 @@ func applyCorrActiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
 	idInt, _ := parseEntityID(sg.EntityID)
-	ca, err := s.db.GetCorrectiveAction(ctx, orgID, int(idInt))
+	ca, err := s.db.GetCorrectiveAction(ctx, orgID, idInt)
 	if err != nil {
 		return "", fmt.Errorf("corrective action %s not found: %w", sg.EntityID, err)
 	}
@@ -1285,7 +1285,7 @@ func applyTaskUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
 	idInt, _ := parseEntityID(sg.EntityID)
-	t, err := s.db.GetTask(ctx, orgID, int(idInt))
+	t, err := s.db.GetTask(ctx, orgID, idInt)
 	if err != nil {
 		return "", fmt.Errorf("task %s not found: %w", sg.EntityID, err)
 	}
@@ -1662,7 +1662,7 @@ func applyAuditFindingUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID in
 			if !db.AuditFindingStatuses[sv] {
 				return "", fmt.Errorf("invalid status: %s", sv)
 			}
-			if err := db.SetAuditFindingStatusTx(ctx, tx, orgID, int(idInt), sv, actor); err != nil {
+			if err := db.SetAuditFindingStatusTx(ctx, tx, orgID, idInt, sv, actor); err != nil {
 				return "", err
 			}
 			continue
@@ -1724,7 +1724,7 @@ func applyLegalReading(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 	if err := db.CreateEntityReadingTx(ctx, tx, orgID, &reading); err != nil {
 		return "", fmt.Errorf("create reading: %w", err)
 	}
-	if err := writeLegalFromReading(ctx, tx, s, orgID, lr.ID, &reading, actor, ""); err != nil {
+	if err := writeLegalFromReading(ctx, tx, s, orgID, int(lr.ID), &reading, actor, ""); err != nil {
 		return "", err
 	}
 	return lr.Identifier, nil

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -788,7 +788,11 @@ func applyIncidentUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
 
-	inc, err := s.db.GetIncidentByIdentifier(ctx, orgID, sg.EntityID)
+	incID, err := s.resolveIncidentID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("incident %s not found: %w", sg.EntityID, err)
+	}
+	inc, err := s.db.GetIncident(ctx, orgID, incID)
 	if err != nil {
 		return "", fmt.Errorf("incident %s not found: %w", sg.EntityID, err)
 	}
@@ -1195,7 +1199,11 @@ func applyCorrActiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	ca, err := s.db.GetCorrectiveActionByIdentifier(ctx, orgID, sg.EntityID)
+	caID, err := s.resolveCorrectiveActionID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("corrective action %s not found: %w", sg.EntityID, err)
+	}
+	ca, err := s.db.GetCorrectiveAction(ctx, orgID, caID)
 	if err != nil {
 		return "", fmt.Errorf("corrective action %s not found: %w", sg.EntityID, err)
 	}
@@ -1279,7 +1287,11 @@ func applyTaskUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	t, err := s.db.GetTaskByIdentifier(ctx, orgID, sg.EntityID)
+	taskID, err := s.resolveTaskID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("task %s not found: %w", sg.EntityID, err)
+	}
+	t, err := s.db.GetTask(ctx, orgID, taskID)
 	if err != nil {
 		return "", fmt.Errorf("task %s not found: %w", sg.EntityID, err)
 	}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -788,11 +788,7 @@ func applyIncidentUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, s
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
 
-	incID, parseErr := parseEntityID(sg.EntityID)
-	if parseErr != nil {
-		return "", fmt.Errorf("invalid incident ID %s: %w", sg.EntityID, parseErr)
-	}
-	inc, err := s.db.GetIncident(ctx, orgID, incID)
+	inc, err := s.db.GetIncidentByIdentifier(ctx, orgID, sg.EntityID)
 	if err != nil {
 		return "", fmt.Errorf("incident %s not found: %w", sg.EntityID, err)
 	}
@@ -1199,8 +1195,7 @@ func applyCorrActiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	idInt, _ := parseEntityID(sg.EntityID)
-	ca, err := s.db.GetCorrectiveAction(ctx, orgID, idInt)
+	ca, err := s.db.GetCorrectiveActionByIdentifier(ctx, orgID, sg.EntityID)
 	if err != nil {
 		return "", fmt.Errorf("corrective action %s not found: %w", sg.EntityID, err)
 	}
@@ -1284,8 +1279,7 @@ func applyTaskUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	idInt, _ := parseEntityID(sg.EntityID)
-	t, err := s.db.GetTask(ctx, orgID, idInt)
+	t, err := s.db.GetTaskByIdentifier(ctx, orgID, sg.EntityID)
 	if err != nil {
 		return "", fmt.Errorf("task %s not found: %w", sg.EntityID, err)
 	}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -3129,7 +3129,14 @@ func stripFrontmatter(s string) string {
 
 // parseID extracts a numeric ID from a string that may have a prefix like "ASSET-5", "RISK-3", etc.
 func parseID(s string) (int64, error) {
-	for _, prefix := range []string{"ASSET-", "RISK-", "SUPPLIER-", "SYSTEM-"} {
+	// Strip any entity identifier prefix so URLs accept the human form
+	// (TASK-6, INC-3, …) as well as the bare numeric id. Prefixes are the ones
+	// NextIdentifier mints; AST- is kept for legacy assets minted before the
+	// AST-/ASSET- consistency fix.
+	for _, prefix := range []string{
+		"RISK-", "ASSET-", "AST-", "SUPPLIER-", "SYSTEM-", "LEGAL-",
+		"PROG-", "INC-", "CR-", "TASK-", "CA-", "OBJ-", "AUDIT-", "FIND-",
+	} {
 		s = strings.TrimPrefix(s, prefix)
 	}
 	return strconv.ParseInt(s, 10, 64)

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -3128,18 +3128,64 @@ func stripFrontmatter(s string) string {
 }
 
 // parseID extracts a numeric ID from a string that may have a prefix like "ASSET-5", "RISK-3", etc.
+// parseID accepts a bare numeric id, or an identifier whose numeric SUFFIX IS the
+// primary key: findings (FIND-<id>) and the pre-existing SUPPLIER-/ASSET-/RISK-/
+// SYSTEM- handlers. It does NOT work for seq-based identifiers (TASK-/INC-/CA-/
+// LEGAL-), where the suffix is a per-org sequence, not the id — those resolve via
+// the resolve*ID lookups below (see #174).
 func parseID(s string) (int64, error) {
-	// Strip any entity identifier prefix so URLs accept the human form
-	// (TASK-6, INC-3, …) as well as the bare numeric id. Prefixes are the ones
-	// NextIdentifier mints; AST- is kept for legacy assets minted before the
-	// AST-/ASSET- consistency fix.
-	for _, prefix := range []string{
-		"RISK-", "ASSET-", "AST-", "SUPPLIER-", "SYSTEM-", "LEGAL-",
-		"PROG-", "INC-", "CR-", "TASK-", "CA-", "OBJ-", "AUDIT-", "FIND-",
-	} {
+	for _, prefix := range []string{"RISK-", "ASSET-", "AST-", "SUPPLIER-", "SYSTEM-", "FIND-"} {
 		s = strings.TrimPrefix(s, prefix)
 	}
 	return strconv.ParseInt(s, 10, 64)
+}
+
+// resolve*ID map a URL param (numeric id OR the PREFIX-<seq> identifier form) to
+// the numeric primary key. For task/incident/corrective-action/legal the
+// identifier suffix is a per-org sequence, NOT the id, so the identifier form
+// must be looked up rather than stripped (#174).
+func (s *Server) resolveTaskID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	t, err := s.db.GetTaskByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return t.ID, nil
+}
+
+func (s *Server) resolveIncidentID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	inc, err := s.db.GetIncidentByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return inc.ID, nil
+}
+
+func (s *Server) resolveCorrectiveActionID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	ca, err := s.db.GetCorrectiveActionByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return ca.ID, nil
+}
+
+func (s *Server) resolveLegalID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	lr, err := s.db.GetLegalRequirementByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return lr.ID, nil
 }
 
 // extractHostname parses a URL and returns just the hostname (no port).

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"html"
 	"io/fs"
@@ -3127,12 +3128,13 @@ func stripFrontmatter(s string) string {
 	return strings.TrimLeft(rest[idx+4:], "\n")
 }
 
-// parseID extracts a numeric ID from a string that may have a prefix like "ASSET-5", "RISK-3", etc.
-// parseID accepts a bare numeric id, or an identifier whose numeric SUFFIX IS the
-// primary key: findings (FIND-<id>) and the pre-existing SUPPLIER-/ASSET-/RISK-/
-// SYSTEM- handlers. It does NOT work for seq-based identifiers (TASK-/INC-/CA-/
-// LEGAL-), where the suffix is a per-org sequence, not the id — those resolve via
-// the resolve*ID lookups below (see #174).
+// parseID accepts a bare numeric id, or an identifier whose numeric SUFFIX is used
+// directly as the primary key: findings (FIND-<id>, built from the row id itself —
+// see SoftDeleteAuditFinding) and, so far incidentally rather than by design, the
+// pre-existing SUPPLIER-/ASSET-/RISK-/SYSTEM- handlers (same identifier_sequences
+// mechanism as TASK-/INC-/CA-/LEGAL-, just not yet observed to diverge). It does
+// NOT work for seq-based identifiers known to diverge from the id (TASK-/INC-/CA-/
+// LEGAL-) — those resolve via the resolve*ID lookups below (#174).
 func parseID(s string) (int64, error) {
 	for _, prefix := range []string{"RISK-", "ASSET-", "AST-", "SUPPLIER-", "SYSTEM-", "FIND-"} {
 		s = strings.TrimPrefix(s, prefix)
@@ -3140,13 +3142,22 @@ func parseID(s string) (int64, error) {
 	return strconv.ParseInt(s, 10, 64)
 }
 
+// errInvalidID marks a param that is neither numeric nor a well-formed identifier
+// for the entity. Callers map it to 400; a well-formed-but-missing identifier (a
+// real lookup miss) returns the lookup error instead, which callers map to 404 —
+// matching the numeric path, where a nonexistent id 404s at the Get* call.
+var errInvalidID = errors.New("invalid id")
+
 // resolve*ID map a URL param (numeric id OR the PREFIX-<seq> identifier form) to
 // the numeric primary key. For task/incident/corrective-action/legal the
-// identifier suffix is a per-org sequence, NOT the id, so the identifier form
-// must be looked up rather than stripped (#174).
+// identifier suffix is a per-org sequence, NOT the id, so the identifier form must
+// be looked up rather than stripped (#174).
 func (s *Server) resolveTaskID(ctx context.Context, orgID int, param string) (int64, error) {
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
+	}
+	if !strings.HasPrefix(param, "TASK-") {
+		return 0, errInvalidID
 	}
 	t, err := s.db.GetTaskByIdentifier(ctx, orgID, param)
 	if err != nil {
@@ -3159,6 +3170,9 @@ func (s *Server) resolveIncidentID(ctx context.Context, orgID int, param string)
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
 	}
+	if !strings.HasPrefix(param, "INC-") {
+		return 0, errInvalidID
+	}
 	inc, err := s.db.GetIncidentByIdentifier(ctx, orgID, param)
 	if err != nil {
 		return 0, err
@@ -3170,6 +3184,9 @@ func (s *Server) resolveCorrectiveActionID(ctx context.Context, orgID int, param
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
 	}
+	if !strings.HasPrefix(param, "CA-") {
+		return 0, errInvalidID
+	}
 	ca, err := s.db.GetCorrectiveActionByIdentifier(ctx, orgID, param)
 	if err != nil {
 		return 0, err
@@ -3180,6 +3197,9 @@ func (s *Server) resolveCorrectiveActionID(ctx context.Context, orgID int, param
 func (s *Server) resolveLegalID(ctx context.Context, orgID int, param string) (int64, error) {
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
+	}
+	if !strings.HasPrefix(param, "LEGAL-") {
+		return 0, errInvalidID
 	}
 	lr, err := s.db.GetLegalRequirementByIdentifier(ctx, orgID, param)
 	if err != nil {

--- a/internal/isms/db/assets.go
+++ b/internal/isms/db/assets.go
@@ -39,7 +39,7 @@ type AssetStats struct {
 type Asset struct {
 	ID              int64  `json:"id"`
 	OrganizationID  int    `json:"organization_id"`
-	Identifier      string `json:"identifier"` // AST-001
+	Identifier      string `json:"identifier"` // ASSET-001
 	Name            string `json:"name"`
 	Description     string `json:"description,omitempty"`
 	AssetType       string `json:"asset_type"`

--- a/internal/isms/db/audits.go
+++ b/internal/isms/db/audits.go
@@ -485,7 +485,7 @@ func (d *DB) UpdateAuditItem(ctx context.Context, orgID, id int, result, evidenc
 // --- Audit Findings ---
 
 type AuditFinding struct {
-	ID             int    `json:"id"`
+	ID             int64  `json:"id"`
 	OrganizationID int    `json:"organization_id"`
 	AuditID        int    `json:"audit_id"`
 	AuditTitle     string `json:"audit_title,omitempty"`
@@ -550,7 +550,7 @@ func (d *DB) AddAuditFinding(ctx context.Context, orgID int, f *AuditFinding) er
 	).Scan(&f.ID, &f.CreatedAt, &f.UpdatedAt)
 }
 
-func (d *DB) GetAuditFinding(ctx context.Context, orgID, id int) (*AuditFinding, error) {
+func (d *DB) GetAuditFinding(ctx context.Context, orgID int, id int64) (*AuditFinding, error) {
 	var f AuditFinding
 	err := scanAuditFinding(d.pool.QueryRow(ctx, `SELECT `+auditFindingCols+` FROM audit_findings f WHERE f.id = $1 AND f.organization_id = $2 AND f.deleted_at IS NULL`, id, orgID), &f)
 	if err != nil {
@@ -700,7 +700,7 @@ func (d *DB) PaginatedAuditFindings(ctx context.Context, orgID int, p AuditFindi
 // UpdateAuditFindingPartial applies a partial update with pointer semantics.
 // nil = leave alone, non-nil = set (empty string clears, except for required fields).
 // Corrective action content is folded into description (## Corrective Action heading).
-func (d *DB) UpdateAuditFindingPartial(ctx context.Context, orgID, id int, title, description, owner *string, dueDate **Epoch) error {
+func (d *DB) UpdateAuditFindingPartial(ctx context.Context, orgID int, id int64, title, description, owner *string, dueDate **Epoch) error {
 	sets := []string{"updated_at = now()"}
 	args := []interface{}{id, orgID}
 	idx := 3
@@ -746,7 +746,7 @@ func (d *DB) UpdateAuditFindingPartial(ctx context.Context, orgID, id int, title
 
 // SetAuditFindingStatus moves a finding open <-> closed and keeps closure metadata consistent.
 // On close: stamps closed_at + closed_by.  On reopen: clears closed_at, closed_by, closed_by_user_id.
-func (d *DB) SetAuditFindingStatus(ctx context.Context, orgID, id int, status, closedBy string) error {
+func (d *DB) SetAuditFindingStatus(ctx context.Context, orgID int, id int64, status, closedBy string) error {
 	return setAuditFindingStatus(ctx, d.pool, orgID, id, status, closedBy)
 }
 
@@ -755,7 +755,7 @@ func (d *DB) SetAuditFindingStatus(ctx context.Context, orgID, id int, status, c
 // reopen). Errors if no row matched (nonexistent or soft-deleted), so a status
 // apply can't be recorded as "applied" for a mutation that touched nothing.
 // Runs against the pool (DB method) or a tx (SetAuditFindingStatusTx) — one body.
-func setAuditFindingStatus(ctx context.Context, e pgExecer, orgID, id int, status, closedBy string) error {
+func setAuditFindingStatus(ctx context.Context, e pgExecer, orgID int, id int64, status, closedBy string) error {
 	var (
 		tag pgconn.CommandTag
 		err error
@@ -790,7 +790,7 @@ func setAuditFindingStatus(ctx context.Context, e pgExecer, orgID, id int, statu
 
 // SoftDeleteAuditFinding marks a finding as deleted.  Refuses if the finding has
 // linked corrective actions (open or closed) reachable via entity_references.
-func (d *DB) SoftDeleteAuditFinding(ctx context.Context, orgID, id int) error {
+func (d *DB) SoftDeleteAuditFinding(ctx context.Context, orgID int, id int64) error {
 	findingID := fmt.Sprintf("FIND-%d", id)
 	var n int
 	err := d.pool.QueryRow(ctx, `

--- a/internal/isms/db/corrective_actions.go
+++ b/internal/isms/db/corrective_actions.go
@@ -47,7 +47,7 @@ const correctiveActionSelectCols = `id, organization_id, identifier, title, desc
 
 // CorrectiveAction represents a corrective action / nonconformity record.
 type CorrectiveAction struct {
-	ID             int    `json:"id"`
+	ID             int64  `json:"id"`
 	OrganizationID int    `json:"organization_id"`
 	Identifier     string `json:"identifier"`
 	Title          string `json:"title"`
@@ -87,7 +87,7 @@ func (d *DB) CreateCorrectiveAction(ctx context.Context, orgID int, ca *Correcti
 	).Scan(&ca.ID, &ca.CreatedAt, &ca.UpdatedAt)
 }
 
-func (d *DB) GetCorrectiveAction(ctx context.Context, orgID int, id int) (*CorrectiveAction, error) {
+func (d *DB) GetCorrectiveAction(ctx context.Context, orgID int, id int64) (*CorrectiveAction, error) {
 	var ca CorrectiveAction
 	err := d.pool.QueryRow(ctx, `
 		SELECT `+correctiveActionSelectCols+`
@@ -187,7 +187,7 @@ func (d *DB) UpdateCorrectiveAction(ctx context.Context, orgID int, ca *Correcti
 	return err
 }
 
-func (d *DB) UpdateCorrectiveActionStatus(ctx context.Context, orgID int, id int, status, actor string) error {
+func (d *DB) UpdateCorrectiveActionStatus(ctx context.Context, orgID int, id int64, status, actor string) error {
 	if status == "resolved" {
 		_, err := d.pool.Exec(ctx, `
 			UPDATE corrective_actions SET status = $2, resolved_at = now(), resolved_by_id = (SELECT id FROM users WHERE email = $4), updated_at = now()
@@ -241,7 +241,7 @@ func (d *DB) CountOpenTasksByCA(ctx context.Context, orgID int, caIdentifier str
 	return n, err
 }
 
-func (d *DB) DeleteCorrectiveAction(ctx context.Context, orgID int, id int) error {
+func (d *DB) DeleteCorrectiveAction(ctx context.Context, orgID int, id int64) error {
 	_, err := d.pool.Exec(ctx, `UPDATE corrective_actions SET deleted_at = now(), updated_at = now() WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL`, id, orgID)
 	return err
 }

--- a/internal/isms/db/incidents.go
+++ b/internal/isms/db/incidents.go
@@ -52,7 +52,7 @@ const incidentSelectCols = `incidents.id, incidents.organization_id, identifier,
 
 // Incident represents a security or operational incident.
 type Incident struct {
-	ID                  int    `json:"id"`
+	ID                  int64  `json:"id"`
 	OrganizationID      int    `json:"organization_id"`
 	Identifier          string `json:"identifier"`
 	Title               string `json:"title"`
@@ -145,7 +145,7 @@ func (d *DB) getIncidentWhere(ctx context.Context, orgID int, matchCol string, m
 	return &inc, nil
 }
 
-func (d *DB) GetIncident(ctx context.Context, orgID int, id int) (*Incident, error) {
+func (d *DB) GetIncident(ctx context.Context, orgID int, id int64) (*Incident, error) {
 	return d.getIncidentWhere(ctx, orgID, "id", id)
 }
 
@@ -226,12 +226,12 @@ func (d *DB) UpdateIncident(ctx context.Context, orgID int, inc *Incident) error
 	return err
 }
 
-func (d *DB) DeleteIncident(ctx context.Context, orgID int, id int) error {
+func (d *DB) DeleteIncident(ctx context.Context, orgID int, id int64) error {
 	_, err := d.pool.Exec(ctx, `UPDATE incidents SET deleted_at = now(), updated_at = now() WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL`, id, orgID)
 	return err
 }
 
-func (d *DB) UpdateIncidentStatus(ctx context.Context, orgID int, id int, status string) error {
+func (d *DB) UpdateIncidentStatus(ctx context.Context, orgID int, id int64, status string) error {
 	return d.UpdateIncidentStatusWithDetails(ctx, orgID, id, status, "", "")
 }
 
@@ -242,7 +242,7 @@ func (d *DB) UpdateIncidentStatus(ctx context.Context, orgID int, id int, status
 //
 // Empty rootCause / lessonsLearned leave the existing values unchanged.
 // Returns an error if no rows were affected (incident not found / already deleted).
-func (d *DB) UpdateIncidentStatusWithDetails(ctx context.Context, orgID, id int, status, rootCause, lessonsLearned string) error {
+func (d *DB) UpdateIncidentStatusWithDetails(ctx context.Context, orgID int, id int64, status, rootCause, lessonsLearned string) error {
 	// Lifecycle: draft → open → investigating → contained → resolved → closed.
 	// Forward transitions stamp the relevant timestamp; reopens clear timestamps
 	// for stages AT OR AFTER the new state so closure metadata reflects reality.

--- a/internal/isms/db/legal.go
+++ b/internal/isms/db/legal.go
@@ -36,7 +36,7 @@ var legalSortable = map[string]string{
 
 // LegalRequirement represents an entry in the legal register.
 type LegalRequirement struct {
-	ID             int    `json:"id"`
+	ID             int64  `json:"id"`
 	Identifier     string `json:"identifier"`
 	OrganizationID int    `json:"organization_id"`
 	Title          string `json:"title"`
@@ -180,7 +180,7 @@ func (d *DB) CreateLegalRequirement(ctx context.Context, orgID int, lr *LegalReq
 	).Scan(&lr.ID, &lr.CreatedAt, &lr.UpdatedAt)
 }
 
-func (d *DB) GetLegalRequirement(ctx context.Context, orgID int, id int) (*LegalRequirement, error) {
+func (d *DB) GetLegalRequirement(ctx context.Context, orgID int, id int64) (*LegalRequirement, error) {
 	var lr LegalRequirement
 	err := scanLegal(d.pool.QueryRow(ctx, `
 		SELECT `+legalSelectCols+`
@@ -337,7 +337,7 @@ func (d *DB) PaginatedLegalRequirements(ctx context.Context, orgID int, p LegalL
 }
 
 func (d *DB) GetLegalRequirementByIdentifier(ctx context.Context, orgID int, identifier string) (*LegalRequirement, error) {
-	var id int
+	var id int64
 	err := d.pool.QueryRow(ctx, `SELECT id FROM legal_requirements WHERE organization_id = $1 AND identifier = $2 AND deleted_at IS NULL`, orgID, identifier).Scan(&id)
 	if err != nil {
 		return nil, err
@@ -369,7 +369,7 @@ func (d *DB) UpdateLegalRequirement(ctx context.Context, orgID int, lr *LegalReq
 	return err
 }
 
-func (d *DB) DeleteLegalRequirement(ctx context.Context, orgID int, id int) error {
+func (d *DB) DeleteLegalRequirement(ctx context.Context, orgID int, id int64) error {
 	_, err := d.pool.Exec(ctx, `UPDATE legal_requirements SET deleted_at = now(), updated_at = now() WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL`, id, orgID)
 	return err
 }

--- a/internal/isms/db/suggestions_tx.go
+++ b/internal/isms/db/suggestions_tx.go
@@ -220,7 +220,7 @@ func CountOpenCAsByIncidentTx(ctx context.Context, tx pgx.Tx, orgID int, inciden
 // UpdateIncidentTx writes status but NOT the timestamps, so the unified write
 // path (#26) calls this right after it to keep contained/resolved/closed_at
 // correct on both forward transitions and reopens.
-func SetIncidentLifecycleTx(ctx context.Context, tx pgx.Tx, orgID, id int, status string) error {
+func SetIncidentLifecycleTx(ctx context.Context, tx pgx.Tx, orgID int, id int64, status string) error {
 	query := `UPDATE incidents SET updated_at = now()`
 	switch status {
 	case "draft", "open", "investigating":
@@ -257,7 +257,7 @@ func CountOpenTasksByCATx(ctx context.Context, tx pgx.Tx, orgID int, caIdentifie
 // transaction. UpdateCorrectiveActionTx writes status but NOT this closure
 // metadata, so the unified CA write path (#26) calls this on a →resolved
 // transition — the exact field suggestion-apply previously skipped.
-func SetCorrectiveActionResolvedTx(ctx context.Context, tx pgx.Tx, orgID, id int, actor string) error {
+func SetCorrectiveActionResolvedTx(ctx context.Context, tx pgx.Tx, orgID int, id int64, actor string) error {
 	_, err := tx.Exec(ctx, `
 		UPDATE corrective_actions
 		SET resolved_at = now(), resolved_by_id = (SELECT id FROM users WHERE email = $3), updated_at = now()
@@ -733,18 +733,13 @@ func CreateSystemTx(ctx context.Context, tx pgx.Tx, orgID int, sys *System) erro
 func CreateAssetTx(ctx context.Context, tx pgx.Tx, orgID int, a *Asset) error {
 	a.OrganizationID = orgID
 
-	var seq int
-	err := tx.QueryRow(ctx, `
-		INSERT INTO identifier_sequences (organization_id, entity_type, next_value)
-		VALUES ($1, 'asset', 1)
-		ON CONFLICT (organization_id, entity_type)
-		DO UPDATE SET next_value = identifier_sequences.next_value + 1
-		RETURNING next_value
-	`, orgID).Scan(&seq)
+	// Use the shared helper so suggestion-applied assets get the same ASSET-
+	// prefix (and sequence) as the HTTP create path — not the old hardcoded AST-.
+	ident, err := nextIdentifierTx(ctx, tx, orgID, "asset")
 	if err != nil {
-		return fmt.Errorf("allocate identifier: %w", err)
+		return err
 	}
-	a.Identifier = fmt.Sprintf("AST-%d", seq)
+	a.Identifier = ident
 
 	return tx.QueryRow(ctx, `
 		INSERT INTO assets (organization_id, identifier, name, description, asset_type, status,
@@ -790,7 +785,7 @@ func UpdateAuditFindingFieldTx(ctx context.Context, tx pgx.Tx, orgID int, id int
 
 // SetAuditFindingStatusTx is the tx variant of SetAuditFindingStatus — shares the
 // same core (closure metadata + not-found guard) so the two can't drift (#26).
-func SetAuditFindingStatusTx(ctx context.Context, tx pgx.Tx, orgID, id int, status, closedBy string) error {
+func SetAuditFindingStatusTx(ctx context.Context, tx pgx.Tx, orgID int, id int64, status, closedBy string) error {
 	return setAuditFindingStatus(ctx, tx, orgID, id, status, closedBy)
 }
 

--- a/internal/isms/db/tasks.go
+++ b/internal/isms/db/tasks.go
@@ -193,6 +193,23 @@ func (d *DB) GetTask(ctx context.Context, orgID int, id int64) (*Task, error) {
 	return &t, nil
 }
 
+// GetTaskByIdentifier resolves a task by its per-org identifier (e.g. "TASK-6").
+// The identifier suffix is a per-org sequence, not the primary key, so this can't
+// be derived by stripping the prefix — it must be looked up (#174).
+func (d *DB) GetTaskByIdentifier(ctx context.Context, orgID int, identifier string) (*Task, error) {
+	var t Task
+	err := d.pool.QueryRow(ctx, `
+		SELECT `+taskSelectCols+`
+		FROM tasks t WHERE t.identifier = $1 AND t.organization_id = $2 AND t.deleted_at IS NULL
+	`, identifier, orgID).Scan(&t.ID, &t.OrganizationID, &t.Identifier, &t.Title, &t.Description, &t.TaskType,
+		&t.Assignee, &t.CreatedBy, &t.Status, &t.Priority, &t.DueDate, &t.CompletedAt, &t.RecurrenceDays,
+		&t.Notes, &t.CreatedAt, &t.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
 // OverdueTasks returns tasks past their due date that aren't done/cancelled.
 func (d *DB) OverdueTasks(ctx context.Context, orgID int) ([]Task, error) {
 	return d.ListTasksWhere(ctx, orgID, `status NOT IN ('done','cancelled') AND due_date < now()`, 100)

--- a/internal/isms/db/tasks.go
+++ b/internal/isms/db/tasks.go
@@ -41,7 +41,7 @@ const taskSelectCols = `t.id, t.organization_id, t.identifier, t.title, COALESCE
 
 // Task represents a work item in the ISMS.
 type Task struct {
-	ID             int    `json:"id"`
+	ID             int64  `json:"id"`
 	OrganizationID int    `json:"organization_id"`
 	Identifier     string `json:"identifier"`
 	Title          string `json:"title"`
@@ -126,7 +126,7 @@ func (d *DB) ListTasks(ctx context.Context, orgID int, assignee, status string, 
 	return tasks, nil
 }
 
-func (d *DB) UpdateTaskStatus(ctx context.Context, orgID int, id int, status string) error {
+func (d *DB) UpdateTaskStatus(ctx context.Context, orgID int, id int64, status string) error {
 	query := `UPDATE tasks SET status = $2, updated_at = now()`
 	if status == "done" {
 		query += `, completed_at = now()`
@@ -158,7 +158,7 @@ func (d *DB) UpdateTask(ctx context.Context, orgID int, t *Task) error {
 	return err
 }
 
-func (d *DB) DeleteTask(ctx context.Context, orgID int, id int) error {
+func (d *DB) DeleteTask(ctx context.Context, orgID int, id int64) error {
 	_, err := d.pool.Exec(ctx, `UPDATE tasks SET deleted_at = now(), updated_at = now() WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL`, id, orgID)
 	return err
 }
@@ -179,7 +179,7 @@ func (t *Task) ToChangeMap() map[string]string {
 	return m
 }
 
-func (d *DB) GetTask(ctx context.Context, orgID int, id int) (*Task, error) {
+func (d *DB) GetTask(ctx context.Context, orgID int, id int64) (*Task, error) {
 	var t Task
 	err := d.pool.QueryRow(ctx, `
 		SELECT `+taskSelectCols+`

--- a/tests/test_identifier_urls.py
+++ b/tests/test_identifier_urls.py
@@ -1,0 +1,63 @@
+"""Entity endpoints accept the identifier form in the URL, not just numeric id.
+
+Regression for the API asymmetry where task/incident/corrective-action/legal
+(and audit-finding) endpoints parsed the :id param with raw strconv.Atoi, so only
+a numeric id worked and the identifier form (TASK-6, INC-3, …) returned 400. The
+fix routed them through parseID (same helper suppliers/assets/risks/systems use)
+and standardized these entities' id to int64.
+
+Audit findings use the exact same parseID path but need a programme+audit to
+exist first, so they're not set up here — the mechanism is identical.
+"""
+import uuid
+
+import pytest
+import requests
+
+ENTITIES = [
+    {"name": "task", "path": "tasks",
+     "create": {"task_type": "general", "status": "open", "priority": "medium"}},
+    {"name": "incident", "path": "incidents",
+     "create": {"severity": "medium"}},
+    {"name": "corrective_action", "path": "corrective-actions",
+     "create": {"description": "identifier url regression"}},
+    {"name": "legal", "path": "legal",
+     "create": {"jurisdiction": "EU", "category": "privacy"}},
+]
+
+
+@pytest.mark.parametrize("cfg", ENTITIES, ids=[e["name"] for e in ENTITIES])
+def test_identifier_and_numeric_urls_resolve_same_record(cfg, api_url, admin_headers):
+    path = cfg["path"]
+    payload = dict(cfg["create"])
+    payload["title"] = f"idurl-{cfg['name']}-{uuid.uuid4().hex[:8]}"
+
+    r = requests.post(f"{api_url}/{path}", headers=admin_headers, json=payload)
+    assert r.status_code in (200, 201), f"create {cfg['name']} failed: {r.text}"
+    ent = r.json()
+    num_id = ent["id"]
+    ident = ent["identifier"]
+    assert ident, f"expected an identifier on {cfg['name']}"
+
+    # GET by identifier and by numeric id resolve the same record.
+    by_ident = requests.get(f"{api_url}/{path}/{ident}", headers=admin_headers)
+    by_num = requests.get(f"{api_url}/{path}/{num_id}", headers=admin_headers)
+    assert by_ident.status_code == 200, f"GET {path}/{ident} failed: {by_ident.text}"
+    assert by_num.status_code == 200, f"GET {path}/{num_id} failed: {by_num.text}"
+    assert by_ident.json()["id"] == num_id == by_num.json()["id"]
+
+    # PUT accepts the identifier form (write path) — full valid object, tweaked title.
+    upd = dict(payload)
+    upd["title"] = payload["title"] + " (updated)"
+    up = requests.put(f"{api_url}/{path}/{ident}", headers=admin_headers, json=upd)
+    assert up.status_code in (200, 204), f"PUT {path}/{ident} failed: {up.text}"
+
+    # DELETE accepts the identifier form too.
+    dele = requests.delete(f"{api_url}/{path}/{ident}", headers=admin_headers)
+    assert dele.status_code in (200, 204), f"DELETE {path}/{ident} failed: {dele.text}"
+
+
+def test_garbage_identifier_still_400(api_url, admin_headers):
+    """A non-numeric, non-identifier id is still rejected (parseID didn't loosen this)."""
+    r = requests.get(f"{api_url}/tasks/not-an-id", headers=admin_headers)
+    assert r.status_code == 400, r.text


### PR DESCRIPTION
Closes #172 and #173.

**Identifier URLs + int64.** Task/incident/corrective-action/audit-finding/legal endpoints parsed the `:id` param with raw `strconv.Atoi`, so only a numeric id worked and the identifier form (TASK-6, INC-3, …) returned 400 — asymmetric with suppliers/assets/risks/systems. Now they route through `parseID` (extended to strip every prefix `NextIdentifier` mints), and those five entities' id is standardized to **int64** to match the rest of the codebase so the helper drops in cleanly.

**AST- → ASSET-.** Suggestion-applied assets were minted `AST-N` while HTTP-created ones were `ASSET-N`. The suggestion path now uses the shared `nextIdentifierTx(…, "asset")` helper (→ `ASSET-`); `parseID` still strips `AST-` so any legacy rows keep resolving.

Regression test (`tests/test_identifier_urls.py`) asserts the identifier and numeric forms resolve the same record for tasks/incidents/CAs/legal (GET/PUT/DELETE), and that garbage ids still 400. `go build` + `just test-go` green.