### PR TITLE
fix(security): authorize comment writes on reviews and register entities

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -843,6 +843,49 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 	})
 }
 
+// isReviewParticipant reports whether actor is the review's author or one of its
+// assigned reviewers. Assignment — not role — is what grants comment rights on a
+// review, so a reader assigned as a reviewer participates fully (see CLAUDE.md,
+// "Review assignment grants approve/comment rights to any role").
+func (s *Server) isReviewParticipant(ctx context.Context, orgID int, review *db.Review, actor string) bool {
+	if review == nil || actor == "" {
+		return false
+	}
+	if review.RequestedBy == actor {
+		return true
+	}
+	assignments, _ := s.db.ListAssignmentsForReview(ctx, orgID, review.ID)
+	for _, a := range assignments {
+		if a.Reviewer == actor {
+			return true
+		}
+	}
+	return false
+}
+
+// authorizeReviewComment is the single gate for writing a comment onto a review.
+// Both comment routes must call it: POST /reviews/:id/comment and POST /comments
+// with a client-supplied review_id. Without it on the latter, the check here is
+// decorative — one guarded door in a two-door room.
+func (s *Server) authorizeReviewComment(ctx context.Context, orgID int, reviewID int, actor, role string) (*db.Review, error) {
+	review, err := s.db.GetReview(ctx, orgID, reviewID)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "review not found")
+	}
+	// A published or abandoned review is a closed record — nobody appends to it.
+	// Checked before the participant rule so the message names the real reason.
+	if review.Status == "merged" || review.Status == "closed" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "review is "+review.Status)
+	}
+	if role == "admin" || role == "manager" {
+		return review, nil
+	}
+	if !s.isReviewParticipant(ctx, orgID, review, actor) {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "not authorized to comment on this review")
+	}
+	return review, nil
+}
+
 // handleAddReviewComment adds a comment tied to a specific review.
 func (s *Server) handleAddReviewComment(c echo.Context) error {
 	orgID := getOrgID(c)
@@ -852,27 +895,11 @@ func (s *Server) handleAddReviewComment(c echo.Context) error {
 	}
 	ctx := c.Request().Context()
 
-	// Verify review exists.
-	review, err := s.db.GetReview(ctx, orgID, id)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
-	}
-
-	// Authorization: admin/manager always, others must be assigned
 	actor := getUserEmail(c)
 	role, _ := c.Get("user_role").(string)
