### PR TITLE
feat(suggestions): 'Suggested by' label on suggestion lists (#168)

### DIFF
--- a/web/src/components/SuggestionPanel.vue
+++ b/web/src/components/SuggestionPanel.vue
@@ -20,7 +20,7 @@
           <span v-if="sg.suggested_by_type === 'agent'" class="px-1 py-0.5 rounded text-[9px] bg-purple-500/15 text-purple-400">AI</span>
         </div>
         <div v-if="sg.rationale" class="text-sm text-slate-500">{{ sg.rationale }}</div>
-        <div class="text-[10px] text-slate-600">{{ sg.suggested_by }} · {{ formatDate(sg.created_at) }}</div>
+        <div class="text-[10px] text-slate-600">Suggested by {{ sg.suggested_by }}<span v-if="sg.suggested_by_type === 'agent'"> (AI)</span> · {{ formatDate(sg.created_at) }}</div>
 
         <!-- Actions -->
         <div v-if="canReview && sg.status === 'open'" class="flex items-center gap-1.5 pt-1">

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -664,7 +664,7 @@
                 </div>
                 <div class="text-sm text-slate-300 mt-0.5">{{ sg.title }}</div>
                 <div class="text-xs text-slate-500 mt-1">
-                  {{ sg.suggested_by?.split('@')[0] }} &middot; {{ formatDate(sg.created_at) }}
+                  Suggested by {{ sg.suggested_by?.split('@')[0] }} &middot; {{ formatDate(sg.created_at) }}
                 </div>
               </div>
               <!-- Actions -->


### PR DESCRIPTION
Closes #168

## What
An explicit **"Suggested by"** label on the creator line of suggestions.

## Why / status
Assessed the issue: suggestions are shown in exactly two places — the per-entity **SuggestionPanel** (used by all 11 modules) and the **Inbox** — and both already surfaced the creator (`suggested_by`) and human-vs-agent (a purple **AI** badge). So the data was there, but the creator line was a bare email/name with no label. This adds the literal **"Suggested by"** prefix so the attribution reads clearly "at a glance" per the issue.

## How
Display-only: prefix the creator line with "Suggested by" in `SuggestionPanel` and `Inbox` (panel also appends "(AI)" for agent suggestions). No API change — the data already exists.

## Testing
`just build-web` passes.