### PR TITLE
build(freebsd): jail support — goreleaser target + rc.d service + docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,9 +37,15 @@ universal_binaries:
 archives:
   - formats: [tar.gz]
     name_template: "isms_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    # Ship the FreeBSD rc.d service script + a config sample so a jail install is
-    # copy-into-place. Harmless on other OSes (they just ignore rc.d/isms).
+    # Specifying `files` REPLACES goreleaser's default list, so the defaults
+    # (LICENSE/README/CHANGELOG) must be re-listed explicitly or every platform's
+    # tarball silently loses them — a licence-distribution regression, not just a
+    # FreeBSD one. Keep the defaults, then add the FreeBSD rc.d script + config
+    # sample so a jail install is copy-into-place (harmless on other OSes).
     files:
+      - LICENSE*
+      - README*
+      - CHANGELOG*
       - src: contrib/freebsd/rc.d/isms
         dst: rc.d/isms
       - src: contrib/freebsd/isms.env.sample

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ builds:
       - linux
       - darwin
       - openbsd
+      - freebsd
     goarch:
       - amd64
       - arm64
@@ -36,6 +37,15 @@ universal_binaries:
 archives:
   - formats: [tar.gz]
     name_template: "isms_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Ship the FreeBSD rc.d service script + a config sample so a jail install is
+    # copy-into-place. Harmless on other OSes (they just ignore rc.d/isms).
+    files:
+      - src: contrib/freebsd/rc.d/isms
+        dst: rc.d/isms
+      - src: contrib/freebsd/isms.env.sample
+        dst: isms.env.sample
+      - src: contrib/freebsd/README.md
+        dst: FREEBSD.md
 
 checksum:
   name_template: checksums.txt

--- a/contrib/freebsd/README.md
+++ b/contrib/freebsd/README.md
@@ -1,4 +1,7 @@
-# Running ISMS on FreeBSD (jails)
+# Running ISMS on FreeBSD
+
+Works on any FreeBSD system — a bare-metal/VM host or a jail; there is nothing
+jail-specific here (a jail is just a FreeBSD userland with the same rc(8) system).
 
 ISMS ships as a single self-contained binary — the web UI and DB migrations are
 embedded, so there is nothing else to deploy for the app itself. You still need a

--- a/contrib/freebsd/README.md
+++ b/contrib/freebsd/README.md
@@ -1,0 +1,78 @@
+# Running ISMS on FreeBSD (jails)
+
+ISMS ships as a single self-contained binary — the web UI and DB migrations are
+embedded, so there is nothing else to deploy for the app itself. You still need a
+PostgreSQL database (commonly its own jail/host) and the templates repo on disk.
+
+The release tarball `isms_<version>_freebsd_amd64.tar.gz` (also `arm64`) contains:
+
+```
+isms              # the binary
+rc.d/isms         # the service script (this dir)
+isms.env.sample   # configuration sample
+FREEBSD.md        # this file
+```
+
+## Install
+
+```sh
+# In the jail, as root:
+fetch https://github.com/unidoc/isms/releases/download/vX.Y.Z/isms_X.Y.Z_freebsd_amd64.tar.gz
+tar xzf isms_X.Y.Z_freebsd_amd64.tar.gz
+
+install -m 755 isms /usr/local/bin/isms
+install -m 755 rc.d/isms /usr/local/etc/rc.d/isms
+
+# Service account (no login, no home needed — git storage lives under a data dir
+# you choose via config):
+pw useradd isms -d /nonexistent -s /usr/sbin/nologin -c "ISMS service"
+
+# Configuration:
+install -m 600 -o isms isms.env.sample /usr/local/etc/isms.env
+$EDITOR /usr/local/etc/isms.env        # set DATABASE_URL, ISMS_TEMPLATE_PATH, ISMS_BASE_URL
+```
+
+## Database + templates
+
+- Create the PostgreSQL role/database and point `DATABASE_URL` at it (note:
+  `DATABASE_URL`, not `ISMS_DATABASE_URL`).
+- Apply the schema — migrations are embedded:
+
+  ```sh
+  env $(grep -v '^#' /usr/local/etc/isms.env | xargs) isms migrate
+  ```
+
+- Put the standard templates repo at `ISMS_TEMPLATE_PATH`.
+
+## Enable + run
+
+```sh
+sysrc isms_enable=YES
+service isms start
+service isms status
+```
+
+By default it listens on `:8080` and runs as the `isms` user. To change the
+listen address (e.g. bind to loopback behind a reverse proxy):
+
+```sh
+sysrc isms_args="server --addr 127.0.0.1:8080"
+service isms restart
+```
+
+## rc.conf variables
+
+| variable        | default                      | meaning                          |
+| --------------- | ---------------------------- | -------------------------------- |
+| `isms_enable`   | `NO`                         | enable the service               |
+| `isms_user`     | `isms`                       | user to run as                   |
+| `isms_env_file` | `/usr/local/etc/isms.env`    | file with `ISMS_*` / `DATABASE_URL` config |
+| `isms_args`     | `server`                     | `isms` subcommand + flags        |
+
+Logs go to syslog via `daemon(8)`; the pidfile is `/var/run/isms.pid`.
+
+## `pkg install` (later)
+
+This tarball + rc script is all you need to run ISMS in a jail. A native
+`pkg install isms` can come later, either from a self-hosted pkg repo or an
+official FreeBSD port — tracked separately.

