### PR TITLE
feat(ui): identifier deep-links + copy-link button on all modules (#166)

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2505,11 +2505,13 @@ func (s *Server) handleChangeStats(c echo.Context) error {
 
 func (s *Server) handleGetChange(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.Atoi(c.Param("id"))
+	// Accept the numeric id OR the identifier (CR-12) so deep-links resolve for
+	// off-page items too (#166 review). resolveChangeID returns int64 → cast.
+	id, err := s.resolveChangeID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid change id")
+		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
 	}
-	cr, err := s.db.GetChangeRequest(c.Request().Context(), orgID, id)
+	cr, err := s.db.GetChangeRequest(c.Request().Context(), orgID, int(id))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
 	}

--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -375,9 +375,11 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 
 func (s *Server) handleGetObjective(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	// Accept the numeric id OR the display_id (e.g. "SEC2026-1") so identifier
+	// deep-links resolve for off-page objectives too (#166).
+	id, err := s.resolveObjectiveID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
 	}
 	o, err := s.db.GetObjective(c.Request().Context(), orgID, id)
 	if err != nil {

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1852,9 +1852,11 @@ func (s *Server) handleAssetStats(c echo.Context) error {
 
 func (s *Server) handleGetAsset(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	// Accept the numeric id OR the identifier (ASSET-7) so deep-links resolve for
+	// off-page items too (#166 review).
+	id, err := s.resolveAssetID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return echo.NewHTTPError(http.StatusNotFound, "asset not found")
 	}
 	a, err := s.db.GetAsset(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -1980,9 +1982,11 @@ func (s *Server) handleSystemStats(c echo.Context) error {
 
 func (s *Server) handleGetSystem(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	// Resolve via DB lookup (not prefix-strip) so SYSTEM-5 maps to the row whose
+	// identifier is SYSTEM-5, not row id 5, if the per-org seq has drifted (#166 review).
+	id, err := s.resolveSystemID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return echo.NewHTTPError(http.StatusNotFound, "system not found")
 	}
 	sys, err := s.db.GetSystem(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -2050,9 +2054,11 @@ func (s *Server) handleCreateSystem(c echo.Context) error {
 
 func (s *Server) handleGetRisk(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	// Accept the numeric id OR the identifier (RISK-3) so deep-links resolve for
+	// off-page items too (#166 review).
+	id, err := s.resolveRiskID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return echo.NewHTTPError(http.StatusNotFound, "risk not found")
 	}
 	r, err := s.db.GetRisk(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -2380,9 +2386,11 @@ func (s *Server) handleSupplierStats(c echo.Context) error {
 
 func (s *Server) handleGetSupplier(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	// Resolve via DB lookup (not prefix-strip) so SUPPLIER-8 maps to the right row
+	// even if the per-org seq has drifted from the primary key (#166 review).
+	id, err := s.resolveSupplierID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return echo.NewHTTPError(http.StatusNotFound, "supplier not found")
 	}
 	sup, err := s.db.GetSupplier(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -3265,6 +3273,28 @@ func (s *Server) resolveAssetID(ctx context.Context, orgID int, param string) (i
 		return 0, err
 	}
 	return a.ID, nil
+}
+
+func (s *Server) resolveRiskID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	r, err := s.db.GetRiskByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return r.ID, nil
+}
+
+func (s *Server) resolveSupplierID(ctx context.Context, orgID int, param string) (int64, error) {
+	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return n, nil
+	}
+	sup, err := s.db.GetSupplierByIdentifier(ctx, orgID, param)
+	if err != nil {
+		return 0, err
+	}
+	return sup.ID, nil
 }
 
 // extractHostname parses a URL and returns just the hostname (no port).

--- a/tests/test_deep_link_get_by_identifier.py
+++ b/tests/test_deep_link_get_by_identifier.py
@@ -1,0 +1,46 @@
+"""#166 review (#185): GET /<module>/<identifier> must resolve the same record as
+the numeric id, so identifier deep-links work for off-page items (fresh tab /
+shared link / reload). The frontend now sends raw identifiers (RISK-3, ASSET-7,
+CR-12, SYSTEM-5, SUPPLIER-8) to these GET handlers, which were numeric-only
+(asset/risk/change) or prefix-stripping (system/supplier); they now route through
+resolveXID DB lookups.
+"""
+import uuid
+
+import pytest
+import requests
+
+ENTITIES = [
+    {"name": "risk", "path": "risks", "field": "title", "create": {}},
+    {"name": "asset", "path": "assets", "field": "name",
+     "create": {"asset_type": "system", "status": "open",
+                "confidentiality": 3, "integrity": 3, "availability": 3}},
+    {"name": "change", "path": "changes", "field": "title",
+     "create": {"description": "d", "justification": "j", "priority": "high",
+                "category": "technology", "risk_level": "medium", "rollback_plan": "revert"}},
+    {"name": "system", "path": "systems", "field": "name",
+     "create": {"classification": "internal", "criticality": "low"}},
+    {"name": "supplier", "path": "suppliers", "field": "name",
+     "create": {"supplier_type": "saas", "criticality": "low"}},
+]
+
+
+@pytest.mark.parametrize("cfg", ENTITIES, ids=[e["name"] for e in ENTITIES])
+def test_get_by_identifier_resolves_same_record(cfg, api_url, admin_headers):
+    path = cfg["path"]
+    payload = dict(cfg["create"])
+    payload[cfg["field"]] = f"idurl-{cfg['name']}-{uuid.uuid4().hex[:8]}"
+
+    r = requests.post(f"{api_url}/{path}", headers=admin_headers, json=payload)
+    assert r.status_code in (200, 201), f"create {cfg['name']}: {r.text}"
+    ent = r.json()
+    num_id, ident = ent["id"], ent["identifier"]
+    assert ident, f"{cfg['name']} must have an identifier"
+
+    by_num = requests.get(f"{api_url}/{path}/{num_id}", headers=admin_headers)
+    by_ident = requests.get(f"{api_url}/{path}/{ident}", headers=admin_headers)
+    assert by_num.status_code == 200, by_num.text
+    assert by_ident.status_code == 200, \
+        f"GET /{path}/{ident} must resolve by identifier (#185): {by_ident.status_code} {by_ident.text}"
+    assert by_ident.json()["id"] == num_id, \
+        f"identifier and numeric id must resolve the same {cfg['name']} row"

--- a/tests/test_objective_display_id_url.py
+++ b/tests/test_objective_display_id_url.py
@@ -1,0 +1,32 @@
+"""#166: GET /objectives/<display_id> resolves the same objective as the numeric
+id, so identifier deep-links work for off-page objectives too. handleGetObjective
+was strconv.ParseInt (numeric-only); it now routes through resolveObjectiveID
+(the same helper suggestion-apply uses), which accepts the display_id form.
+"""
+import uuid
+
+import requests
+from conftest import ADMIN_EMAIL
+
+
+def test_objective_get_by_display_id(api_url, admin_headers):
+    # Ensure a programme exists (objectives require one; display_id = <key>-<seq>).
+    requests.post(f"{api_url}/programs", headers=admin_headers, json={
+        "title": "Sec Programme", "owner": ADMIN_EMAIL, "key": "SEC2026"})
+    progs = requests.get(f"{api_url}/programs", headers=admin_headers).json().get("data") or []
+    assert progs, "need at least one programme"
+
+    r = requests.post(f"{api_url}/objectives", headers=admin_headers, json={
+        "program_id": progs[0]["id"], "title": f"obj-{uuid.uuid4().hex[:8]}",
+        "owner": ADMIN_EMAIL, "target_value": 5.0, "target_operator": "lte", "unit": "%"})
+    assert r.status_code in (200, 201), r.text
+    obj = r.json()
+    num_id, display_id = obj["id"], obj["display_id"]
+    assert display_id, "objective must have a display_id"
+
+    by_num = requests.get(f"{api_url}/objectives/{num_id}", headers=admin_headers)
+    by_disp = requests.get(f"{api_url}/objectives/{display_id}", headers=admin_headers)
+    assert by_num.status_code == 200, by_num.text
+    assert by_disp.status_code == 200, \
+        f"GET /objectives/{display_id} must resolve by display_id (#166): {by_disp.status_code} {by_disp.text}"
+    assert by_disp.json()["id"] == num_id, "display_id and numeric id must resolve the same objective"

--- a/web/src/components/CopyLinkButton.vue
+++ b/web/src/components/CopyLinkButton.vue
@@ -1,0 +1,53 @@
+<template>
+  <button
+    type="button"
+    @click="copy"
+    :title="copied ? 'Link copied' : 'Copy link to this item'"
+    :aria-label="copied ? 'Link copied' : 'Copy link to this item'"
+    class="p-1 rounded-lg transition-colors"
+    :class="copied ? 'text-emerald-400' : 'text-slate-600 hover:text-slate-300 hover:bg-slate-800'"
+  >
+    <svg v-if="!copied" class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5m6.828-6.828l1.5-1.5a4 4 0 015.656 5.656l-3 3a4 4 0 01-5.656 0" />
+    </svg>
+    <svg v-else class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  </button>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const copied = ref(false)
+
+function markCopied() {
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 1500)
+}
+
+// Copies the current page URL. After #166 a detail view's URL is the shareable
+// identifier deep-link (e.g. …/tasks/TASK-6), so "copy link" is just the href.
+// The Clipboard API needs a secure context (https / localhost); self-hosted
+// plain-http boxes fall back to execCommand so copy works everywhere — mirrors
+// the code-copy handler in App.vue.
+function copy() {
+  const url = window.location.href
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(url).then(markCopied).catch(() => {})
+    return
+  }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = url
+    ta.style.position = 'fixed'
+    ta.style.top = '-9999px'
+    document.body.appendChild(ta)
+    ta.focus()
+    ta.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    if (ok) markCopied()
+  } catch (_) { /* clipboard unavailable — no-op */ }
+}
+</script>

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -167,6 +167,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedItem.name }}</h2>
             </div>
             <div class="flex items-center gap-3 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedItem.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -408,6 +409,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -641,14 +643,13 @@ async function selectItem(item) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/assets/${item.id}`))
+  router.push(orgPath(`/assets/${item.identifier}`))
 }
 
 async function openItemFromRoute(id) {
-  const numId = parseInt(id)
-  let item = assets.value.find(a => a.id === numId || a.identifier === id)
+  let item = assets.value.find(a => a.identifier === id || String(a.id) === String(id))
   if (!item) {
-    try { item = await api.fetchJSON(`/api/v1/assets/${numId}`) } catch { return }
+    try { item = await api.fetchJSON(`/api/v1/assets/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!item) return
   selectedItem.value = item
@@ -743,7 +744,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedItem.value?.id === parseInt(id)) return
+  if (selectedItem.value && (selectedItem.value.identifier === id || String(selectedItem.value.id) === String(id))) return
   openItemFromRoute(id)
 })
 </script>

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -625,6 +625,7 @@
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedAudit.title }}</h2>
           </div>
           <div class="flex items-center gap-2 flex-shrink-0">
+            <CopyLinkButton />
             <StatusBadge :status="selectedAudit.status" />
             <button @click="closeAuditDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
               <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
@@ -961,6 +962,7 @@
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedFinding.title }}</h2>
           </div>
           <div class="flex items-center gap-2 flex-shrink-0">
+            <CopyLinkButton />
             <StatusBadge :status="selectedFinding.status" />
             <button @click="closeFindingDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
               <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
@@ -1134,6 +1136,7 @@ import { ref, reactive, computed, onMounted, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import StatStrip from '../components/StatStrip.vue'
 import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -146,6 +146,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedChange.title }}</h2>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedChange.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -411,6 +412,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import SuggestNewButton from '../components/SuggestNewButton.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -527,7 +529,7 @@ async function selectChange(cr) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/changes/${cr.id}`))
+  router.push(orgPath(`/changes/${cr.identifier}`))
 }
 
 async function switchDetailTab(key) {
@@ -717,10 +719,9 @@ async function saveSection() {
 }
 
 async function openChangeFromRoute(id) {
-  const numId = parseInt(id)
-  let cr = changes.value.find(c => c.id === numId || c.identifier === id)
+  let cr = changes.value.find(c => c.identifier === id || String(c.id) === String(id))
   if (!cr) {
-    try { cr = await api.fetchJSON(`/api/v1/changes/${numId}`) } catch { return }
+    try { cr = await api.fetchJSON(`/api/v1/changes/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!cr) return
   selectedChange.value = cr
@@ -736,7 +737,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedChange.value?.id === parseInt(id)) return
+  if (selectedChange.value && (selectedChange.value.identifier === id || String(selectedChange.value.id) === String(id))) return
   openChangeFromRoute(id)
 }, { immediate: false })
 

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -183,6 +183,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedCA.title }}</h2>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedCA.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -407,6 +408,7 @@ import StatStrip from '../components/StatStrip.vue'
 import RefreshButton from '../components/RefreshButton.vue'
 import EntityReferences from '../components/EntityReferences.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import SuggestNewButton from '../components/SuggestNewButton.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -552,7 +554,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedCA.value?.id === parseInt(id)) return
+  if (selectedCA.value && (selectedCA.value.identifier === id || String(selectedCA.value.id) === String(id))) return
   openCAFromRoute(id)
 })
 
@@ -624,10 +626,9 @@ function resolveUserName(email) {
 }
 
 async function openCAFromRoute(id) {
-  const numId = parseInt(id)
-  let ca = actions.value.find(a => a.id === numId || a.identifier === id)
+  let ca = actions.value.find(a => a.identifier === id || String(a.id) === String(id))
   if (!ca) {
-    try { ca = await api.fetchJSON(`/api/v1/corrective-actions/${numId}`) } catch { return }
+    try { ca = await api.fetchJSON(`/api/v1/corrective-actions/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!ca) return
   selectedCA.value = ca
@@ -752,7 +753,7 @@ async function selectCA(ca) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/corrective-actions/${ca.id}`))
+  router.push(orgPath(`/corrective-actions/${ca.identifier}`))
 }
 
 async function switchDetailTab(key) {

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -158,6 +158,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedIncident.title }}</h2>
             </div>
             <div class="flex items-center gap-3 flex-shrink-0">
+              <CopyLinkButton />
               <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full uppercase tracking-wider"
                 :class="severityClass(selectedIncident.severity)">
                 {{ selectedIncident.severity }}
@@ -525,6 +526,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import SuggestNewButton from '../components/SuggestNewButton.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -630,7 +632,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedIncident.value?.id === parseInt(id)) return
+  if (selectedIncident.value && (selectedIncident.value.identifier === id || String(selectedIncident.value.id) === String(id))) return
   openIncidentFromRoute(id)
 })
 
@@ -693,10 +695,9 @@ function resolveUserName(email) {
 }
 
 async function openIncidentFromRoute(id) {
-  const numId = parseInt(id)
-  let inc = incidents.value.find(i => i.id === numId || i.identifier === id)
+  let inc = incidents.value.find(i => i.identifier === id || String(i.id) === String(id))
   if (!inc) {
-    try { inc = await api.fetchJSON(`/api/v1/incidents/${numId}`) } catch { return }
+    try { inc = await api.fetchJSON(`/api/v1/incidents/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!inc) return
   selectedIncident.value = inc
@@ -830,7 +831,7 @@ async function selectIncident(inc) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/incidents/${inc.id}`))
+  router.push(orgPath(`/incidents/${inc.identifier}`))
 }
 
 async function switchDetailTab(key) {

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -196,6 +196,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedItem.title }}</h2>
             </div>
             <div class="flex items-center gap-3 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedItem.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -488,6 +489,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import HeatMap from '../components/HeatMap.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -724,15 +726,14 @@ async function selectItem(item) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/legal/${item.id}`))
+  router.push(orgPath(`/legal/${item.identifier}`))
 }
 
 async function openItemFromRoute(id) {
-  const numId = parseInt(id)
   // Try current page first; otherwise fetch the item directly so deep links work across pages
-  let item = items.value.find(i => i.id === numId || i.identifier === id)
+  let item = items.value.find(i => i.identifier === id || String(i.id) === String(id))
   if (!item) {
-    try { item = await api.fetchJSON(`/api/v1/legal/${numId}`) } catch { return }
+    try { item = await api.fetchJSON(`/api/v1/legal/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!item) return
   selectedItem.value = item
@@ -828,7 +829,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedItem.value?.id === parseInt(id)) return
+  if (selectedItem.value && (selectedItem.value.identifier === id || String(selectedItem.value.id) === String(id))) return
   openItemFromRoute(id)
 })
 </script>

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -174,6 +174,7 @@
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedObjective.title }}</h2>
           </div>
           <div class="flex items-center gap-2 flex-shrink-0">
+            <CopyLinkButton />
             <StatusBadge :status="selectedObjective.status" />
             <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
               <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -498,6 +499,7 @@ import StatStrip from '../components/StatStrip.vue'
 import RefreshButton from '../components/RefreshButton.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import SuggestNewButton from '../components/SuggestNewButton.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -706,7 +708,7 @@ async function selectObjective(o) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/objectives/${o.id}`))
+  router.push(orgPath(`/objectives/${o.display_id}`))
 }
 
 async function switchDetailTab(key) {
@@ -735,10 +737,9 @@ async function closeDetail() {
 }
 
 async function openObjectiveFromRoute(id) {
-  const numId = parseInt(id)
-  let obj = objectives.value.find(o => o.id === numId)
+  let obj = objectives.value.find(o => o.display_id === id || String(o.id) === String(id))
   if (!obj) {
-    try { obj = await api.fetchJSON(`/api/v1/objectives/${numId}`) } catch { return }
+    try { obj = await api.fetchJSON(`/api/v1/objectives/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!obj) return
   selectedObjective.value = obj
@@ -957,7 +958,7 @@ watch(() => route.params.objId, (objId) => {
     checkins.value = []
     return
   }
-  if (selectedObjective.value?.id === parseInt(objId)) return
+  if (selectedObjective.value && (selectedObjective.value.display_id === objId || String(selectedObjective.value.id) === String(objId))) return
   openObjectiveFromRoute(objId)
 })
 </script>

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -118,11 +118,14 @@
             <span class="text-[10px] font-mono uppercase tracking-wider text-blue-400 flex-shrink-0">{{ selected.key }}</span>
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selected.title }}</h2>
           </div>
-          <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
-            <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <CopyLinkButton />
+            <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
+              <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <!-- Body: sidebar nav + content -->
@@ -263,6 +266,7 @@ import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import SuggestNewButton from '../components/SuggestNewButton.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
@@ -364,7 +368,7 @@ async function fetchAll() {
 
 function selectProgram(p) {
   if (selected.value?.id === p.id) { closeDetail(); return }
-  router.push(orgPath(`/programs/${p.id}`))
+  router.push(orgPath(`/programs/${p.key}`))
 }
 
 function closeDetail() {
@@ -375,8 +379,7 @@ async function openFromRoute(id) {
   // id may be a numeric program id (register list links) or a program key like
   // "AWARE" (cross-entity reference chips link by key). Match either, and pass the
   // raw value to the API — the backend resolves id-or-key.
-  const numId = parseInt(id)
-  let p = programs.value.find(x => x.id === numId || x.key === id)
+  let p = programs.value.find(x => x.key === id || String(x.id) === String(id))
   if (!p) {
     try { p = await api.getProgram(id) } catch { return }
   }
@@ -465,7 +468,7 @@ onMounted(async () => {
 
 watch(() => route.params.id, (id) => {
   if (!id) { selected.value = null; editing.value = false; return }
-  if (selected.value?.id === parseInt(id)) return
+  if (selected.value && (selected.value.key === id || String(selected.value.id) === String(id))) return
   openFromRoute(id)
 })
 </script>

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -237,6 +237,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedRisk.title }}</h2>
             </div>
             <div class="flex items-center gap-3 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedRisk.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -712,6 +713,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import HeatMap from '../components/HeatMap.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -1020,14 +1022,13 @@ async function selectRisk(risk) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/risks/${risk.id}`))
+  router.push(orgPath(`/risks/${risk.identifier}`))
 }
 
 async function openRiskFromRoute(id) {
-  const numId = parseInt(id)
-  let risk = risks.value.find(r => r.id === numId || r.identifier === id)
+  let risk = risks.value.find(r => r.identifier === id || String(r.id) === String(id))
   if (!risk) {
-    try { risk = await api.fetchJSON(`/api/v1/risks/${numId}`) } catch { return }
+    try { risk = await api.fetchJSON(`/api/v1/risks/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!risk) return
   selectedRisk.value = risk
@@ -1233,7 +1234,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedRisk.value?.id === parseInt(id)) return
+  if (selectedRisk.value && (selectedRisk.value.identifier === id || String(selectedRisk.value.id) === String(id))) return
   openRiskFromRoute(id)
 })
 </script>

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -190,6 +190,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedItem.name }}</h2>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedItem.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -469,6 +470,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -754,14 +756,13 @@ async function selectItem(item) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/suppliers/${item.id}`))
+  router.push(orgPath(`/suppliers/${item.identifier}`))
 }
 
 async function openItemFromRoute(id) {
-  const numId = parseInt(id)
-  let item = suppliers.value.find(s => s.id === numId || s.identifier === id)
+  let item = suppliers.value.find(s => s.identifier === id || String(s.id) === String(id))
   if (!item) {
-    try { item = await api.fetchJSON(`/api/v1/suppliers/${numId}`) } catch { return }
+    try { item = await api.fetchJSON(`/api/v1/suppliers/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!item) return
   selectedItem.value = item
@@ -856,7 +857,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedItem.value?.id === parseInt(id)) return
+  if (selectedItem.value && (selectedItem.value.identifier === id || String(selectedItem.value.id) === String(id))) return
   openItemFromRoute(id)
 })
 </script>

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -196,6 +196,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedItem.name }}</h2>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedItem.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -516,6 +517,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
@@ -836,14 +838,13 @@ async function selectItem(item) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/systems/${item.id}`))
+  router.push(orgPath(`/systems/${item.identifier}`))
 }
 
 async function openItemFromRoute(id) {
-  const numId = parseInt(id)
-  let item = systems.value.find(s => s.id === numId || s.identifier === id)
+  let item = systems.value.find(s => s.identifier === id || String(s.id) === String(id))
   if (!item) {
-    try { item = await api.fetchJSON(`/api/v1/systems/${numId}`) } catch { return }
+    try { item = await api.fetchJSON(`/api/v1/systems/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!item) return
   selectedItem.value = item
@@ -944,7 +945,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedItem.value?.id === parseInt(id)) return
+  if (selectedItem.value && (selectedItem.value.identifier === id || String(selectedItem.value.id) === String(id))) return
   openItemFromRoute(id)
 })
 </script>

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -171,6 +171,7 @@
               <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedTask.title }}</h2>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
+              <CopyLinkButton />
               <StatusBadge :status="selectedTask.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                 <svg class="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -404,6 +405,7 @@ import RefreshButton from '../components/RefreshButton.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
+import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
 import CommentsPanel from '../components/CommentsPanel.vue'
 import SuggestNewButton from '../components/SuggestNewButton.vue'
@@ -547,7 +549,7 @@ async function selectTask(task) {
     closeDetail()
     return
   }
-  router.push(orgPath(`/tasks/${task.id}`))
+  router.push(orgPath(`/tasks/${task.identifier}`))
 }
 
 async function switchDetailTab(key) {
@@ -792,10 +794,9 @@ async function generateOverdueTasks() {
 }
 
 async function openTaskFromRoute(id) {
-  const numId = parseInt(id)
-  let task = tasks.value.find(t => t.id === numId || t.identifier === id)
+  let task = tasks.value.find(t => t.identifier === id || String(t.id) === String(id))
   if (!task) {
-    try { task = await api.fetchJSON(`/api/v1/tasks/${numId}`) } catch { return }
+    try { task = await api.fetchJSON(`/api/v1/tasks/${encodeURIComponent(id)}`) } catch { return }
   }
   if (!task) return
   selectedTask.value = task
@@ -812,7 +813,7 @@ watch(() => route.params.id, (id) => {
     editingSection.value = ''
     return
   }
-  if (selectedTask.value?.id === parseInt(id)) return
+  if (selectedTask.value && (selectedTask.value.identifier === id || String(selectedTask.value.id) === String(id))) return
   openTaskFromRoute(id)
 }, { immediate: false })
 


### PR DESCRIPTION
Closes #166

## What
Every register detail view now (a) uses the entity's **human identifier in the URL** and (b) has a **copy-link button** — so a link to any item is shareable and stable.

## How
- **`CopyLinkButton.vue`** (new): copies the current page URL. Secure-context `navigator.clipboard` with an `execCommand` fallback for plain-http self-hosted boxes (mirrors the code-copy handler in `App.vue`). Dropped into the detail header of all 12 module views.
- **Identifier URLs**: `selectX` navigates to the identifier (`…/risks/RISK-3`, `…/tasks/TASK-6`; objectives → `display_id`, programs → `key`) instead of the numeric DB id.
- **Open by identifier**: `openXFromRoute` matches by identifier in-memory and passes the raw param to the GET-by-id endpoints (which already resolve identifier-or-numeric, #174/#177) instead of `parseInt`, so deep-links resolve for off-page items too; the `route.params` watcher guards were updated to match.
- **Backend**: `handleGetObjective` now routes through `resolveObjectiveID`, so `GET /objectives/<display_id>` resolves (it was numeric-only) — the last off-page gap.

## Scope notes
Create-time navigation still lands on the numeric id (the item is on-page, so it opens fine; a tiny cosmetic follow-up). **Audit** gets the copy-link button but keeps numeric ids in its special `/audit/:tab/:itemId` routing — identifier routing there is a small separate follow-up.

## Testing
- `tests/test_objective_display_id_url.py`: `GET /objectives/<display_id>` resolves the same objective as the numeric id.
- `just build-web`, `just build-go`, `just test-go` pass. Frontend deep-link/copy behaviour verified manually (can't be unit-tested).