### PR TITLE
feat(suppliers): add 'contractor' to supplier_type enum

### DIFF
--- a/cmd/isms/supplier.go
+++ b/cmd/isms/supplier.go
@@ -75,7 +75,7 @@ func supplierAddCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Supplier name")
-	cmd.Flags().StringVar(&supplierType, "type", "", "Type: cloud, saas, consulting, hosting, other")
+	cmd.Flags().StringVar(&supplierType, "type", "", "Type: cloud, saas, consulting, hosting, infrastructure, software, contractor, other")
 	cmd.Flags().StringVar(&criticality, "criticality", "", "Criticality: low, medium, high, critical")
 	cmd.Flags().BoolVar(&dataAccess, "data-access", false, "Supplier has access to our data")
 	cmd.Flags().StringVar(&contact, "contact", "", "Contact info")

--- a/internal/isms/api/openapi.yaml
+++ b/internal/isms/api/openapi.yaml
@@ -3376,7 +3376,7 @@ components:
         id: { type: integer }
         identifier: { type: string, example: "SUPPLIER-001" }
         name: { type: string }
-        supplier_type: { type: string, enum: [cloud, saas, consulting, hosting, infrastructure, software, other] }
+        supplier_type: { type: string, enum: [cloud, saas, consulting, hosting, infrastructure, software, contractor, other] }
         criticality: { type: string, enum: [low, medium, high, critical] }
         data_access: { type: boolean }
         contact: { type: string }

--- a/internal/isms/db/suppliers.go
+++ b/internal/isms/db/suppliers.go
@@ -68,7 +68,7 @@ type Supplier struct {
 }
 
 // Valid supplier types.
-var SupplierTypes = []string{"cloud", "saas", "consulting", "hosting", "infrastructure", "software", "other"}
+var SupplierTypes = []string{"cloud", "saas", "consulting", "hosting", "infrastructure", "software", "contractor", "other"}
 
 // Valid criticality levels.
 var CriticalityLevels = []string{"low", "medium", "high", "critical"}

--- a/migrations/20260713000000_v0.7.1.sql
+++ b/migrations/20260713000000_v0.7.1.sql
@@ -11,3 +11,12 @@
 ALTER TABLE entity_readings DROP CONSTRAINT IF EXISTS entity_readings_entity_type_check;
 ALTER TABLE entity_readings ADD CONSTRAINT entity_readings_entity_type_check
     CHECK (entity_type IN ('risk', 'legal_requirement', 'asset', 'system', 'supplier'));
+
+-- Supplier register: add 'contractor' to supplier_type. The IT-centric set had
+-- no home for physical works contractors (rock/concrete, blasting, tank cleaning,
+-- coating, marine), which were landing in 'other'. DROP IF EXISTS + re-ADD is
+-- safe on fresh DBs; existing rows all satisfy the wider set.
+ALTER TABLE suppliers DROP CONSTRAINT IF EXISTS suppliers_supplier_type_check;
+ALTER TABLE suppliers ADD CONSTRAINT suppliers_supplier_type_check
+    CHECK (supplier_type IN ('cloud', 'saas', 'consulting', 'hosting',
+        'infrastructure', 'software', 'contractor', 'other'));

--- a/tests/test_supplier_types.py
+++ b/tests/test_supplier_types.py
@@ -1,0 +1,52 @@
+"""Supplier register accepts every supplier_type, including `contractor`.
+
+Regression for adding `contractor` to the supplier_type enum — the IT-centric set
+(cloud/saas/consulting/hosting/infrastructure/software/other) had no home for
+physical works contractors, which were landing in `other`.
+"""
+import uuid
+
+import requests
+
+SUPPLIER_TYPES = [
+    "cloud", "saas", "consulting", "hosting",
+    "infrastructure", "software", "contractor", "other",
+]
+
+
+def test_every_supplier_type_accepted(api_url, admin_headers):
+    created = {}
+    for t in SUPPLIER_TYPES:
+        r = requests.post(f"{api_url}/suppliers", headers=admin_headers, json={
+            "name": f"stype-{t}-{uuid.uuid4().hex[:8]}",
+            "supplier_type": t,
+            "criticality": "medium",
+        })
+        assert r.status_code in (200, 201), f"create supplier_type={t} failed: {r.text}"
+        s = r.json()
+        assert s["supplier_type"] == t, f"expected {t}, got {s.get('supplier_type')}"
+        created[t] = s["id"]
+
+    # Each is stored and retrievable with its type (robust vs list pagination).
+    for t, sid in created.items():
+        got = requests.get(f"{api_url}/suppliers/{sid}", headers=admin_headers)
+        assert got.status_code == 200, got.text
+        assert got.json()["supplier_type"] == t
+
+
+def test_reclassify_other_to_contractor(api_url, admin_headers):
+    r = requests.post(f"{api_url}/suppliers", headers=admin_headers, json={
+        "name": f"reclass-{uuid.uuid4().hex[:8]}",
+        "supplier_type": "other",
+        "criticality": "low",
+    })
+    assert r.status_code in (200, 201), r.text
+    sid = r.json()["id"]
+
+    up = requests.put(f"{api_url}/suppliers/{sid}", headers=admin_headers,
+                      json={"supplier_type": "contractor"})
+    assert up.status_code in (200, 204), f"reclassify failed: {up.text}"
+
+    got = requests.get(f"{api_url}/suppliers/{sid}", headers=admin_headers)
+    assert got.status_code == 200
+    assert got.json()["supplier_type"] == "contractor"

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -542,6 +542,7 @@ const supplierTypes = [
   { key: 'hosting', label: 'Hosting' },
   { key: 'infrastructure', label: 'Infrastructure' },
   { key: 'software', label: 'Software' },
+  { key: 'contractor', label: 'Contractor' },
   { key: 'other', label: 'Other' },
 ]
 


### PR DESCRIPTION
Closes #175.

Adds `contractor` to the `supplier_type` enum — the IT-centric set (cloud/saas/consulting/hosting/infrastructure/software/other) had no home for physical works contractors, so they were landing in `other`.

Everywhere the enum is defined:
- **Migration:** appended to the existing 0.7.1 release file `v0.7.1.sql` (one migration per release — not a new file), widening `suppliers_supplier_type_check`.
- `db/suppliers.go` `SupplierTypes`, `api/openapi.yaml` enum, `cmd/isms/supplier.go` `--type` help (also syncs the stale hint that was missing infrastructure/software), `web/src/views/Suppliers.vue` picker.

No data migration; existing rows stay valid. Regression test (`tests/test_supplier_types.py`) creates a supplier of every type and reclassifies `other` → `contractor`. `go build` + `build-web` + gofmt green.