--- a/contrib/freebsd/README.md
+++ b/contrib/freebsd/README.md
@@ -26,13 +26,19 @@ tar xzf isms_X.Y.Z_freebsd_amd64.tar.gz
 install -m 755 isms /usr/local/bin/isms
 install -m 755 rc.d/isms /usr/local/etc/rc.d/isms
 
-# Service account (no login, no home needed — git storage lives under a data dir
-# you choose via config):
+# Service account (no login, no home — it only runs the daemon):
 pw useradd isms -d /nonexistent -s /usr/sbin/nologin -c "ISMS service"
 
-# Configuration:
-install -m 600 -o isms isms.env.sample /usr/local/etc/isms.env
-$EDITOR /usr/local/etc/isms.env        # set DATABASE_URL, ISMS_TEMPLATE_PATH, ISMS_BASE_URL
+# Data directory: per-org git repos ($ISMS_DATA_DIR/repos/{slug}.git) and, with
+# the file storage backend, branding + evidence blobs. Create it and hand it to
+# the service user (matches ISMS_DATA_DIR in the env file):
+mkdir -p /var/db/isms && chown isms:isms /var/db/isms
+
+# Configuration. Install as root:wheel — NOT owned by the isms user: the rc.d
+# script sources this file as root (before dropping privileges), so an env file
+# writable by isms would be a local root-escalation path.
+install -m 600 -o root -g wheel isms.env.sample /usr/local/etc/isms.env
+$EDITOR /usr/local/etc/isms.env        # DATABASE_URL, ISMS_DATA_DIR, ISMS_STORAGE_BACKEND, ISMS_TEMPLATE_PATH
 ```
 
 ## Database + templates
@@ -42,7 +48,7 @@ $EDITOR /usr/local/etc/isms.env        # set DATABASE_URL, ISMS_TEMPLATE_PATH, I
 - Apply the schema — migrations are embedded:
 
   ```sh
-  env $(grep -v '^#' /usr/local/etc/isms.env | xargs) isms migrate
+  env $(grep -v '^#' /usr/local/etc/isms.env | xargs) isms server migrate
   ```
 
 - Put the standard templates repo at `ISMS_TEMPLATE_PATH`.
@@ -59,7 +65,7 @@ By default it listens on `:8080` and runs as the `isms` user. To change the
 listen address (e.g. bind to loopback behind a reverse proxy):
 
 ```sh
