### PR TITLE
feat(comments): reference entities with # + add objectives/programs to search (#171)

### DIFF
--- a/internal/isms/api/api_search.go
+++ b/internal/isms/api/api_search.go
@@ -364,6 +364,44 @@ func (s *Server) buildSearchIndex(orgID int) {
 		return entries
 	})
 
+	// Objectives (#171: were missing from search, so couldn't be picked as a
+	// reference target). display_id is the identifier form resolveEntityTitle +
+	// deep-links use.
+	collect(func() []SearchEntry {
+		items, err := s.db.ListObjectives(ctx, orgID, 0, "")
+		if err != nil {
+			return nil
+		}
+		entries := make([]SearchEntry, 0, len(items))
+		for _, o := range items {
+			entries = append(entries, SearchEntry{
+				Type:   "objective",
+				ID:     o.DisplayID,
+				Title:  o.Title,
+				Search: strings.ToLower(o.DisplayID + " " + o.Title + " " + o.Description),
+			})
+		}
+		return entries
+	})
+
+	// Programs (#171). Key is the identifier form resolveEntityTitle + deep-links use.
+	collect(func() []SearchEntry {
+		items, err := s.db.ListPrograms(ctx, orgID)
+		if err != nil {
+			return nil
+		}
+		entries := make([]SearchEntry, 0, len(items))
+		for _, p := range items {
+			entries = append(entries, SearchEntry{
+				Type:   "program",
+				ID:     p.Key,
+				Title:  p.Title,
+				Search: strings.ToLower(p.Key + " " + p.Title + " " + p.Description),
+			})
+		}
+		return entries
+	})
+
 	wg.Wait()
 
 	s.searchIndex.Set(orgID, all)

--- a/internal/isms/api/api_search.go
+++ b/internal/isms/api/api_search.go
@@ -145,6 +145,36 @@ func (idx *SearchIndex) Remove(orgID int, entryType, entryID string) {
 }
 
 // buildSearchIndex loads all entity types for an org and populates the index.
+// objectiveSearchEntries / programSearchEntries build the index rows for these
+// two types. Kept pure (no DB) so they're unit testable (#171 review). ID is the
+// identifier form (objective display_id, program key) that resolveEntityTitle and
+// the deep-link routes resolve.
+func objectiveSearchEntries(items []db.Objective) []SearchEntry {
+	entries := make([]SearchEntry, 0, len(items))
+	for _, o := range items {
+		entries = append(entries, SearchEntry{
+			Type:   "objective",
+			ID:     o.DisplayID,
+			Title:  o.Title,
+			Search: strings.ToLower(o.DisplayID + " " + o.Title + " " + o.Description),
+		})
+	}
+	return entries
+}
+
+func programSearchEntries(items []db.Program) []SearchEntry {
+	entries := make([]SearchEntry, 0, len(items))
+	for _, p := range items {
+		entries = append(entries, SearchEntry{
+			Type:   "program",
+			ID:     p.Key,
+			Title:  p.Title,
+			Search: strings.ToLower(p.Key + " " + p.Title + " " + p.Description),
+		})
+	}
+	return entries
+}
+
 func (s *Server) buildSearchIndex(orgID int) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -364,42 +394,24 @@ func (s *Server) buildSearchIndex(orgID int) {
 		return entries
 	})
 
-	// Objectives (#171: were missing from search, so couldn't be picked as a
-	// reference target). display_id is the identifier form resolveEntityTitle +
-	// deep-links use.
+	// Objectives + programs (#171: were missing from search, so couldn't be picked
+	// as reference targets). Entry-building is in pure helpers below so it's unit
+	// testable without a DB. display_id / key are the identifier forms
+	// resolveEntityTitle + deep-links use.
 	collect(func() []SearchEntry {
 		items, err := s.db.ListObjectives(ctx, orgID, 0, "")
 		if err != nil {
 			return nil
 		}
-		entries := make([]SearchEntry, 0, len(items))
-		for _, o := range items {
-			entries = append(entries, SearchEntry{
-				Type:   "objective",
-				ID:     o.DisplayID,
-				Title:  o.Title,
-				Search: strings.ToLower(o.DisplayID + " " + o.Title + " " + o.Description),
-			})
-		}
-		return entries
+		return objectiveSearchEntries(items)
 	})
 
