### PR TITLE
fix(web): hide write controls users cannot use (#191)

### DIFF
--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -232,7 +232,7 @@
       <!-- ===================== TASKS TAB ===================== -->
       <template v-if="activeTab === 'tasks'">
         <!-- Create task button -->
-        <div class="flex justify-end">
+        <div v-if="canManageInbox" class="flex justify-end">
           <button
             @click="showTaskForm = !showTaskForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
@@ -361,7 +361,7 @@
 
             <!-- Status button (click to advance) -->
             <button
-              v-if="task.status !== 'done'"
+              v-if="task.status !== 'done' && canAdvanceTask(task)"
               @click="advanceTaskStatus(task)"
               class="flex-shrink-0"
               :title="task.status === 'open' ? 'Start task' : 'Mark done'"
@@ -430,7 +430,7 @@
       <!-- ===================== CHANGES TAB ===================== -->
       <template v-if="activeTab === 'changes'">
         <!-- Create change button -->
-        <div class="flex justify-end">
+        <div v-if="canManageInbox" class="flex justify-end">
           <button
             @click="showChangeForm = !showChangeForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
@@ -582,7 +582,7 @@
               <!-- Actions -->
               <div class="flex items-center gap-3 pt-3 border-t border-slate-800">
                 <button
-                  v-if="change.status === 'proposed'"
+                  v-if="canManageInbox && change.status === 'proposed'"
                   @click="updateChangeStatus(change, 'approved')"
                   :disabled="changeActioning"
                   class="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
@@ -590,7 +590,7 @@
                   Approve
                 </button>
                 <button
-                  v-if="change.status === 'proposed'"
+                  v-if="canManageInbox && change.status === 'proposed'"
                   @click="updateChangeStatus(change, 'rejected')"
                   :disabled="changeActioning"
                   class="px-4 py-2 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
@@ -598,7 +598,7 @@
                   Reject
                 </button>
                 <button
-                  v-if="change.status === 'approved'"
+                  v-if="canManageInbox && change.status === 'approved'"
                   @click="updateChangeStatus(change, 'implemented')"
                   :disabled="changeActioning"
                   class="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
@@ -846,6 +846,19 @@ const sortedTasks = computed(() => {
 })
 
 const canReviewSuggestions = computed(() => ['admin', 'manager'].includes(currentUserRole.value))
+
+// Mirrors handleCreateTask, handleCreateChange and handleUpdateChangeStatus in
+// api_collab.go, all of which requireRole("admin", "manager"). Hide the controls
+// rather than let them 403 with the typed input still sitting in the form.
+const canManageInbox = computed(() => ['admin', 'manager'].includes(currentUserRole.value))
+
+// handleUpdateTaskStatus is wider than canManageInbox but per-task: a contributor
+// may advance only a task assigned to them, managers and admins any task. The
+// inbox lists other people's tasks too, so this has to be evaluated per row.
+const canAdvanceTask = (task) => {
+  if (['admin', 'manager'].includes(currentUserRole.value)) return true
+  return currentUserRole.value === 'contributor' && task?.assignee === currentUserEmail.value
+}
 
 // Resolving a comment needs manager rights or authorship of the comment itself
 // (the server also accepts a participant in the comment's review, which the

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -845,18 +845,23 @@ const sortedTasks = computed(() => {
   })
 })
 
-const canReviewSuggestions = computed(() => ['admin', 'manager'].includes(currentUserRole.value))
+// Base role predicate. The computeds below stay separate because each mirrors a
+// different server-side rule; they happen to share this base today, but they are
+// free to diverge if an endpoint's requireRole() changes.
+const isManagerOrAdmin = computed(() => ['admin', 'manager'].includes(currentUserRole.value))
+
+const canReviewSuggestions = computed(() => isManagerOrAdmin.value)
 
 // Mirrors handleCreateTask, handleCreateChange and handleUpdateChangeStatus in
 // api_collab.go, all of which requireRole("admin", "manager"). Hide the controls
 // rather than let them 403 with the typed input still sitting in the form.
-const canManageInbox = computed(() => ['admin', 'manager'].includes(currentUserRole.value))
+const canManageInbox = computed(() => isManagerOrAdmin.value)
 
 // handleUpdateTaskStatus is wider than canManageInbox but per-task: a contributor
 // may advance only a task assigned to them, managers and admins any task. The
 // inbox lists other people's tasks too, so this has to be evaluated per row.
 const canAdvanceTask = (task) => {
-  if (['admin', 'manager'].includes(currentUserRole.value)) return true
+  if (isManagerOrAdmin.value) return true
   return currentUserRole.value === 'contributor' && task?.assignee === currentUserEmail.value
 }
 