-sysrc isms_args="server --addr 127.0.0.1:8080"
+sysrc isms_args="server serve --addr 127.0.0.1:8080"
 service isms restart
 ```
 
@@ -69,10 +75,10 @@ service isms restart
 | --------------- | ---------------------------- | -------------------------------- |
 | `isms_enable`   | `NO`                         | enable the service               |
 | `isms_user`     | `isms`                       | user to run as                   |
-| `isms_env_file` | `/usr/local/etc/isms.env`    | file with `ISMS_*` / `DATABASE_URL` config |
-| `isms_args`     | `server`                     | `isms` subcommand + flags        |
+| `isms_env_file` | `/usr/local/etc/isms.env`    | file with `DATABASE_URL` / `ISMS_*` config |
+| `isms_args`     | `server serve`               | `isms` subcommand + flags        |
 
-Logs go to syslog via `daemon(8)`; the pidfile is `/var/run/isms.pid`.
+Logs go to syslog (tag `isms`) via `daemon(8) -S`; the pidfile is `/var/run/isms.pid`.
 
 ## `pkg install` (later)
 

--- a/contrib/freebsd/isms.env.sample
+++ b/contrib/freebsd/isms.env.sample
@@ -9,15 +9,26 @@ DATABASE_URL=postgres://isms:CHANGEME@127.0.0.1:5432/isms?sslmode=disable
 # Standard templates repo on disk (separate from the app; the org's git repo is
 # the source of truth after scaffolding).
 ISMS_TEMPLATE_PATH=/usr/local/share/isms/templates
+# Base data directory: per-org bare git repos ($ISMS_DATA_DIR/repos/{slug}.git)
+# and, with the file storage backend, branding + evidence blobs. Must exist and
+# be owned by the service user. Startup aborts if unset.
+ISMS_DATA_DIR=/var/db/isms
+# Storage backend for blobs (branding, evidence). "file" keeps them under
+# ISMS_DATA_DIR; "s3" needs the ISMS_S3_* vars below. Startup aborts if unset.
+ISMS_STORAGE_BACKEND=file
 
 # --- Common ---
 # Public base URL (used in emails, links, CORS).
 ISMS_BASE_URL=https://isms.example.com
 
 # The listen address is a flag, not an env var (default :8080). To change it, set
-# in rc.conf:  sysrc isms_args="server --addr 127.0.0.1:8080"
+# in rc.conf:  sysrc isms_args="server serve --addr 127.0.0.1:8080"
 
 # --- Optional (see the docs for the full list) ---
 # ISMS_CORS_ORIGIN=https://isms.example.com
-# ISMS_STORAGE_BACKEND=file            # or s3
 # ISMS_USER_SIGNUP=false
+# S3/R2 backend (only when ISMS_STORAGE_BACKEND=s3):
+# ISMS_S3_BUCKET=isms
+# ISMS_S3_ENDPOINT=https://...
+# ISMS_S3_ACCESS_KEY=...
+# ISMS_S3_SECRET_KEY=...

--- a/contrib/freebsd/isms.env.sample
+++ b/contrib/freebsd/isms.env.sample
@@ -1,0 +1,23 @@
+# ISMS configuration for the FreeBSD rc.d service.
+# Copy to /usr/local/etc/isms.env, edit, and `chmod 600` it (it holds secrets).
+# These are plain KEY=VALUE lines sourced by the rc.d script.
+
+# --- Required ---
+# PostgreSQL connection (note: DATABASE_URL, NOT ISMS_-prefixed). Often a
+# separate jail/host.
+DATABASE_URL=postgres://isms:CHANGEME@127.0.0.1:5432/isms?sslmode=disable
+# Standard templates repo on disk (separate from the app; the org's git repo is
+# the source of truth after scaffolding).
+ISMS_TEMPLATE_PATH=/usr/local/share/isms/templates
+
+# --- Common ---
+# Public base URL (used in emails, links, CORS).
+ISMS_BASE_URL=https://isms.example.com
+
+# The listen address is a flag, not an env var (default :8080). To change it, set
+# in rc.conf:  sysrc isms_args="server --addr 127.0.0.1:8080"
+
+# --- Optional (see the docs for the full list) ---
+# ISMS_CORS_ORIGIN=https://isms.example.com
+# ISMS_STORAGE_BACKEND=file            # or s3
+# ISMS_USER_SIGNUP=false

--- a/contrib/freebsd/rc.d/isms
+++ b/contrib/freebsd/rc.d/isms
@@ -11,13 +11,14 @@
 #   service isms start
 #
 # Configuration is read from an environment file (KEY=VALUE lines) — see
-# isms.env.sample. Required at minimum: ISMS_DATABASE_URL and ISMS_TEMPLATE_PATH.
+# isms.env.sample. Required at minimum: DATABASE_URL, ISMS_DATA_DIR,
+# ISMS_STORAGE_BACKEND and ISMS_TEMPLATE_PATH.
 #
 # rc.conf variables (defaults shown):
 #   isms_enable="NO"
 #   isms_user="isms"                          # user to run as
-#   isms_env_file="/usr/local/etc/isms.env"   # ISMS_* configuration
-#   isms_args="server"                        # isms subcommand + flags
+#   isms_env_file="/usr/local/etc/isms.env"   # DATABASE_URL / ISMS_* config
+#   isms_args="server serve"                  # isms subcommand + flags
 
 . /etc/rc.subr
 
@@ -29,12 +30,15 @@ load_rc_config "$name"
 : ${isms_enable:="NO"}
 : ${isms_user:="isms"}
 : ${isms_env_file:="/usr/local/etc/isms.env"}
-: ${isms_args:="server"}
+: ${isms_args:="server serve"}
 
 pidfile="/var/run/${name}.pid"
 procname="/usr/local/bin/${name}"
 command="/usr/sbin/daemon"
-command_args="-f -p ${pidfile} -u ${isms_user} ${procname} ${isms_args}"
+# -f: detach; -S -T isms: forward the child's stdout/stderr to syslog under the
+# "isms" tag (without -S, -f sends output to /dev/null and a failed start — e.g. a
+# fatal config error — is undiagnosable); -r: restart the child if it exits.
+command_args="-f -r -S -T ${name} -p ${pidfile} -u ${isms_user} ${procname} ${isms_args}"
 
 start_precmd="isms_precmd"
 isms_precmd()

--- a/contrib/freebsd/rc.d/isms
+++ b/contrib/freebsd/rc.d/isms
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# PROVIDE: isms
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# rc.d service script for ISMS. Copy to /usr/local/etc/rc.d/isms (chmod +x),
+# then enable in rc.conf:
+#
+#   sysrc isms_enable=YES
+#   service isms start
+#
+# Configuration is read from an environment file (KEY=VALUE lines) — see
+# isms.env.sample. Required at minimum: ISMS_DATABASE_URL and ISMS_TEMPLATE_PATH.
+#
+# rc.conf variables (defaults shown):
+#   isms_enable="NO"
+#   isms_user="isms"                          # user to run as
+#   isms_env_file="/usr/local/etc/isms.env"   # ISMS_* configuration
+#   isms_args="server"                        # isms subcommand + flags
+
+. /etc/rc.subr
+
+name="isms"
+rcvar="isms_enable"
+
+load_rc_config "$name"
+
+: ${isms_enable:="NO"}
+: ${isms_user:="isms"}
+: ${isms_env_file:="/usr/local/etc/isms.env"}
+: ${isms_args:="server"}
+
+pidfile="/var/run/${name}.pid"
+procname="/usr/local/bin/${name}"
+command="/usr/sbin/daemon"
+command_args="-f -p ${pidfile} -u ${isms_user} ${procname} ${isms_args}"
+
+start_precmd="isms_precmd"
+isms_precmd()
+{
+	# Load ISMS_* config into the environment; daemon(8) inherits it and passes
+	# it through to the isms process.
+	if [ -r "${isms_env_file}" ]; then
+		set -a
+		. "${isms_env_file}"
+		set +a
+	fi
+	# daemon writes the pidfile as isms_user — make sure it can.
+	install -o "${isms_user}" -g wheel -m 644 /dev/null "${pidfile}" 2>/dev/null || true
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
Closes #188

## What
Run ISMS from FreeBSD jails. **Build/packaging only** — no app code change, no schema/migration — so it's safe in 0.7.1 (needed to actually run the system on FreeBSD).

## How
- **goreleaser** (`.goreleaser.yaml`): add `freebsd` to the build `goos` (OpenBSD was already there; the binary is pure-Go/CGO-off and cross-compiles cleanly). The existing `tar.gz` archive now yields `isms_<ver>_freebsd_amd64.tar.gz` + `arm64`, and every archive ships the rc.d script + config sample + `FREEBSD.md`.
- **rc.d service** (`contrib/rc.d/isms`): `rc.subr` script running `isms server` under `daemon(8)` as the `isms` user, sourcing `ISMS_*` / `DATABASE_URL` from an env file.
- **Docs** (`contrib/freebsd/`): `isms.env.sample` + `README.md`. Notes the gotchas: `DATABASE_URL` is **not** `ISMS_`-prefixed, and the listen address is the `--addr` flag (default `:8080`), not an env var.

## Out of scope (separate follow-up)
Native `pkg install isms` — goreleaser can't build a FreeBSD `.pkg`, so the release ships only the tarball. A `.pkg` is a separate `pkg create` step on FreeBSD, then `pkg repo` + host as a self-hosted repo (or an official FreeBSD port later). Not needed to run in a jail.

## Testing
`goreleaser check` passes; `freebsd/amd64` + `freebsd/arm64` cross-compile clean; `just build-go` passes. Release artifacts are produced by `just release`.