-	// Programs (#171). Key is the identifier form resolveEntityTitle + deep-links use.
 	collect(func() []SearchEntry {
 		items, err := s.db.ListPrograms(ctx, orgID)
 		if err != nil {
 			return nil
 		}
-		entries := make([]SearchEntry, 0, len(items))
-		for _, p := range items {
-			entries = append(entries, SearchEntry{
-				Type:   "program",
-				ID:     p.Key,
-				Title:  p.Title,
-				Search: strings.ToLower(p.Key + " " + p.Title + " " + p.Description),
-			})
-		}
-		return entries
+		return programSearchEntries(items)
 	})
 
 	wg.Wait()

--- a/internal/isms/api/api_search_test.go
+++ b/internal/isms/api/api_search_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"isms.sh/internal/isms/db"
+)
+
+// #171: objectives + programs join the search index. These lock in that the
+// SearchEntry uses the IDENTIFIER form (display_id / key), not the numeric id —
+// which is what resolveEntityTitle and the deep-link routes resolve against.
+
+func TestObjectiveSearchEntries(t *testing.T) {
+	got := objectiveSearchEntries([]db.Objective{
+		{ID: 42, DisplayID: "ISMS-1", Title: "Reduce phishing", Description: "click rate"},
+	})
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	e := got[0]
+	if e.Type != "objective" {
+		t.Errorf("Type=%q, want objective", e.Type)
+	}
+	if e.ID != "ISMS-1" {
+		t.Errorf("ID=%q, want the display_id ISMS-1 (not the numeric id 42)", e.ID)
+	}
+	if e.Title != "Reduce phishing" {
+		t.Errorf("Title=%q, want Reduce phishing", e.Title)
+	}
+	if !strings.Contains(e.Search, "reduce phishing") || !strings.Contains(e.Search, "isms-1") {
+		t.Errorf("Search should carry the lowercased display_id + title: %q", e.Search)
+	}
+}
+
+func TestProgramSearchEntries(t *testing.T) {
+	got := programSearchEntries([]db.Program{
+		{ID: 7, Key: "ISMS", Title: "Security Programme", Description: "annual"},
+	})
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	e := got[0]
+	if e.Type != "program" {
+		t.Errorf("Type=%q, want program", e.Type)
+	}
+	if e.ID != "ISMS" {
+		t.Errorf("ID=%q, want the key ISMS (not the numeric id 7)", e.ID)
+	}
+	if e.Title != "Security Programme" {
+		t.Errorf("Title=%q, want Security Programme", e.Title)
+	}
+	if !strings.Contains(e.Search, "security programme") || !strings.Contains(e.Search, "isms") {
+		t.Errorf("Search should carry the lowercased key + title: %q", e.Search)
+	}
+}
+
+func TestSearchEntriesEmpty(t *testing.T) {
+	if got := objectiveSearchEntries(nil); len(got) != 0 {
+		t.Errorf("nil objectives → %d entries, want 0", len(got))
+	}
+	if got := programSearchEntries(nil); len(got) != 0 {
+		t.Errorf("nil programs → %d entries, want 0", len(got))
+	}
+}

--- a/web/src/components/MentionTextarea.vue
+++ b/web/src/components/MentionTextarea.vue
@@ -7,26 +7,33 @@
       @keydown="onKeydown"
       v-bind="$attrs"
     />
