### PR TITLE
fix(suggestions): resolve seq-based identifiers on apply (#177)

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -195,6 +195,31 @@ func getUserEmail(c echo.Context) string {
 	return ""
 }
 
+// taskViewer builds the task-visibility scope for the current caller: managers
+// and admins see every task; everyone else sees only public tasks plus their own
+// (assigned to them or created by them).
+func taskViewer(c echo.Context) db.TaskViewer {
+	role, _ := c.Get("user_role").(string)
+	return db.TaskViewer{
+		Email:     getUserEmail(c),
+		CanSeeAll: role == "manager" || role == "admin",
+	}
+}
+
+// canViewTask mirrors db.TaskViewer for single by-id fetches (which aren't
+// SQL-filtered): reports whether the caller may see this task under the privacy
+// rule. A hidden task is treated as not-found (404), never 403 — don't reveal it.
+func canViewTask(c echo.Context, t *db.Task) bool {
+	if !t.Private {
+		return true
+	}
+	if role, _ := c.Get("user_role").(string); role == "manager" || role == "admin" {
+		return true
+	}
+	email := getUserEmail(c)
+	return t.Assignee == email || t.CreatedBy == email
+}
+
 // getOrgID returns the organization ID set by AuthMiddleware, or 0 if not set.
 func getOrgID(c echo.Context) int {
 	if id, ok := c.Get("org_id").(int); ok {
@@ -2031,7 +2056,7 @@ func (s *Server) handleListTasks(c echo.Context) error {
 		TaskType: c.QueryParam("task_type"),
 		Assignee: c.QueryParam("assignee"),
 	}
-	items, total, err := s.db.PaginatedTasks(c.Request().Context(), orgID, params)
+	items, total, err := s.db.PaginatedTasks(c.Request().Context(), orgID, taskViewer(c), params)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -2105,6 +2130,13 @@ func (s *Server) handleCreateTask(c echo.Context) error {
 		return err
 	}
 	ctx := c.Request().Context()
+	// Visibility: an explicit flag wins; otherwise fall back to the org default
+	// (public unless the org has opted into task_default_private).
+	if req.Private != nil {
+		t.Private = *req.Private
+	} else if v, _ := s.db.GetOrgSetting(ctx, orgID, "task_default_private"); v == "true" {
+		t.Private = true
+	}
 	if err := s.db.CreateTask(ctx, orgID, &t); err != nil {
 		return pgxHTTPError(err)
 	}
@@ -2196,6 +2228,9 @@ func (s *Server) handleGetTask(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "task not found")
 	}
+	if !canViewTask(c, task) {
+		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+	}
 	return c.JSON(http.StatusOK, task)
 }
 
@@ -2269,6 +2304,9 @@ func (s *Server) handleUpdateTask(c echo.Context) error {
 	}
 	if req.Notes != nil {
 		t.Notes = *req.Notes
+	}
+	if req.Private != nil {
+		t.Private = *req.Private
 	}
 
 	if err := s.db.UpdateTask(ctx, orgID, &t); err != nil {
@@ -2347,6 +2385,7 @@ type taskCreateRequest struct {
 	DueDate        *db.Epoch        `json:"due_date"`
 	RecurrenceDays *int             `json:"recurrence_days"`
 	Notes          string           `json:"notes"`
+	Private        *bool            `json:"private"`
 	References     []ReferenceInput `json:"references"`
 }
 
@@ -2360,6 +2399,7 @@ type taskUpdateRequest struct {
 	DueDate        **db.Epoch `json:"due_date"`
 	RecurrenceDays **int      `json:"recurrence_days"`
 	Notes          *string    `json:"notes"`
+	Private        *bool      `json:"private"`
 }
 
 // --- Change Requests ---
@@ -3303,8 +3343,8 @@ func (s *Server) handleInbox(c echo.Context) error {
 	}
 
 	// Open tasks assigned to this user
-	tasks, _ := s.db.ListTasks(ctx, orgID, actor, "open", 50)
-	inProgressTasks, _ := s.db.ListTasks(ctx, orgID, actor, "in_progress", 50)
+	tasks, _ := s.db.ListTasks(ctx, orgID, taskViewer(c), actor, "open", 50)
+	inProgressTasks, _ := s.db.ListTasks(ctx, orgID, taskViewer(c), actor, "in_progress", 50)
 	tasks = append(tasks, inProgressTasks...)
 	for _, t := range tasks {
 		items = append(items, inboxItem{
@@ -3445,8 +3485,8 @@ func (s *Server) handleInboxDump(c echo.Context) error {
 	}
 
 	// Tasks assigned to actor
-	tasks, _ := s.db.ListTasks(ctx, orgID, actor, "open", 50)
-	inProgress, _ := s.db.ListTasks(ctx, orgID, actor, "in_progress", 50)
+	tasks, _ := s.db.ListTasks(ctx, orgID, taskViewer(c), actor, "open", 50)
+	inProgress, _ := s.db.ListTasks(ctx, orgID, taskViewer(c), actor, "in_progress", 50)
 	tasks = append(tasks, inProgress...)
 	for _, t := range tasks {
 		dump.Tasks = append(dump.Tasks, taskInfo{

--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -69,7 +69,7 @@ func (s *Server) handleListReferences(c echo.Context) error {
 		}
 		seen[pairKey] = true
 		rwt := refWithTitle{EntityReference: r}
-		rwt.Title = s.resolveEntityTitle(ctx, orgID, otherType, otherID)
+		rwt.Title = s.resolveEntityTitle(ctx, orgID, taskViewer(c), otherType, otherID)
 		if otherType == "document" {
 			rwt.Subtype = s.resolveDocumentSubtype(ctx, orgID, otherID)
 		}
@@ -179,7 +179,7 @@ func (s *Server) resolveDocumentSubtype(ctx context.Context, orgID int, docID st
 }
 
 // resolveEntityTitle looks up the display name for an entity by type and ID.
-func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, entityType, entityID string) string {
+func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, viewer db.TaskViewer, entityType, entityID string) string {
 	// References store per-org identifiers (e.g. "RISK-12", "INC-3") — both
 	// the UI and createReferencesForEntity write that format. Resolve by
 	// identifier, never by numeric row id: the numeric part of an identifier
@@ -318,6 +318,11 @@ func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, entityType, 
 		}
 		t, err := s.db.GetTask(ctx, orgID, int64(id))
 		if err != nil {
+			return entityID
+		}
+		// Don't leak a private task's title to someone who may not see it — fall
+		// back to the identifier (mirrors db.TaskViewer's rule).
+		if t.Private && !viewer.CanSeeAll && t.Assignee != viewer.Email && t.CreatedBy != viewer.Email {
 			return entityID
 		}
 		return t.Title

--- a/internal/isms/api/api_search.go
+++ b/internal/isms/api/api_search.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"isms.sh/internal/isms/db"
 )
 
 // SearchEntry is a single searchable item in the index.
@@ -306,7 +307,12 @@ func (s *Server) buildSearchIndex(orgID int) {
 
 	// Tasks
 	collect(func() []SearchEntry {
-		items, err := s.db.ListTasks(ctx, orgID, "", "", 0)
+		// The search index is an org-wide shared/cached structure, so it can't be
+		// filtered per viewer at build time. Include ONLY public tasks (zero
+		// TaskViewer → public-only) so a private task's title can't leak through
+		// universal search. Trade-off: private tasks aren't universally searchable
+		// (tracked as a follow-up — needs query-time visibility filtering).
+		items, err := s.db.ListTasks(ctx, orgID, db.TaskViewer{}, "", "", 0)
 		if err != nil {
 			return nil
 		}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -1092,8 +1092,11 @@ func applyChangeUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	idInt, _ := parseEntityID(sg.EntityID)
-	cr, err := s.db.GetChangeRequest(ctx, orgID, int(idInt))
+	id, err := s.resolveChangeID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("change request %s not found: %w", sg.EntityID, err)
+	}
+	cr, err := s.db.GetChangeRequest(ctx, orgID, int(id))
 	if err != nil {
 		return "", fmt.Errorf("change request %s not found: %w", sg.EntityID, err)
 	}
@@ -1380,8 +1383,11 @@ func applyObjectiveUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, 
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	idInt, _ := parseEntityID(sg.EntityID)
-	o, err := s.db.GetObjective(ctx, orgID, idInt)
+	id, err := s.resolveObjectiveID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("objective %s not found: %w", sg.EntityID, err)
+	}
+	o, err := s.db.GetObjective(ctx, orgID, id)
 	if err != nil {
 		return "", fmt.Errorf("objective %s not found: %w", sg.EntityID, err)
 	}
@@ -1470,8 +1476,11 @@ func applySystemUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg 
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	idInt, _ := parseEntityID(sg.EntityID)
-	sys, err := s.db.GetSystem(ctx, orgID, idInt)
+	id, err := s.resolveSystemID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("system %s not found: %w", sg.EntityID, err)
+	}
+	sys, err := s.db.GetSystem(ctx, orgID, id)
 	if err != nil {
 		return "", fmt.Errorf("system %s not found: %w", sg.EntityID, err)
 	}
@@ -1566,8 +1575,11 @@ func applyAssetUpdate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *
 	if err := json.Unmarshal(sg.Payload, &payload); err != nil {
 		return "", fmt.Errorf("invalid update payload: %w", err)
 	}
-	idInt, _ := parseEntityID(sg.EntityID)
-	asset, err := s.db.GetAsset(ctx, orgID, idInt)
+	id, err := s.resolveAssetID(ctx, orgID, sg.EntityID)
+	if err != nil {
+		return "", fmt.Errorf("asset %s not found: %w", sg.EntityID, err)
+	}
+	asset, err := s.db.GetAsset(ctx, orgID, id)
 	if err != nil {
 		return "", fmt.Errorf("asset %s not found: %w", sg.EntityID, err)
 	}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -3215,6 +3215,58 @@ func (s *Server) resolveLegalID(ctx context.Context, orgID int, param string) (i
 	return lr.ID, nil
 }
 
+// resolveChangeID / resolveObjectiveID / resolveSystemID / resolveAssetID map a
+// suggestion's EntityID (numeric primary key OR the per-org identifier form) to
+// the numeric id via lookup (#177). Unlike resolveTaskID et al. these skip a
+// fixed-prefix check on purpose: asset identifiers exist as both ASSET- and AST-,
+// systems as SYSTEM-, and objective "identifiers" are program-key-scoped display
+// IDs (e.g. ISMS-1), so a hardcoded prefix would be wrong. Numeric → the id;
+// otherwise look it up — a per-org seq that differs from the id no longer silently
+// resolves to the wrong row.
+func (s *Server) resolveChangeID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	cr, err := s.db.GetChangeRequestByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return int64(cr.ID), nil
+}
+
+func (s *Server) resolveObjectiveID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	o, err := s.db.GetObjectiveByDisplayID(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return o.ID, nil
+}
+
+func (s *Server) resolveSystemID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	sys, err := s.db.GetSystemByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return sys.ID, nil
+}
+
+func (s *Server) resolveAssetID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	a, err := s.db.GetAssetByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return a.ID, nil
+}
+
 // extractHostname parses a URL and returns just the hostname (no port).
 // deriveKey uses HKDF-SHA256 to derive a purpose-specific key from the master secret.
 func deriveKey(master []byte, label string, n int) []byte {

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -932,6 +932,10 @@ func (s *Server) handleGetConfig(c echo.Context) error {
 		// hides the "Sign up" affordances when this is false — the signup handler
 		// itself is the hard gate (403), this just keeps the UI honest.
 		SignupEnabled bool `json:"signup_enabled"`
+
+		// New tasks default to private in this org (ISMS task_default_private).
+		// The web create form seeds its Public/Private control from this.
+		TaskDefaultPrivate bool `json:"task_default_private"`
 	}
 	resp := configResponse{}
 	resp.SubdomainRouting = s.subdomainRouting
@@ -987,6 +991,9 @@ func (s *Server) handleGetConfig(c echo.Context) error {
 	if val, err := s.db.GetOrgSetting(ctx, orgID, "privacy_url"); err == nil && val != "" {
 		resp.PrivacyURL = val
 		resp.HasPrivacy = true
+	}
+	if val, err := s.db.GetOrgSetting(ctx, orgID, "task_default_private"); err == nil {
+		resp.TaskDefaultPrivate = val == "true" || val == "1"
 	}
 
 	return c.JSON(http.StatusOK, resp)

--- a/internal/isms/api/task_visibility_test.go
+++ b/internal/isms/api/task_visibility_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"isms.sh/internal/isms/db"
+)
+
+// TestCanViewTask covers the single by-id visibility check (GetTask paths, which
+// aren't SQL-filtered). It must mirror db.TaskViewer exactly: public → everyone;
+// private → only manager/admin, the assignee, or the creator. A false positive
+// here leaks a private task to an unrelated reader/contributor (incl. agents).
+func TestCanViewTask(t *testing.T) {
+	e := echo.New()
+	ctx := func(role, email string) echo.Context {
+		c := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), httptest.NewRecorder())
+		c.Set("user_role", role)
+		c.Set("user_email", email)
+		return c
+	}
+	pub := &db.Task{Private: false, Assignee: "a@x.io", CreatedBy: "c@x.io"}
+	priv := &db.Task{Private: true, Assignee: "a@x.io", CreatedBy: "c@x.io"}
+
+	cases := []struct {
+		name  string
+		role  string
+		email string
+		task  *db.Task
+		want  bool
+	}{
+		{"public visible to unrelated reader", "reader", "z@x.io", pub, true},
+		{"private visible to manager", "manager", "z@x.io", priv, true},
+		{"private visible to admin", "admin", "z@x.io", priv, true},
+		{"private visible to assignee", "contributor", "a@x.io", priv, true},
+		{"private visible to creator", "reader", "c@x.io", priv, true},
+		{"private hidden from unrelated reader", "reader", "z@x.io", priv, false},
+		{"private hidden from unrelated contributor (agent)", "contributor", "z@x.io", priv, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canViewTask(ctx(tc.role, tc.email), tc.task); got != tc.want {
+				t.Errorf("canViewTask(role=%s, email=%s, private=%v) = %v, want %v",
+					tc.role, tc.email, tc.task.Private, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/isms/db/changes.go
+++ b/internal/isms/db/changes.go
@@ -106,6 +106,24 @@ func (d *DB) GetChangeRequest(ctx context.Context, orgID int, id int) (*ChangeRe
 	return &cr, nil
 }
 
+// GetChangeRequestByIdentifier resolves a change request by its per-org identifier
+// (e.g. "CR-6"). The suffix is a per-org sequence, not the primary key, so it must
+// be looked up rather than stripped (#174/#177).
+func (d *DB) GetChangeRequestByIdentifier(ctx context.Context, orgID int, identifier string) (*ChangeRequest, error) {
+	var cr ChangeRequest
+	err := d.pool.QueryRow(ctx, `
+		SELECT `+changeRequestSelectCols+`
+		FROM change_requests WHERE identifier = $1 AND organization_id = $2 AND deleted_at IS NULL
+	`, identifier, orgID).Scan(&cr.ID, &cr.OrganizationID, &cr.Identifier, &cr.Title, &cr.Description, &cr.Justification,
+		&cr.Priority, &cr.Category, &cr.RiskLevel, &cr.RollbackPlan, &cr.Notes,
+		&cr.RequestedBy, &cr.AssignedTo, &cr.Status, &cr.ApprovedBy,
+		&cr.ApprovedAt, &cr.PlannedAt, &cr.ImplementedAt, &cr.CreatedAt, &cr.UpdatedAt, &cr.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &cr, nil
+}
+
 func (d *DB) ListChangeRequests(ctx context.Context, orgID int, status string, limit int) ([]ChangeRequest, error) {
 	query := `SELECT ` + changeRequestSelectCols + `
 		FROM change_requests WHERE organization_id = $1 AND deleted_at IS NULL`

--- a/internal/isms/db/overdue.go
+++ b/internal/isms/db/overdue.go
@@ -298,7 +298,7 @@ func (d *DB) CreateOverdueReviewTasks(ctx context.Context, orgID int, createdBy 
 	}
 
 	// Load existing open review tasks to deduplicate.
-	existingTasks, err := d.ListTasksWhere(ctx, orgID, "status NOT IN ('done','cancelled')", 1000)
+	existingTasks, err := d.ListTasksWhere(ctx, orgID, TaskViewer{CanSeeAll: true}, "status NOT IN ('done','cancelled')", 1000)
 	if err != nil {
 		existingTasks = nil
 	}

--- a/internal/isms/db/tasks.go
+++ b/internal/isms/db/tasks.go
@@ -37,7 +37,7 @@ var taskSortable = map[string]string{
 }
 
 const taskSelectCols = `t.id, t.organization_id, t.identifier, t.title, COALESCE(t.description,''), t.task_type,
-	(SELECT email FROM users WHERE id = t.assignee_id), t.created_by, t.status, t.priority, t.due_date, t.completed_at, t.recurrence_days, COALESCE(t.notes,''), t.created_at, t.updated_at`
+	(SELECT email FROM users WHERE id = t.assignee_id), t.created_by, t.status, t.priority, t.due_date, t.completed_at, t.recurrence_days, COALESCE(t.notes,''), t.created_at, t.updated_at, t.private`
 
 // Task represents a work item in the ISMS.
 type Task struct {
@@ -57,6 +57,27 @@ type Task struct {
 	Notes          string `json:"notes,omitempty"`
 	CreatedAt      Epoch  `json:"created_at"`
 	UpdatedAt      Epoch  `json:"updated_at"`
+	Private        bool   `json:"private"`
+}
+
+// TaskViewer scopes task reads under the privacy rule: managers/admins (CanSeeAll)
+// see every task; everyone else sees public tasks plus their own (assigned or
+// created). A zero TaskViewer{} sees only public tasks — callers that must see
+// everything (system/rollup jobs) pass TaskViewer{CanSeeAll: true}.
+type TaskViewer struct {
+	Email     string
+	CanSeeAll bool
+}
+
+// visibilityClause returns an AND-predicate (leading space) restricting tasks to
+// what the viewer may see, using placeholder $n, plus the arg to append. Returns
+// ("", nil) when the viewer may see everything, so existing queries are unchanged.
+func (v TaskViewer) visibilityClause(n int) (string, []interface{}) {
+	if v.CanSeeAll {
+		return "", nil
+	}
+	return fmt.Sprintf(` AND (t.private = false OR t.created_by = $%d OR t.assignee_id = (SELECT id FROM users WHERE email = $%d))`, n, n),
+		[]interface{}{v.Email}
 }
 
 func (d *DB) FindTaskByTitle(ctx context.Context, orgID int, title string) (*Task, error) {
@@ -76,15 +97,15 @@ func (d *DB) CreateTask(ctx context.Context, orgID int, t *Task) error {
 	}
 	t.Identifier = ident
 	return d.pool.QueryRow(ctx, `
-		INSERT INTO tasks (organization_id, identifier, title, description, task_type, assignee_id, created_by, created_by_user_id, status, priority, due_date, recurrence_days, notes)
-		VALUES ($1, $2, $3, $4, $5, (SELECT id FROM users WHERE email = $6), $7, (SELECT id FROM users WHERE email = $7), $8, $9, $10, $11, $12)
+		INSERT INTO tasks (organization_id, identifier, title, description, task_type, assignee_id, created_by, created_by_user_id, status, priority, due_date, recurrence_days, notes, private)
+		VALUES ($1, $2, $3, $4, $5, (SELECT id FROM users WHERE email = $6), $7, (SELECT id FROM users WHERE email = $7), $8, $9, $10, $11, $12, $13)
 		RETURNING id, created_at, updated_at
 	`, orgID, t.Identifier, t.Title, t.Description, t.TaskType,
-		t.Assignee, t.CreatedBy, t.Status, t.Priority, t.DueDate, t.RecurrenceDays, nilIfEmpty(t.Notes),
+		t.Assignee, t.CreatedBy, t.Status, t.Priority, t.DueDate, t.RecurrenceDays, nilIfEmpty(t.Notes), t.Private,
 	).Scan(&t.ID, &t.CreatedAt, &t.UpdatedAt)
 }
 
-func (d *DB) ListTasks(ctx context.Context, orgID int, assignee, status string, limit int) ([]Task, error) {
+func (d *DB) ListTasks(ctx context.Context, orgID int, viewer TaskViewer, assignee, status string, limit int) ([]Task, error) {
 	query := `SELECT ` + taskSelectCols + `
 		FROM tasks t WHERE t.organization_id = $1 AND t.deleted_at IS NULL`
 	args := []interface{}{orgID}
@@ -98,6 +119,11 @@ func (d *DB) ListTasks(ctx context.Context, orgID int, assignee, status string, 
 		n++
 		query += fmt.Sprintf(` AND t.status = $%d`, n)
 		args = append(args, status)
+	}
+	if clause, cargs := viewer.visibilityClause(n + 1); clause != "" {
+		n++
+		query += clause
+		args = append(args, cargs...)
 	}
 	query += ` ORDER BY CASE t.priority WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'medium' THEN 3 ELSE 4 END, t.due_date ASC NULLS LAST`
 	if limit > 0 {
@@ -115,7 +141,7 @@ func (d *DB) ListTasks(ctx context.Context, orgID int, assignee, status string, 
 		var t Task
 		if err := rows.Scan(&t.ID, &t.OrganizationID, &t.Identifier, &t.Title, &t.Description, &t.TaskType,
 			&t.Assignee, &t.CreatedBy, &t.Status, &t.Priority, &t.DueDate, &t.CompletedAt, &t.RecurrenceDays,
-			&t.Notes, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			&t.Notes, &t.CreatedAt, &t.UpdatedAt, &t.Private); err != nil {
 			return nil, err
 		}
 		tasks = append(tasks, t)
@@ -151,10 +177,11 @@ func (d *DB) UpdateTask(ctx context.Context, orgID int, t *Task) error {
 				ELSE completed_at
 			END,
 			notes = $9,
+			private = $11,
 			updated_at = now()
 		WHERE id = $1 AND organization_id = $10 AND deleted_at IS NULL
 	`, t.ID, t.Title, nilIfEmpty(t.Description), t.Assignee,
-		t.Priority, t.DueDate, t.TaskType, t.Status, nilIfEmpty(t.Notes), orgID)
+		t.Priority, t.DueDate, t.TaskType, t.Status, nilIfEmpty(t.Notes), orgID, t.Private)
 	return err
 }
 
@@ -172,6 +199,7 @@ func (t *Task) ToChangeMap() map[string]string {
 		"status":      t.Status,
 		"task_type":   t.TaskType,
 		"notes":       t.Notes,
+		"private":     fmt.Sprintf("%t", t.Private),
 	}
 	if t.DueDate != nil {
 		m["due_date"] = t.DueDate.Format("2006-01-02")
@@ -186,7 +214,7 @@ func (d *DB) GetTask(ctx context.Context, orgID int, id int64) (*Task, error) {
 		FROM tasks t WHERE t.id = $1 AND t.organization_id = $2 AND t.deleted_at IS NULL
 	`, id, orgID).Scan(&t.ID, &t.OrganizationID, &t.Identifier, &t.Title, &t.Description, &t.TaskType,
 		&t.Assignee, &t.CreatedBy, &t.Status, &t.Priority, &t.DueDate, &t.CompletedAt, &t.RecurrenceDays,
-		&t.Notes, &t.CreatedAt, &t.UpdatedAt)
+		&t.Notes, &t.CreatedAt, &t.UpdatedAt, &t.Private)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +231,7 @@ func (d *DB) GetTaskByIdentifier(ctx context.Context, orgID int, identifier stri
 		FROM tasks t WHERE t.identifier = $1 AND t.organization_id = $2 AND t.deleted_at IS NULL
 	`, identifier, orgID).Scan(&t.ID, &t.OrganizationID, &t.Identifier, &t.Title, &t.Description, &t.TaskType,
 		&t.Assignee, &t.CreatedBy, &t.Status, &t.Priority, &t.DueDate, &t.CompletedAt, &t.RecurrenceDays,
-		&t.Notes, &t.CreatedAt, &t.UpdatedAt)
+		&t.Notes, &t.CreatedAt, &t.UpdatedAt, &t.Private)
 	if err != nil {
 		return nil, err
 	}
@@ -211,15 +239,18 @@ func (d *DB) GetTaskByIdentifier(ctx context.Context, orgID int, identifier stri
 }
 
 // OverdueTasks returns tasks past their due date that aren't done/cancelled.
-func (d *DB) OverdueTasks(ctx context.Context, orgID int) ([]Task, error) {
-	return d.ListTasksWhere(ctx, orgID, `status NOT IN ('done','cancelled') AND due_date < now()`, 100)
+func (d *DB) OverdueTasks(ctx context.Context, orgID int, viewer TaskViewer) ([]Task, error) {
+	return d.ListTasksWhere(ctx, orgID, viewer, `status NOT IN ('done','cancelled') AND due_date < now()`, 100)
 }
 
-func (d *DB) ListTasksWhere(ctx context.Context, orgID int, where string, limit int) ([]Task, error) {
+func (d *DB) ListTasksWhere(ctx context.Context, orgID int, viewer TaskViewer, where string, limit int) ([]Task, error) {
+	args := []interface{}{orgID}
+	vis, vargs := viewer.visibilityClause(2)
+	args = append(args, vargs...)
 	query := fmt.Sprintf(`SELECT `+taskSelectCols+`
-		FROM tasks t WHERE t.organization_id = $1 AND t.deleted_at IS NULL AND %s ORDER BY t.due_date ASC NULLS LAST LIMIT %d`, where, limit)
+		FROM tasks t WHERE t.organization_id = $1 AND t.deleted_at IS NULL AND %s%s ORDER BY t.due_date ASC NULLS LAST LIMIT %d`, where, vis, limit)
 
-	rows, err := d.pool.Query(ctx, query, orgID)
+	rows, err := d.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +261,7 @@ func (d *DB) ListTasksWhere(ctx context.Context, orgID int, where string, limit 
 		var t Task
 		if err := rows.Scan(&t.ID, &t.OrganizationID, &t.Identifier, &t.Title, &t.Description, &t.TaskType,
 			&t.Assignee, &t.CreatedBy, &t.Status, &t.Priority, &t.DueDate, &t.CompletedAt, &t.RecurrenceDays,
-			&t.Notes, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			&t.Notes, &t.CreatedAt, &t.UpdatedAt, &t.Private); err != nil {
 			return nil, err
 		}
 		tasks = append(tasks, t)
@@ -279,7 +310,7 @@ func (d *DB) TaskStats(ctx context.Context, orgID int) (*TaskStats, error) {
 }
 
 // PaginatedTasks returns a filtered/sorted/paginated slice of tasks plus total count.
-func (d *DB) PaginatedTasks(ctx context.Context, orgID int, p TaskListParams) ([]Task, int, error) {
+func (d *DB) PaginatedTasks(ctx context.Context, orgID int, viewer TaskViewer, p TaskListParams) ([]Task, int, error) {
 	if p.Page < 1 {
 		p.Page = 1
 	}
@@ -322,6 +353,11 @@ func (d *DB) PaginatedTasks(ctx context.Context, orgID int, p TaskListParams) ([
 		args = append(args, p.Assignee)
 		idx++
 	}
+	if clause, cargs := viewer.visibilityClause(idx); clause != "" {
+		where += clause
+		args = append(args, cargs...)
+		idx++
+	}
 
 	var total int
 	if err := d.pool.QueryRow(ctx, `SELECT count(*) FROM tasks t`+where, args...).Scan(&total); err != nil {
@@ -358,7 +394,7 @@ func (d *DB) PaginatedTasks(ctx context.Context, orgID int, p TaskListParams) ([
 		var t Task
 		if err := rows.Scan(&t.ID, &t.OrganizationID, &t.Identifier, &t.Title, &t.Description, &t.TaskType,
 			&t.Assignee, &t.CreatedBy, &t.Status, &t.Priority, &t.DueDate, &t.CompletedAt, &t.RecurrenceDays,
-			&t.Notes, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			&t.Notes, &t.CreatedAt, &t.UpdatedAt, &t.Private); err != nil {
 			return nil, 0, err
 		}
 		tasks = append(tasks, t)

--- a/internal/isms/db/tasks_visibility_test.go
+++ b/internal/isms/db/tasks_visibility_test.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTaskViewerVisibilityClause is the core of task privacy on the read side:
+// managers/admins (CanSeeAll) get no restriction, everyone else gets a predicate
+// that only lets through public tasks plus their own (assigned or created). A bug
+// here is a data-leak (too permissive) or a black-hole (too restrictive).
+func TestTaskViewerVisibilityClause(t *testing.T) {
+	// CanSeeAll → no predicate, no args → existing queries are byte-for-byte
+	// unchanged, so managers/admins see every task.
+	if clause, args := (TaskViewer{Email: "m@x.io", CanSeeAll: true}).visibilityClause(3); clause != "" || args != nil {
+		t.Errorf("CanSeeAll viewer: got clause=%q args=%v, want empty/nil", clause, args)
+	}
+
+	// Restricted viewer → predicate on the given placeholder, email bound once.
+	clause, args := TaskViewer{Email: "u@x.io"}.visibilityClause(4)
+	if clause == "" {
+		t.Fatal("restricted viewer: expected a predicate, got empty")
+	}
+	for _, want := range []string{"t.private = false", "t.created_by = $4", "email = $4"} {
+		if !strings.Contains(clause, want) {
+			t.Errorf("predicate missing %q: %s", want, clause)
+		}
+	}
+	if len(args) != 1 || args[0] != "u@x.io" {
+		t.Errorf("args = %v, want [u@x.io] (email bound exactly once)", args)
+	}
+}

--- a/migrations/20260713000000_v0.7.1.sql
+++ b/migrations/20260713000000_v0.7.1.sql
@@ -20,3 +20,18 @@ ALTER TABLE suppliers DROP CONSTRAINT IF EXISTS suppliers_supplier_type_check;
 ALTER TABLE suppliers ADD CONSTRAINT suppliers_supplier_type_check
     CHECK (supplier_type IN ('cloud', 'saas', 'consulting', 'hosting',
         'infrastructure', 'software', 'contractor', 'other'));
+
+-- Task visibility: per-task privacy flag. PUBLIC by default, so existing tasks
+-- and existing deployments are unchanged. When true, a task is visible only to
+-- its assignee, its creator, and managers/admins — enforced in the API task read
+-- paths (NOT via RLS). Org setting `task_default_private` decides the value for
+-- new tasks when a create request omits it.
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS private BOOLEAN NOT NULL DEFAULT false;
+
+-- Org default for new-task visibility, surfaced in Admin -> Settings. The
+-- settings UI is catalog-driven and renders this as a boolean toggle because
+-- default_value is 'true'/'false'. Public by default; an org opts into privacy
+-- by flipping this. Idempotent so a re-run / fresh DB both behave.
+INSERT INTO settings (key, description, category, default_value, sensitive) VALUES
+    ('task_default_private', 'New tasks default to private (visible only to the assignee, creator, and managers)', 'tasks', 'false', false)
+ON CONFLICT (key) DO NOTHING;

--- a/tests/test_suggestion_apply_identifier.py
+++ b/tests/test_suggestion_apply_identifier.py
@@ -1,0 +1,107 @@
+"""Regression (#177): applying an *update* suggestion whose entity_id is the
+per-org IDENTIFIER form (CR-n / SYSTEM-n / ASSET-n / objective display_id) must
+resolve to the correct row via lookup — not by stripping the prefix to an int.
+
+The identifier suffix is a per-org sequence, which on a shared/persistent stack
+differs from the global primary key. applyChange/Objective/System/AssetUpdate
+used to do `parseEntityID` (strip → int) and then GetX(thatInt), so an
+identifier-form suggestion silently hit the wrong row (or 'not found'). They now
+resolve via GetXByIdentifier / GetObjectiveByDisplayID (mirrors #174 for
+task/incident/CA).
+
+force=true on apply bypasses stale-detection (a fresh entity's own create
+changelog would otherwise flag it), so the resolve/apply path is what's exercised.
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL
+
+
+def _apply_update_by(api_url, headers, entity_type, entity_ref, fields):
+    """Create + apply an update suggestion addressing the entity by entity_ref
+    (here: its identifier form). Asserts the apply itself succeeds."""
+    sg = requests.post(f"{api_url}/suggestions", headers=headers, json={
+        "entity_type": entity_type,
+        "suggestion_type": "update",
+        "entity_id": str(entity_ref),
+        "title": "identifier-resolve regression",
+        "rationale": "#177",
+        "payload": {"fields": fields},
+    })
+    assert sg.status_code in (200, 201), f"create suggestion ({entity_type}): {sg.text}"
+    ap = requests.post(f"{api_url}/suggestions/{sg.json()['id']}/apply",
+                       headers=headers, json={"force": True})
+    assert ap.status_code == 200 and ap.json().get("status") == "applied", \
+        f"apply by identifier must resolve+succeed ({entity_type}, ref={entity_ref}): {ap.status_code} {ap.text}"
+
+
+def test_change_update_by_identifier(api_url, admin_headers):
+    r = requests.post(f"{api_url}/changes", headers=admin_headers, json={
+        "title": f"chg-{uuid.uuid4().hex[:8]}", "description": "d", "justification": "j",
+        "priority": "high", "category": "technology", "risk_level": "medium",
+        "rollback_plan": "revert",
+    })
+    assert r.status_code in (200, 201), r.text
+    cr = r.json()
+    assert cr["identifier"].startswith("CR-"), cr
+
+    _apply_update_by(api_url, admin_headers, "change_request", cr["identifier"], {"priority": "low"})
+
+    got = requests.get(f"{api_url}/changes/{cr['id']}", headers=admin_headers).json()
+    assert got.get("priority") == "low", f"identifier-form apply hit the wrong change: {got}"
+
+
+def test_system_update_by_identifier(api_url, admin_headers):
+    r = requests.post(f"{api_url}/systems", headers=admin_headers, json={
+        "name": f"sys-{uuid.uuid4().hex[:8]}", "classification": "internal", "criticality": "low",
+    })
+    assert r.status_code in (200, 201), r.text
+    sys = r.json()
+    assert sys["identifier"].startswith("SYSTEM-"), sys
+    new_name = f"sys-renamed-{uuid.uuid4().hex[:8]}"
+
+    _apply_update_by(api_url, admin_headers, "system", sys["identifier"], {"name": new_name})
+
+    got = requests.get(f"{api_url}/systems/{sys['id']}", headers=admin_headers).json()
+    assert got.get("name") == new_name, f"identifier-form apply hit the wrong system: {got}"
+
+
+def test_asset_update_by_identifier(api_url, admin_headers):
+    r = requests.post(f"{api_url}/assets", headers=admin_headers, json={
+        "name": f"ast-{uuid.uuid4().hex[:8]}", "asset_type": "system", "status": "open",
+        "confidentiality": 3, "integrity": 3, "availability": 3,
+    })
+    assert r.status_code in (200, 201), r.text
+    asset = r.json()
+    assert asset["identifier"].startswith("ASSET-"), asset
+    new_name = f"ast-renamed-{uuid.uuid4().hex[:8]}"
+
+    _apply_update_by(api_url, admin_headers, "asset", asset["identifier"], {"name": new_name})
+
+    got = requests.get(f"{api_url}/assets/{asset['id']}", headers=admin_headers).json()
+    assert got.get("name") == new_name, f"identifier-form apply hit the wrong asset: {got}"
+
+
+def test_objective_update_by_display_id(api_url, admin_headers):
+    # Objectives need a programme; its display_id (e.g. SEC2026-1) is the identifier form.
+    requests.post(f"{api_url}/programs", headers=admin_headers, json={
+        "title": "Sec Programme", "owner": ADMIN_EMAIL, "key": "SEC2026",
+    })
+    progs = requests.get(f"{api_url}/programs", headers=admin_headers).json().get("data") or []
+    assert progs, "need at least one programme to create an objective"
+
+    r = requests.post(f"{api_url}/objectives", headers=admin_headers, json={
+        "program_id": progs[0]["id"], "title": f"obj-{uuid.uuid4().hex[:8]}",
+        "owner": ADMIN_EMAIL, "target_value": 5.0, "target_operator": "lte", "unit": "%",
+    })
+    assert r.status_code in (200, 201), r.text
+    obj = r.json()
+    display_id = obj.get("display_id")
+    assert display_id, f"objective response missing display_id: {obj}"
+    new_title = f"obj-renamed-{uuid.uuid4().hex[:8]}"
+
+    _apply_update_by(api_url, admin_headers, "objective", display_id, {"title": new_title})
+
+    got = requests.get(f"{api_url}/objectives/{obj['id']}", headers=admin_headers).json()
+    assert got.get("title") == new_title, f"display_id apply hit the wrong objective: {got}"

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -53,6 +53,13 @@
               <option value="other">Other</option>
             </select>
           </div>
+          <div>
+            <label class="block text-xs text-slate-500 mb-1">Visibility</label>
+            <select v-model="form.private" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
+              <option :value="false">Public — everyone in the org</option>
+              <option :value="true">Private — assignee, creator &amp; managers</option>
+            </select>
+          </div>
         </div>
         <div class="text-[10px] text-slate-600 mt-1">You can add description, assignee, due date and notes after creating.</div>
         <div class="flex gap-2 pt-2">
@@ -135,6 +142,7 @@
                 <StatusBadge :status="task.status" />
                 <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(task.priority)">{{ task.priority }}</span>
                 <span v-if="task.task_type && task.task_type !== 'general'" class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ task.task_type.replace(/_/g, ' ') }}</span>
+                <span v-if="task.private" class="px-1.5 py-0.5 rounded text-[10px] font-medium text-amber-300 bg-amber-500/10" title="Private — visible to assignee, creator &amp; managers">Private</span>
               </div>
               <div class="text-xs text-slate-500 mt-1">
                 <span v-if="task.assignee">{{ resolveUserName(task.assignee) }}</span>
@@ -451,6 +459,9 @@ const creating = ref(false)
 const generating = ref(false)
 const genResult = ref(null)
 const userRole = ref('')
+// Org default for a new task's visibility (task_default_private) — seeds the
+// create form's Public/Private control so a privacy-by-default org gets it right.
+const orgDefaultPrivate = ref(false)
 
 // Tab-based detail state
 const detailTab = ref('overview')
@@ -484,7 +495,7 @@ function defaultDueDate() {
   return d.toISOString().slice(0, 10)
 }
 function defaultForm() {
-  return { title: '', priority: 'medium', task_type: 'general' }
+  return { title: '', priority: 'medium', task_type: 'general', private: orgDefaultPrivate.value }
 }
 const form = ref(defaultForm())
 
@@ -615,6 +626,7 @@ async function create() {
       title: form.value.title,
       priority: form.value.priority,
       task_type: form.value.task_type,
+      private: form.value.private,
     }
     // Source links come from quick-action query params; the same info also seeds
     // a one-line markdown reference into Notes so the source is visible inline
@@ -811,6 +823,7 @@ onMounted(async () => {
     currentUserEmail.value = me?.email || ''
   } catch {}
   try { orgMembers.value = await api.getUsers() || [] } catch { orgMembers.value = [] }
+  try { const cfg = await api.getConfig(); orgDefaultPrivate.value = !!cfg?.task_default_private } catch { /* keep public default */ }
   await loadTasks()
   if (route.params.id) await openTaskFromRoute(route.params.id)
 


### PR DESCRIPTION
Closes #177

## What
Suggestion-**apply** now resolves the target entity by lookup for **change / objective / system / asset**, so an update suggestion addressing an entity by its per-org **identifier form** lands on the right row.

## Why
`applyChange/Objective/System/AssetUpdate` did `parseEntityID(sg.EntityID)` (strip prefix → int) then `GetX(thatInt)`. The identifier suffix is a **per-org sequence, not the primary key** — on a shared/persistent stack they differ, so an identifier-form suggestion (`CR-n`, `SYSTEM-n`, `ASSET-n`, objective `display_id`) silently updated the **wrong entity**, or errored "not found". This is the same class of bug #174 fixed for task / incident / corrective_action.

## How
- New `resolveChangeID` / `resolveObjectiveID` / `resolveSystemID` / `resolveAssetID`: numeric → id; otherwise look up (`GetChangeRequestByIdentifier` [new] / `GetObjectiveByDisplayID` / `GetSystemByIdentifier` / `GetAssetByIdentifier`). They deliberately skip a fixed-prefix check — asset ids exist as `ASSET-`/`AST-`, systems as `SYSTEM-`, and objective identifiers are program-key display IDs (e.g. `ISMS-1`), so a hardcoded prefix would be wrong.
- The four apply handlers resolve via those helpers instead of `parseEntityID`.

## Testing
- `tests/test_suggestion_apply_identifier.py`: for each of the four types, create it, apply an update addressing it **by its identifier form**, assert the correct row changed (`force=true` to bypass stale-detection).
- `just fmt`, `just build-go`, `just test-go` pass. The Python test runs against the stack (integration).

## Noted, not fixed here
The stale-detection path (`parseEntityID` at the top of the apply/get flow) has the same mis-resolution for these types, but it only affects staleness-warning accuracy, not which row is mutated — separate follow-up if we want it.