@@ -865,7 +870,7 @@ const canAdvanceTask = (task) => {
 // inbox list has no data for — those users can still resolve from the review
 // page). Hide rather than let the button 403.
 function canResolveComment(c) {
-  if (['admin', 'manager'].includes(currentUserRole.value)) return true
+  if (isManagerOrAdmin.value) return true
   return !!c?.author && c.author === currentUserEmail.value
 }
 const openSuggestions = computed(() => suggestions.value.filter(s => s.status === 'open' || s.status === 'in_review'))

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -74,7 +74,7 @@
         </div>
 
         <!-- Review guide for first-time visitors -->
-        <div v-if="review.status === 'open' && !reviewGuideHidden && !userIsAuthor" class="mb-6 bg-blue-950/20 border border-blue-800/20 rounded-xl px-5 py-4">
+        <div v-if="review.status === 'open' && !reviewGuideHidden && !userIsAuthor && userCanReview" class="mb-6 bg-blue-950/20 border border-blue-800/20 rounded-xl px-5 py-4">
           <div class="flex items-start justify-between">
             <div class="space-y-2 text-sm text-blue-300/80">
               <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">1</span> Review the document and changes</div>
@@ -271,7 +271,7 @@
               </div>
 
               <!-- Comment input -->
-              <div v-if="review.status !== 'merged' && review.status !== 'closed'" class="mt-6 bg-slate-900 border border-slate-800 rounded-lg overflow-hidden">
+              <div v-if="canCommentOnReview" class="mt-6 bg-slate-900 border border-slate-800 rounded-lg overflow-hidden">
                 <div class="px-4 py-2.5 border-b border-slate-800">
                   <span class="text-xs text-slate-500 font-medium">Add a comment</span>
                 </div>
@@ -322,7 +322,7 @@
                 <SideBySideReview v-if="changesViewMode === 'split'"
                   :old-body="activeOldBody" :new-body="activeNewBody" :raw-diff="activeDiffData || ''"
                   :comment-count="review.comment_count || 0" :review-status="statusLabel(review.status)"
-                  :readonly="review.status === 'merged' || review.status === 'closed'"
+                  :readonly="!canCommentOnReview"
                   :comments="diffComments"
                   @comment="onDiffComment" />
                 <!-- Unified view (inline track changes with comments) -->
@@ -331,7 +331,7 @@
                   :author="diffMeta?.last_modified_by" :date="diffMeta?.last_modified"
                   :document-id="review?.document_id || ''" :blame-ref="diffMeta?.has_branch ? `review/${review?.id}` : ''"
                   :comments="diffComments"
-                  :readonly="review.status === 'merged' || review.status === 'closed'"
+                  :readonly="!canCommentOnReview"
                   @comment="onDiffComment" />
 
               </div>


### PR DESCRIPTION
Closes #191

## The problem

Two screens showed people buttons they were not allowed to press. A reader would type out a comment on a review, hit **Comment**, and get an error toast — with their text still sitting in the box. Same on the Inbox: **Add Task**, **Add Change Request**, and the change **Approve** / **Reject** buttons were visible to everyone, and failed for anyone who was not a manager or admin.

Nothing was ever at risk here — the server always refused these actions correctly. This is purely about the interface promising something the permissions never allowed, which reads to the user as a broken product rather than a locked door.

## What changes

Each control is now hidden from people who cannot use it, matching how the rest of the app already behaves. Concretely, per role:

| | Reader | Contributor | Manager / Admin |
|---|---|---|---|
| Comment on a review they were **assigned to** | Yes | Yes | Yes |
| Comment on a review they were **not** assigned to | Hidden | Hidden | Yes |
| Add Task, Add Change Request | Hidden | Hidden | Yes |
| Approve / Reject / Mark Implemented a change | Hidden | Hidden | Yes |
| Move a task's status forward | Hidden | Own tasks only | Any task |

The important nuance: **being assigned to a review, not job title, is what grants comment rights.** A reader who has been asked to review a document keeps the full comment box, the inline comments on the diff, and the Approve / Request Changes buttons. That behaviour is unchanged and was explicitly re-tested in both directions.

Where a control disappears, the surrounding page already explains why — the review sidebar says "You are not a reviewer on this request." No new empty screens or dead ends were introduced, and nobody loses an ability they actually had.

## Verification

Ran a real server with a real organisation and logged into the browser as three separate accounts — reader, contributor, admin. For every control, its visibility was compared against a direct check of whether the server would in fact have accepted that action for that user. They matched in all cases, including the ones where the answer differs per item (a contributor can advance their own task but not a colleague's).

## One related thing left alone

The Change Management screen has the same class of issue in a smaller form: it offers contributors a create button the server does not accept. It sits outside what this fix covers, and the scope of the contributor role was already flagged as its own discussion in #191. Happy to open a separate ticket for it.