-    <!-- Mentions dropdown -->
-    <div v-if="showMentions && filteredMembers.length > 0"
+    <!-- Autocomplete dropdown: @ mentions a user, # references an entity -->
+    <div v-if="showMentions && items.length > 0"
       class="absolute z-50 bg-slate-900 border border-slate-700 rounded-lg shadow-xl max-h-40 overflow-y-auto"
       :style="dropdownStyle">
-      <button v-for="(m, i) in filteredMembers" :key="m.email || m.id"
-        @mousedown.prevent="selectMention(m)"
+      <button v-for="(m, i) in items" :key="mentionMode === 'user' ? (m.email || m.id) : (m.type + ':' + m.id)"
+        @mousedown.prevent="selectItem(m)"
         class="w-full text-left px-3 py-1.5 text-xs hover:bg-slate-700 transition-colors flex items-center gap-2"
         :class="i === activeIndex ? 'bg-slate-700 text-white' : 'text-slate-300'">
-        <span class="w-5 h-5 rounded-full bg-blue-600 text-white text-[10px] font-bold flex items-center justify-center flex-shrink-0">
-          {{ (m.name || m.email || '?').charAt(0).toUpperCase() }}
-        </span>
-        <span class="truncate">{{ m.name || m.email?.split('@')[0] }}</span>
-        <span class="text-slate-500 text-[10px] ml-auto flex-shrink-0">{{ m.email }}</span>
+        <template v-if="mentionMode === 'user'">
+          <span class="w-5 h-5 rounded-full bg-blue-600 text-white text-[10px] font-bold flex items-center justify-center flex-shrink-0">
+            {{ (m.name || m.email || '?').charAt(0).toUpperCase() }}
+          </span>
+          <span class="truncate">{{ m.name || m.email?.split('@')[0] }}</span>
+          <span class="text-slate-500 text-[10px] ml-auto flex-shrink-0">{{ m.email }}</span>
+        </template>
+        <template v-else>
+          <span class="text-[9px] font-mono uppercase tracking-wider text-blue-400 flex-shrink-0">{{ m.id }}</span>
+          <span class="truncate">{{ m.title }}</span>
+        </template>
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, nextTick } from 'vue'
+import { api } from '../api'
 
 defineOptions({ inheritAttrs: false })
 
@@ -42,6 +49,8 @@ const showMentions = ref(false)
 const mentionQuery = ref('')
 const mentionStart = ref(-1)
 const activeIndex = ref(0)
+const mentionMode = ref('user') // 'user' (@) or 'entity' (#)
+const entityResults = ref([])
 
 const dropdownStyle = computed(() => {
   return { bottom: '100%', left: '0', right: '0', marginBottom: '4px' }
@@ -56,70 +65,90 @@ const filteredMembers = computed(() => {
   }).slice(0, 8)
 })
 