-	if role != "admin" && role != "manager" {
-		assignments, _ := s.db.ListAssignmentsForReview(ctx, orgID, id)
-		isAssigned := false
-		for _, a := range assignments {
-			if a.Reviewer == actor {
-				isAssigned = true
-				break
-			}
-		}
-		if !isAssigned && review.RequestedBy != actor {
-			return echo.NewHTTPError(http.StatusForbidden, "not authorized to comment on this review")
-		}
+	review, err := s.authorizeReviewComment(ctx, orgID, id, actor, role)
+	if err != nil {
+		return err
 	}
 
 	var req struct {
@@ -1704,6 +1731,20 @@ func (s *Server) handleAddCommentDB(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	comment.Author = getUserEmail(c) // always use authenticated user
+	// review_id arrives from the client, so a comment aimed at a review must pass
+	// the same gate as POST /reviews/:id/comment — otherwise this route is a way
+	// around it. Plain document comments (no review_id) stay open to every role,
+	// which is what the reader exemption in RoleMiddleware exists for.
+	if comment.ReviewID != nil {
+		role, _ := c.Get("user_role").(string)
+		review, err := s.authorizeReviewComment(c.Request().Context(), orgID, *comment.ReviewID, comment.Author, role)
+		if err != nil {
+			return err
+		}
+		// Trust the review, not the client, for which document this lands on.
+		comment.DocumentID = review.DocumentID
+	}
+	comment.Status = "open" // the row is inserted open; echo what was stored
 	// If suggestion_body is provided, set suggestion_status to pending
 	if comment.SuggestionBody != nil && *comment.SuggestionBody != "" && comment.SuggestionStatus == nil {
 		pending := "pending"
@@ -1751,8 +1792,29 @@ func (s *Server) handleResolveCommentDB(c echo.Context) error {
 	}
 	resolvedBy := getUserEmail(c) // always use authenticated user
 	ctx := c.Request().Context()
-	// Get document_id from comment before resolving
-	docID, _ := s.db.GetCommentDocumentID(ctx, orgID, id)
+
+	// Resolving closes someone's open feedback, so it needs the same care as
+	// writing it: admin/manager, the comment's own author, or — for a comment on
+	// a review — a participant in that review (the document author resolving
+	// reviewer feedback is the common case).
+	comment, err := s.db.GetComment(ctx, orgID, id)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "comment not found")
+	}
+	role, _ := c.Get("user_role").(string)
+	if role != "admin" && role != "manager" && comment.Author != resolvedBy {
+		authorized := false
+		if comment.ReviewID != nil {
+			if review, revErr := s.db.GetReview(ctx, orgID, *comment.ReviewID); revErr == nil {
+				authorized = s.isReviewParticipant(ctx, orgID, review, resolvedBy)
+			}
+		}
+		if !authorized {
+			return echo.NewHTTPError(http.StatusForbidden, "not authorized to resolve this comment")
+		}
+	}
+
+	docID := comment.DocumentID // captured above, before resolving
 	if err := s.db.ResolveComment(ctx, orgID, id, resolvedBy); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/internal/isms/api/api_entity_comments.go
+++ b/internal/isms/api/api_entity_comments.go
@@ -29,6 +29,12 @@ func (s *Server) handleListEntityComments(c echo.Context) error {
 }
 
 func (s *Server) handleCreateEntityComment(c echo.Context) error {
+	// Contributors and managers comment on register entities; readers are
+	// read-only (#23). Mirrors handleCreateEntitySuggestion — the two are the
+	// contributor's write surface and had drifted apart.
+	if err := requireRole(c, "admin", "manager", "contributor"); err != nil {
+		return err
+	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)

--- a/internal/isms/api/middleware.go
+++ b/internal/isms/api/middleware.go
@@ -372,8 +372,16 @@ func (s *Server) RoleMiddleware() echo.MiddlewareFunc {
 					strings.HasSuffix(path, "/comment") || strings.HasSuffix(path, "/content")) {
 					return next(c)
 				}
-				// Allow readers to add comments (assignment check in handler)
-				if strings.HasPrefix(path, "/api/v1/comments") {
+				// Allow readers to comment on documents and to resolve comments
+				// they are entitled to; both handlers authorize per-comment
+				// (handleAddCommentDB / handleResolveCommentDB). Deliberately not
+				// a bare `/api/v1/comments` prefix — that also exempted
+				// /comments/:id/accept and /reject, and would exempt any future
+				// route under the prefix. `strings.Contains` on "/comments/" is
+				// avoided too, since /api/v1/entity-comments/:id/resolve would
+				// match it.
+				if path == "/api/v1/comments" ||
+					(strings.HasPrefix(path, "/api/v1/comments/") && strings.HasSuffix(path, "/resolve")) {
 					return next(c)
 				}
 				return echo.NewHTTPError(http.StatusForbidden, "read-only access")

--- a/tests/test_comment_authorization.py
+++ b/tests/test_comment_authorization.py
@@ -1,0 +1,204 @@
+"""Comment authorization tests.
+
+POST /comments takes a client-supplied review_id, so it must apply the same gate
+as POST /reviews/:id/comment — otherwise it is a way around it. Resolving needs
+its own gate, and commenting on a register entity is a contributor-and-above
+write (#23).
+
+The load-bearing case is test_05: an *assigned* reader must still be able to
+comment, because assignment (not role) grants comment rights on a review. A
+role-based fix would pass every refusal test here and still be wrong.
+"""
+import requests
+from conftest import READER_EMAIL, CONTRIBUTOR_EMAIL
+
+
+class TestReviewCommentAuthorization:
+    """A reader who is not a participant cannot comment via either route."""
+
+    review_id = None
+    doc_id = "iso27001-a-8-11"
+
+    def test_01_open_review_without_the_reader(self, api_url, admin_headers):
+        r = requests.post(f"{api_url}/documents/{self.doc_id}/reviews",
+                          headers=admin_headers,
+                          json={"reviewers": [CONTRIBUTOR_EMAIL],
+                                "message": "comment authz test"})
+        assert r.status_code in [200, 201], f"Failed: {r.text}"
+        TestReviewCommentAuthorization.review_id = r.json()["review_id"]
+
+    def test_02_gated_route_refuses_unassigned_reader(self, api_url, reader_headers):
+        r = requests.post(f"{api_url}/reviews/{self.review_id}/comment",
+                          headers=reader_headers, json={"body": "should be refused"})
+        assert r.status_code == 403, f"Expected 403, got {r.status_code}: {r.text}"
+
+    def test_03_generic_route_refuses_the_same_write(self, api_url, reader_headers):
+        """The bypass: same intent, client-supplied review_id."""
+        r = requests.post(f"{api_url}/comments", headers=reader_headers,
+                          json={"document_id": self.doc_id,
+                                "review_id": self.review_id,
+                                "body": "injected via the generic route"})
+        assert r.status_code == 403, f"Bypass still open: {r.status_code} {r.text}"
+
+    def test_04_document_comment_without_review_id_still_allowed(self, api_url, reader_headers):
+        """Readers may comment on documents — that is what the exemption is for."""
+        r = requests.post(f"{api_url}/comments", headers=reader_headers,
+                          json={"document_id": self.doc_id, "body": "plain document comment"})
+        assert r.status_code == 201, f"Reader lost document commenting: {r.text}"
+        assert r.json()["status"] == "open", "response should echo the stored status"
+
+
+class TestAssignedReaderKeepsAccess:
+    """Assignment grants comment rights to any role — the fix must not break this."""
+
+    review_id = None
+    doc_id = "iso27001-a-8-12"
+
+    def test_01_open_review_assigning_the_reader(self, api_url, admin_headers):
+        r = requests.post(f"{api_url}/documents/{self.doc_id}/reviews",
+                          headers=admin_headers,
+                          json={"reviewers": [READER_EMAIL], "message": "assigned reader"})
+        assert r.status_code in [200, 201], f"Failed: {r.text}"
+        TestAssignedReaderKeepsAccess.review_id = r.json()["review_id"]
+
+    def test_02_assigned_reader_may_use_the_gated_route(self, api_url, reader_headers):
+        r = requests.post(f"{api_url}/reviews/{self.review_id}/comment",
+                          headers=reader_headers, json={"body": "assigned reviewer comment"})
+        assert r.status_code == 201, f"Assigned reader blocked: {r.text}"
+
+    def test_03_assigned_reader_may_use_the_generic_route(self, api_url, reader_headers):
+        r = requests.post(f"{api_url}/comments", headers=reader_headers,
+                          json={"document_id": self.doc_id,
+                                "review_id": self.review_id,
+                                "body": "assigned reviewer reply"})
+        assert r.status_code == 201, f"Assigned reader blocked on generic route: {r.text}"
+
+    def test_04_document_id_comes_from_the_review(self, api_url, reader_headers):
+        """A mismatched document_id must not decide where the comment lands."""
+        r = requests.post(f"{api_url}/comments", headers=reader_headers,
+                          json={"document_id": "iso27001-4-1",
+                                "review_id": self.review_id,
+                                "body": "document_id should be overridden"})
+        assert r.status_code == 201, r.text
+        assert r.json()["document_id"] == self.doc_id
+
+
+class TestMergedReviewIsClosed:
+    """Comments must not land on a published review."""
+
+    review_id = None
+    doc_id = "iso27001-a-8-14"
+
+    def test_01_open_approve_and_merge(self, api_url, admin_headers, reader_headers):
+        r = requests.post(f"{api_url}/documents/{self.doc_id}/reviews",
+                          headers=admin_headers,
+                          json={"reviewers": [READER_EMAIL], "message": "merge then comment"})
+        assert r.status_code in [200, 201], f"Failed: {r.text}"
+        rid = r.json()["review_id"]
+        TestMergedReviewIsClosed.review_id = rid
+
+        assert requests.post(f"{api_url}/reviews/{rid}/approve", headers=reader_headers,
+                             json={"decision": "approved", "comment": "ok"}).status_code == 200
+        assert requests.post(f"{api_url}/reviews/{rid}/merge", headers=admin_headers,
+                             json={}).status_code in [200, 201]
+
+    def test_02_generic_route_rejects_comment_on_merged_review(self, api_url, admin_headers):
+        """Even an admin cannot append to a merged review."""
+        r = requests.post(f"{api_url}/comments", headers=admin_headers,
+                          json={"document_id": self.doc_id,
+                                "review_id": self.review_id,
+                                "body": "comment on a merged review"})
+        assert r.status_code == 400, f"Expected 400, got {r.status_code}: {r.text}"
+        assert "merged" in r.text
+
+
+class TestResolveAuthorization:
+    """Resolving closes someone's feedback — it needs its own gate."""
+
+    review_id = None
+    admin_comment_id = None
+    reader_comment_id = None
+    doc_id = "iso27001-a-8-15"
+
+    def test_01_setup_review_with_comments(self, api_url, admin_headers, reader_headers):
+        r = requests.post(f"{api_url}/documents/{self.doc_id}/reviews",
+                          headers=admin_headers,
+                          json={"reviewers": [READER_EMAIL], "message": "resolve authz"})
+        assert r.status_code in [200, 201], f"Failed: {r.text}"
+        TestResolveAuthorization.review_id = r.json()["review_id"]
+
+        r = requests.post(f"{api_url}/reviews/{self.review_id}/comment",
+                          headers=admin_headers, json={"body": "admin feedback"})
+        assert r.status_code == 201, r.text
+        TestResolveAuthorization.admin_comment_id = r.json()["id"]
+
+        r = requests.post(f"{api_url}/reviews/{self.review_id}/comment",
+                          headers=reader_headers, json={"body": "reader feedback"})
+        assert r.status_code == 201, r.text
+        TestResolveAuthorization.reader_comment_id = r.json()["id"]
+
+    def test_02_author_may_resolve_own_comment(self, api_url, reader_headers):
+        r = requests.post(f"{api_url}/comments/{self.reader_comment_id}/resolve",
+                          headers=reader_headers)
+        assert r.status_code == 200, f"Author blocked from own comment: {r.text}"
+
+    def test_03_participant_may_resolve_others_comment(self, api_url, reader_headers):
+        """The reader is an assigned reviewer here, so resolving is legitimate."""
+        r = requests.post(f"{api_url}/comments/{self.admin_comment_id}/resolve",
+                          headers=reader_headers)
+        assert r.status_code == 200, f"Participant blocked: {r.text}"
+
+    def test_04_non_participant_reader_cannot_resolve(self, api_url, admin_headers, reader_headers):
+        """A review the reader has nothing to do with."""
+        r = requests.post(f"{api_url}/documents/iso27001-a-8-16/reviews",
+                          headers=admin_headers,
+                          json={"reviewers": [CONTRIBUTOR_EMAIL], "message": "not the reader's review"})
+        assert r.status_code in [200, 201], r.text
+        rid = r.json()["review_id"]
+
+        r = requests.post(f"{api_url}/reviews/{rid}/comment", headers=admin_headers,
+                          json={"body": "admin feedback the reader must not touch"})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+
+        r = requests.post(f"{api_url}/comments/{cid}/resolve", headers=reader_headers)
+        assert r.status_code == 403, f"Expected 403, got {r.status_code}: {r.text}"
+
+        # and the comment is genuinely untouched
+        r = requests.get(f"{api_url}/comments/open", headers=admin_headers)
+        assert r.status_code == 200
+        rows = r.json().get("data") or []
+        assert any(row["id"] == cid for row in rows), "comment should still be open"
+
+
+class TestEntityCommentAuthorization:
+    """POST /entity-comments is a contributor-and-above write (#23)."""
+
+    def test_01_reader_cannot_comment_on_a_register_entity(self, api_url, admin_headers, reader_headers):
+        r = requests.post(f"{api_url}/risks", headers=admin_headers,
+                          json={"title": "comment authz risk", "likelihood": 3, "impact": 3})
+        assert r.status_code in [200, 201], r.text
+        risk = r.json()
+        identifier = risk.get("identifier") or str(risk.get("id"))
+
+        r = requests.post(f"{api_url}/entity-comments", headers=reader_headers,
+                          json={"entity_type": "risk", "entity_id": identifier,
+                                "body": "reader comment on a register entity"})
+        assert r.status_code == 403, f"Expected 403, got {r.status_code}: {r.text}"
+
+        r = requests.post(f"{api_url}/entity-comments", headers=admin_headers,
+                          json={"entity_type": "risk", "entity_id": identifier,
+                                "body": "admin comment is fine"})
+        assert r.status_code in [200, 201], r.text
+
+    def test_02_contributor_may_comment(self, api_url, admin_headers, contributor_headers):
+        r = requests.post(f"{api_url}/risks", headers=admin_headers,
+                          json={"title": "contributor comment risk", "likelihood": 2, "impact": 2})
+        assert r.status_code in [200, 201], r.text
+        risk = r.json()
+        identifier = risk.get("identifier") or str(risk.get("id"))
+
+        r = requests.post(f"{api_url}/entity-comments", headers=contributor_headers,
+                          json={"entity_type": "risk", "entity_id": identifier,
+                                "body": "contributor comment"})
+        assert r.status_code in [200, 201], f"Contributor blocked: {r.text}"

--- a/web/src/components/CommentsPanel.vue
+++ b/web/src/components/CommentsPanel.vue
@@ -11,7 +11,7 @@
     </div>
 
     <!-- Add -->
-    <div class="border-t border-slate-800 pt-4 space-y-2">
+    <div v-if="canComment" class="border-t border-slate-800 pt-4 space-y-2">
       <MentionTextarea v-model="newComment" :members="members"
         class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500 resize-none"
         placeholder="Add a comment... (type @ to mention)"
@@ -27,16 +27,23 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { api } from '../api'
 import MentionTextarea from './MentionTextarea.vue'
 import { useMembers } from '../composables/useMembers'
 import { renderMention } from '../composables/useMention'
+import { useSession } from '../composables/useSession'
 import { useToast } from '../composables/useToast'
 
 const { show: showError } = useToast()
 
 const { members } = useMembers()
+
+// Commenting on a register entity is a contributor-and-above write; readers are
+// read-only (#23). Same rule and same reason as SuggestNewButton.vue — hide the
+// composer rather than let it 403 on submit.
+const { currentUserData } = useSession()
+const canComment = computed(() => (currentUserData.value?.role || '') !== 'reader')
 
 const props = defineProps({
   entityType: { type: String, required: true },

--- a/web/src/components/DocumentViewer.vue
+++ b/web/src/components/DocumentViewer.vue
@@ -85,7 +85,7 @@
                   <span class="text-[10px] text-emerald-500 font-medium">Resolved</span>
                 </div>
                 <button
-                  v-else
+                  v-else-if="canResolveComment(comment)"
                   @click="doResolveComment(comment.id)"
                   class="ml-auto text-[10px] text-slate-500 hover:text-emerald-400 transition-colors"
                 >Resolve</button>
@@ -148,7 +148,7 @@
               </div>
 
               <!-- Reply button -->
-              <div v-if="comment.status !== 'resolved'" class="mt-1.5">
+              <div v-if="comment.status !== 'resolved' && props.canComment" class="mt-1.5">
                 <button
                   v-if="replyingTo !== comment.id"
                   @click="replyingTo = comment.id; replyText = ''"
@@ -248,7 +248,20 @@ const props = defineProps({
   showComments: { type: Boolean, default: true },
   showReviewProgress: { type: Boolean, default: false },
   canAcceptSuggestions: { type: Boolean, default: false },
+  // Whether the viewer may write comments here, and whether they may resolve
+  // other people's. Both default to true because without a review in play these
+  // are plain document comments, which readers are entitled to (the deliberate
+  // exemption in RoleMiddleware). The review-scoped caller passes the real rule.
+  canComment: { type: Boolean, default: true },
+  canResolveComments: { type: Boolean, default: true },
 })
+
+// Mirrors handleResolveCommentDB: admin/manager or a participant in the comment's
+// review (both folded into canResolveComments by the caller), or the comment's own
+// author. Hide the control rather than let it 403 on click.
+function canResolveComment(comment) {
+  return props.canResolveComments || (!!comment?.author && comment.author === getCurrentUser())
+}
 
 const emit = defineEmits(['comment', 'resolve', 'suggestion-accepted'])
 

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -91,7 +91,7 @@
             <div v-if="c.quote" class="mt-2 text-xs text-slate-600 border-l-2 border-slate-700 pl-2 italic truncate">"{{ c.quote }}"</div>
             <div class="mt-3 flex gap-2">
               <button @click="goToComment(c)" class="text-xs text-blue-400 hover:text-blue-300 cursor-pointer">View in document →</button>
-              <button @click="resolveFromInbox(c.id)" class="text-xs text-slate-500 hover:text-emerald-400 ml-auto">Resolve</button>
+              <button v-if="canResolveComment(c)" @click="resolveFromInbox(c.id)" class="text-xs text-slate-500 hover:text-emerald-400 ml-auto">Resolve</button>
             </div>
           </div>
         </div>
@@ -846,6 +846,15 @@ const sortedTasks = computed(() => {
 })
 
 const canReviewSuggestions = computed(() => ['admin', 'manager'].includes(currentUserRole.value))
+
+// Resolving a comment needs manager rights or authorship of the comment itself
+// (the server also accepts a participant in the comment's review, which the
+// inbox list has no data for — those users can still resolve from the review
+// page). Hide rather than let the button 403.
+function canResolveComment(c) {
+  if (['admin', 'manager'].includes(currentUserRole.value)) return true
+  return !!c?.author && c.author === currentUserEmail.value
+}
 const openSuggestions = computed(() => suggestions.value.filter(s => s.status === 'open' || s.status === 'in_review'))
 
 const totalActionItems = computed(() => {

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -384,6 +384,8 @@
                   :show-comments="true"
                   :show-review-progress="true"
                   :can-accept-suggestions="canWrite || review?.requested_by === userEmail"
+                  :can-comment="canCommentOnReview"
+                  :can-resolve-comments="canResolveReviewComments"
                   @suggestion-accepted="onSuggestionAccepted"
                 />
               </div>
@@ -875,6 +877,26 @@ const userAssignmentStatus = computed(() => {
 })
 
 const userIsAuthor = computed(() => review.value?.requested_by === userEmail.value)
+
+// Assignment — not role — is what grants comment rights on a review (CLAUDE.md:
+// "Review assignment grants approve/comment rights to any role"), so an assigned
+// reader participates fully. Mirrors isReviewParticipant in api_collab.go.
+const userIsParticipant = computed(() =>
+  userIsAuthor.value || assignments.value.some(a => a.reviewer === userEmail.value))
+
+// Mirrors authorizeReviewComment, including its refusal on a merged or closed
+// review — a published or abandoned review is a closed record nobody appends to.
+// Hide the composer rather than let it 403 on submit.
+const canCommentOnReview = computed(() => {
+  if (!review.value) return false
+  if (review.value.status === 'merged' || review.value.status === 'closed') return false
+  return canWrite.value || userIsParticipant.value
+})
+
+// The manager/participant half of handleResolveCommentDB; DocumentViewer adds the
+// comment's own author per comment. Resolve is not gated on review status server
+// side, so it isn't gated here either.
+const canResolveReviewComments = computed(() => canWrite.value || userIsParticipant.value)
 
 // Check if a reviewer proposed a revision (edited the doc and sent back)
 const hasProposedRevision = computed(() => {


### PR DESCRIPTION
Fixes the comment-authorization issues reported privately to `security@isms.sh` per `SECURITY.md` (no public issue exists, hence no `(#n)` in the commit subject).

## What was wrong

Three comment write paths authorized nothing beyond "is authenticated":

| Route | Handler | Gap |
|---|---|---|
| `POST /comments` | `handleAddCommentDB` | binds a client-supplied `review_id`, no participant check, no review-status check |
| `POST /comments/:id/resolve` | `handleResolveCommentDB` | no check of any kind |
| `POST /entity-comments` | `handleCreateEntityComment` | no role gate |

`POST /reviews/:id/comment` has always checked requester-or-assignee — but `POST /comments` accepts the same write with the review named in the body, so the check guarded one door in a two-door room. A `reader` refused by the first route got `201` from the second, and the injected comment appears on the review timeline indistinguishable from a legitimate one. Neither route looked at review status, so comments also landed on **merged** reviews.

`RoleMiddleware`'s reader carve-out (`middleware.go`) asserted `// Allow readers to add comments (assignment check in handler)` — an invariant no handler implemented — and matched a bare `/api/v1/comments` prefix, so it also exempted `/accept` and `/reject` and would have exempted any future route beneath the prefix.

## The fix

- **One rule, both routes.** `authorizeReviewComment` + `isReviewParticipant` extracted from `handleAddReviewComment`; `handleAddCommentDB` now calls it whenever `review_id` is set. The rule is **assignment-based, not role-based** — per `CLAUDE.md`, "Review assignment grants approve/comment rights to any role", so an assigned reader still comments. A `role !== 'reader'` check would have been the wrong fix.
- **Review status is enforced** in the shared helper: `merged`/`closed` → `400 review is merged`. Checked before the participant rule so the message names the real reason.
- **`document_id` now comes from the review**, not the client, so it can't disagree with the review it's attached to.
- **Resolve is authorized**: admin/manager, the comment's author, or a participant in the comment's review.
- **`POST /entity-comments` gated to contributor and above**, mirroring `handleCreateEntitySuggestion` and its #23 rationale — the two are the contributor's write surface and had drifted apart.
- **Middleware exemption narrowed** to `POST /api/v1/comments` and the concrete `/comments/:id/resolve` path, anchored on prefix *and* suffix together so `/entity-comments/:id/resolve` cannot match it. The handler checks are the real fix; this is defence in depth.
- **Frontend**: hid the four affordances this change would otherwise turn into dead buttons — the `CommentsPanel` composer for readers (it's on every register entity page), the Inbox **Resolve** button for users who can't resolve, and in `DocumentViewer` the per-comment **Reply** and **Resolve** controls (new `can-comment` / `can-resolve-comments` props, with `Reviews.vue` passing the participant rule from `authorizeReviewComment` / `handleResolveCommentDB`). Both props default to `true`, so a review-less document viewer is unchanged: readers keep document commenting, which is what the middleware exemption exists for.

## Decision needing your confirmation

The **resolve rule** is a product call I made rather than found: *admin/manager, the comment's author, or a participant in the comment's review*. The reasoning is that the document author resolving reviewer feedback is the common case (covered by "participant"), and an author closing their own comment is uncontroversial. If you'd rather restrict it to admin/manager plus the author, it's a two-line change — say so and I'll adjust.

## Verification

- 16 new integration tests in `tests/test_comment_authorization.py`. The load-bearing ones are in `TestAssignedReaderKeepsAccess`: an assigned reader must keep access through **both** routes. A blunt role-based fix passes every refusal test in this file and fails those.
- Also covered: document comments without `review_id` still `201` for a reader; `document_id` taken from the review; `400` on a merged review even for an admin; author-resolve and participant-resolve allowed, non-participant reader refused with the comment verified still open; reader refused and contributor allowed on `entity-comments`.
- **Idempotent on a persistent stack**: the file was run twice against the same database with no reset between runs — 16 passed, then 16 passed. `handleReviewSend` reuses an already-open review, `AddReviewAssignmentTx` is `ON CONFLICT DO NOTHING`, and each test posts fresh comments.
- Full suite: **673 passed**, 1 failure — `test_brute_force_protection`, which asserts a `429` from the login limiter that the documented test env (`ISMS_RATE_LIMIT=0`) disables. Pre-existing and unrelated to this change. The test already carries a `skipif` for exactly this configuration; it did not fire because the guard reads `ISMS_RATE_LIMIT` from the **pytest process's** environment while that run exported it only to the server. Exporting it to pytest as well — which CI does job-wide — skips the test as intended, so there is nothing to fix. An earlier revision of this description misattributed the failure to `RoleMiddleware`; that was wrong, `RoleMiddleware` does correctly skip `/api/v1/auth/` (`middleware.go:363`).
- `go build ./...`, `go vet ./...`, `npm run build` all clean. No schema or migration changes.

## Related

- #192 — the reader-visible UI affordances on the Reviews and Inbox pages that already `403` **before** this change, and so are deliberately left there. The inline paragraph composer in `DocumentViewer` is one of them: it posts to the always-gated `/reviews/:id/comment`, so this change doesn't alter its behaviour and hiding it stays #192's job. Only the controls this PR would *newly* break are fixed here — the four listed above, whose paths (`POST /comments` with a `review_id`, and `POST /comments/:id/resolve`) returned `201`/`200` to anyone before this change.
- #23 — readers are read-only; the rule `entity-comments` was missing.