+// Unified list the dropdown/keyboard nav operate on.
+const items = computed(() => mentionMode.value === 'user' ? filteredMembers.value : entityResults.value)
+
 function onInput(e) {
-  const val = e.target.value
-  emit('update:modelValue', val)
+  emit('update:modelValue', e.target.value)
   checkForMention(e.target)
 }
 
 function checkForMention(el) {
   const cursor = el.selectionStart
   const text = el.value
-  // Walk backwards from cursor to find @
-  let atPos = -1
+  // Walk backwards from the cursor to the nearest @ or # that starts a word.
+  let pos = -1
+  let mode = ''
   for (let i = cursor - 1; i >= 0; i--) {
     const ch = text[i]
-    if (ch === '@') {
-      // Only trigger if @ is at start or preceded by whitespace
+    if (ch === '@' || ch === '#') {
       if (i === 0 || /\s/.test(text[i - 1])) {
-        atPos = i
+        pos = i
+        mode = ch === '@' ? 'user' : 'entity'
       }
       break
     }
     if (/\s/.test(ch)) break
   }
 
-  if (atPos >= 0) {
-    mentionStart.value = atPos
-    mentionQuery.value = text.substring(atPos + 1, cursor)
+  if (pos >= 0) {
+    mentionStart.value = pos
+    mentionMode.value = mode
+    mentionQuery.value = text.substring(pos + 1, cursor)
     showMentions.value = true
     activeIndex.value = 0
+    if (mode === 'entity') searchEntities(mentionQuery.value)
   } else {
     showMentions.value = false
   }
 }
 
+let searchTimer = null
+function searchEntities(q) {
+  clearTimeout(searchTimer)
+  if (!q) { entityResults.value = []; return }
+  searchTimer = setTimeout(async () => {
+    try {
+      const res = await api.search(q)
+      const data = (res && (res.data || res)) || []
+      entityResults.value = data.slice(0, 8)
+    } catch { entityResults.value = [] }
+  }, 200)
+}
+
 function onKeydown(e) {
-  if (!showMentions.value || filteredMembers.value.length === 0) return
+  if (!showMentions.value || items.value.length === 0) return
 
   if (e.key === 'ArrowDown') {
     e.preventDefault()
-    activeIndex.value = (activeIndex.value + 1) % filteredMembers.value.length
+    activeIndex.value = (activeIndex.value + 1) % items.value.length
   } else if (e.key === 'ArrowUp') {
     e.preventDefault()
-    activeIndex.value = (activeIndex.value - 1 + filteredMembers.value.length) % filteredMembers.value.length
+    activeIndex.value = (activeIndex.value - 1 + items.value.length) % items.value.length
   } else if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
     e.preventDefault()
-    selectMention(filteredMembers.value[activeIndex.value])
+    selectItem(items.value[activeIndex.value])
   } else if (e.key === 'Escape') {
     showMentions.value = false
   }
 }
 
-function selectMention(member) {
+function selectItem(item) {
   const el = textareaRef.value
-  if (!el) return
+  if (!el || !item) return
   const text = el.value
   const before = text.substring(0, mentionStart.value)
   const after = text.substring(el.selectionStart)
-  const mention = `@${member.email} `
-  const newVal = before + mention + after
+  // @ inserts the user's email; # inserts the entity identifier (e.g. TASK-6),
+  // which renderMention turns into a deep-link.
+  const token = mentionMode.value === 'user' ? `@${item.email} ` : `#${item.id} `
+  const newVal = before + token + after
   emit('update:modelValue', newVal)
   showMentions.value = false
 
   nextTick(() => {
     if (textareaRef.value) {
-      const pos = before.length + mention.length
+      const pos = before.length + token.length
       textareaRef.value.selectionStart = pos
       textareaRef.value.selectionEnd = pos
       textareaRef.value.focus()

--- a/web/src/components/MentionTextarea.vue
+++ b/web/src/components/MentionTextarea.vue
@@ -104,15 +104,22 @@ function checkForMention(el) {
 }
 
 let searchTimer = null
+let searchSeq = 0
 function searchEntities(q) {
   clearTimeout(searchTimer)
   if (!q) { entityResults.value = []; return }
   searchTimer = setTimeout(async () => {
+    // Guard against out-of-order responses: a slow earlier request must not
+    // overwrite results for a newer query.
+    const seq = ++searchSeq
     try {
       const res = await api.search(q)
+      if (seq !== searchSeq) return
       const data = (res && (res.data || res)) || []
       entityResults.value = data.slice(0, 8)
-    } catch { entityResults.value = [] }
+    } catch {
+      if (seq === searchSeq) entityResults.value = []
+    }
   }, 200)
 }
 

--- a/web/src/composables/useMention.js
+++ b/web/src/composables/useMention.js
@@ -1,6 +1,34 @@
+import { currentOrgPath } from './useCurrentOrg.js'
+
+// Identifier prefix → register route, so an entity reference in a comment links to
+// the entity's deep-link page (#166 / #171). Objectives (display_id is program-key
+// based, no fixed prefix) and audit items aren't mapped — they render as a
+// highlighted reference rather than a link.
+const ENTITY_ROUTES = {
+  RISK: 'risks', INC: 'incidents', TASK: 'tasks', CA: 'corrective-actions',
+  SUPPLIER: 'suppliers', SYSTEM: 'systems', LEGAL: 'legal', CR: 'changes',
+  ASSET: 'assets', AST: 'assets', PROG: 'programs',
+}
+
 export function renderMention(body) {
   if (!body) return ''
-  const escaped = body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  return escaped.replace(/@([\w.+-]+@[\w.-]+)/g, '<span class="text-blue-400 font-medium">@$1</span>')
+  let out = body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+  // Entity references: #TASK-6 → deep-link to the entity (#171). Known prefixes
+  // become links; anything else stays a highlighted reference.
+  out = out.replace(/#([A-Z][A-Z0-9]*)-(\d+)\b/g, (_m, prefix, num) => {
+    const ident = `${prefix}-${num}`
+    const route = ENTITY_ROUTES[prefix]
+    if (route) {
+      const href = currentOrgPath(`/${route}/${ident}`)
+      return `<a href="${href}" class="text-blue-400 font-medium hover:underline">#${ident}</a>`
+    }
+    return `<span class="text-blue-400 font-medium">#${ident}</span>`
+  })
+
+  // User mentions: @email / @handle.
+  out = out.replace(/@([\w.+-]+@[\w.-]+)/g, '<span class="text-blue-400 font-medium">@$1</span>')
     .replace(/@(\w+)/g, '<span class="text-blue-400 font-medium">@$1</span>')
+
+  return out
 }

--- a/web/src/composables/useMention.js
+++ b/web/src/composables/useMention.js
@@ -1,29 +1,41 @@
 import { currentOrgPath } from './useCurrentOrg.js'
+import { programKeys, loadProgramKeys } from './usePrograms.js'
 
-// Identifier prefix → register route, so an entity reference in a comment links to
-// the entity's deep-link page (#166 / #171). Objectives (display_id is program-key
-// based, no fixed prefix) and audit items aren't mapped — they render as a
-// highlighted reference rather than a link.
+// Fixed system identifier prefixes → register route (Identifier = "TASK-6" etc.
+// from NextIdentifier). Programs and objectives are NOT here: a program is keyed
+// by an arbitrary per-org string and an objective's display_id is "<key>-<seq>",
+// so they're matched against the live program-key cache instead (#171 review).
 const ENTITY_ROUTES = {
   RISK: 'risks', INC: 'incidents', TASK: 'tasks', CA: 'corrective-actions',
   SUPPLIER: 'suppliers', SYSTEM: 'systems', LEGAL: 'legal', CR: 'changes',
-  ASSET: 'assets', AST: 'assets', PROG: 'programs',
+  ASSET: 'assets', AST: 'assets',
 }
 
 export function renderMention(body) {
   if (!body) return ''
+  loadProgramKeys() // fire-and-forget; no-op after the first load
+  const keys = programKeys.value
+
   let out = body.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-  // Entity references: #TASK-6 → deep-link to the entity (#171). Known prefixes
-  // become links; anything else stays a highlighted reference.
-  out = out.replace(/#([A-Z][A-Z0-9]*)-(\d+)\b/g, (_m, prefix, num) => {
-    const ident = `${prefix}-${num}`
-    const route = ENTITY_ROUTES[prefix]
-    if (route) {
-      const href = currentOrgPath(`/${route}/${ident}`)
-      return `<a href="${href}" class="text-blue-400 font-medium hover:underline">#${ident}</a>`
+  const anchor = (route, label) =>
+    `<a href="${currentOrgPath(route)}" class="text-blue-400 font-medium hover:underline">#${label}</a>`
+  const span = (label) => `<span class="text-blue-400 font-medium">#${label}</span>`
+
+  // Entity references (single pass so nothing double-matches):
+  //   #TASK-6  → fixed-prefix register        (link)
+  //   #ISMS-1  → objective (display_id KEY-seq, KEY is a known program key) (link)
+  //   #ISMS    → the program itself (bare known key)                       (link)
+  //   #other / #other-1 (unknown) → highlighted / untouched
+  out = out.replace(/#([A-Z][A-Z0-9]*)(?:-(\d+))?\b/g, (m, prefix, num) => {
+    if (num !== undefined) {
+      const ident = `${prefix}-${num}`
+      if (ENTITY_ROUTES[prefix]) return anchor(`/${ENTITY_ROUTES[prefix]}/${ident}`, ident)
+      if (keys.has(prefix)) return anchor(`/objectives/${ident}`, ident)
+      return span(ident)
     }
-    return `<span class="text-blue-400 font-medium">#${ident}</span>`
+    if (keys.has(prefix)) return anchor(`/programs/${prefix}`, prefix)
+    return m // arbitrary #word — leave as typed
   })
 
   // User mentions: @email / @handle.

--- a/web/src/composables/usePrograms.js
+++ b/web/src/composables/usePrograms.js
@@ -1,0 +1,26 @@
+import { ref } from 'vue'
+import { api } from '../api'
+
+// Shared cache of program keys. Programs are referenced by their per-org key (an
+// arbitrary user-chosen string like "ISMS"/"SEC"), and an objective's display_id
+// is "<programKey>-<seq>". Neither fits a static prefix map, so #KEY / #KEY-N
+// linkification needs the live key set. Loaded once, reused across renders.
+const programKeys = ref(new Set())
+const loaded = ref(false)
+const loading = ref(false)
+
+export async function loadProgramKeys() {
+  if (loaded.value || loading.value) return
+  loading.value = true
+  try {
+    const res = await api.getPrograms()
+    const list = (res && (res.data || res)) || []
+    programKeys.value = new Set(list.map(p => p.key).filter(Boolean))
+    loaded.value = true
+  } catch {
+    /* leave empty — references degrade to a highlighted (non-linked) span */
+  }
+  loading.value = false
+}
+
+export { programKeys }


### PR DESCRIPTION
Closes #171

## What
Reference other entities from inside a comment, and fill the two register types that couldn't be picked as reference targets.

## How
- **`#` entity picker** (`MentionTextarea.vue`): typing `#` opens a searchable dropdown backed by the universal-search index and inserts the entity identifier (e.g. `#TASK-6`). `@` still mentions users — same component, second trigger. Works everywhere `MentionTextarea` is used (entity comments + document comments).
- **Deep-linked render** (`useMention.js` `renderMention`): a known-prefix identifier (`#RISK-3`, `#TASK-6`, …) becomes a link to the entity's page via the #166 identifier deep-links (org-aware `currentOrgPath`); unknown forms stay a highlighted reference.
- **Search picker gap** (`api_search.go`): objectives (`display_id`) and programs (`key`) were missing from the search index, so `ReferenceManager` couldn't find them to link — added both. `resolveEntityTitle` already resolves those identifier forms, so reference chips display correctly.

## Scope / follow-ups (small, tracked separately)
- Audit + audit findings aren't in search yet — needs an org-wide findings list method and handling their special `/audit/:tab/:itemId` routing.
- Objectives/programs enter the index on its TTL rebuild rather than an immediate `searchUpsert` (fine for a reference picker; other types upsert immediately).
- Comment reference links are plain `<a href>` (full navigation) rather than SPA-router pushes.
- Create-time linking via the (still-unwired) `ReferenceCollector` component.

## Testing
`just fmt` / `build-go` / `build-web` / `test-go` pass. The `#` picker and linkified render are interactive frontend with no JS test runner in the repo — verified manually. (A search-index integration test would be TTL-cache flaky, so not added.)