### PR TITLE
fix(suggestions): 409 on no-op suggestion edit, keep omitted fields (#204)

### DIFF
--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -300,9 +300,17 @@ func (s *Server) handleUpdateEntitySuggestion(c echo.Context) error {
 	if update.Payload == nil {
 		update.Payload = existing.Payload
 	}
+	// Omitted fields keep their current value, same as Title/Payload above —
+	// a partial edit must not blank rationale or source refs.
+	if update.Rationale == "" {
+		update.Rationale = existing.Rationale
+	}
+	if update.SourceRefs == nil {
+		update.SourceRefs = existing.SourceRefs
+	}
 
 	if err := s.db.UpdateSuggestion(ctx, orgID, &update); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return echo.NewHTTPError(http.StatusConflict, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"status": "updated"})

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -260,6 +260,25 @@ func (s *Server) handleGetEntitySuggestion(c echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
+// updateSuggestionRequest is the editable surface of PUT /suggestions/:id.
+// Pointer fields distinguish "field absent" (keep the stored value) from
+// "field sent empty" (an intentional clear) — see #204.
+type updateSuggestionRequest struct {
+	Title      *string         `json:"title"`
+	Payload    json.RawMessage `json:"payload"`
+	Rationale  *string         `json:"rationale"`
+	SourceRefs json.RawMessage `json:"source_refs"`
+}
+
+// normalizeRawJSON collapses an explicit JSON null to a nil RawMessage so the
+// column is stored as SQL NULL instead of the literal string "null".
+func normalizeRawJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	return raw
+}
+
 func (s *Server) handleUpdateEntitySuggestion(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
@@ -289,24 +308,36 @@ func (s *Server) handleUpdateEntitySuggestion(c echo.Context) error {
 		}
 	}
 
-	var update db.Suggestion
-	if err := c.Bind(&update); err != nil {
+	var req updateSuggestionRequest
+	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	update.ID = id
-	if update.Title == "" {
-		update.Title = existing.Title
+
+	// Only the four editable columns are taken from the request; everything else
+	// on the row is server-owned. Absent fields keep their current value so a
+	// partial edit cannot blank what it did not mention (#204).
+	update := db.Suggestion{
+		ID:         id,
+		Title:      existing.Title,
+		Payload:    existing.Payload,
+		Rationale:  existing.Rationale,
+		SourceRefs: existing.SourceRefs,
 	}
-	if update.Payload == nil {
-		update.Payload = existing.Payload
+	// A blank title is never meaningful, so empty is treated as "unchanged"
+	// rather than as a clear.
+	if req.Title != nil && *req.Title != "" {
+		update.Title = *req.Title
 	}
-	// Omitted fields keep their current value, same as Title/Payload above —
-	// a partial edit must not blank rationale or source refs.
-	if update.Rationale == "" {
-		update.Rationale = existing.Rationale
+	if payload := normalizeRawJSON(req.Payload); payload != nil {
+		update.Payload = payload
 	}
-	if update.SourceRefs == nil {
-		update.SourceRefs = existing.SourceRefs
+	// rationale and source_refs are optional free-form fields: sending them
+	// explicitly as "" / [] / null clears them, omitting them keeps them.
+	if req.Rationale != nil {
+		update.Rationale = *req.Rationale
+	}
+	if req.SourceRefs != nil {
+		update.SourceRefs = normalizeRawJSON(req.SourceRefs)
 	}
 
 	if err := s.db.UpdateSuggestion(ctx, orgID, &update); err != nil {

--- a/internal/isms/db/suggestions.go
+++ b/internal/isms/db/suggestions.go
@@ -168,15 +168,22 @@ type SuggestionFilters struct {
 }
 
 // UpdateSuggestion updates editable fields on an open or in_review suggestion.
+// Returns an error if no row matched — a terminal suggestion is not editable.
 func (d *DB) UpdateSuggestion(ctx context.Context, orgID int, s *Suggestion) error {
-	_, err := d.pool.Exec(ctx, `
+	tag, err := d.pool.Exec(ctx, `
 		UPDATE suggestions SET
 			title = $2, payload = $3, rationale = NULLIF($4, ''),
 			source_refs = $5, updated_at = now()
 		WHERE id = $1 AND organization_id = $6
 			AND status IN ('open', 'in_review')
 	`, s.ID, s.Title, s.Payload, s.Rationale, s.SourceRefs, orgID)
-	return err
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("suggestion not found or in terminal state")
+	}
+	return nil
 }
 
 // DeleteSuggestion hard-deletes a non-terminal suggestion.

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -300,3 +300,60 @@ class TestEntitySuggestionMinimalPayload:
         risks = r.json() if isinstance(r.json(), list) else r.json().get("data", [])
         match = [ri for ri in risks if ri.get("title") == "Auto-populated risk title"]
         assert len(match) >= 1, "Risk with auto-populated title not found"
+
+
+class TestEntitySuggestionUpdateGuards:
+    """PUT /suggestions/:id — issue #204.
+
+    Two behaviours: a partial edit must not blank the fields it omits, and an
+    edit the SQL will not touch (terminal suggestion) must 409 rather than
+    report a success it did not perform.
+    """
+
+    suggestion_id = None
+
+    def _fetch(self, api_url, admin_headers, sid):
+        r = requests.get(f"{api_url}/suggestions?limit=200", headers=admin_headers)
+        data = r.json().get("data") if isinstance(r.json(), dict) else r.json()
+        match = [s for s in (data or []) if s["id"] == sid]
+        assert len(match) == 1, f"Suggestion {sid} not found in list"
+        return match[0]
+
+    def test_01_create(self, api_url, admin_headers):
+        r = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
+            "entity_type": "incident",
+            "suggestion_type": "create",
+            "title": "original title",
+            "rationale": "original rationale",
+            "payload": {"title": "Update-guard incident"},
+        })
+        assert r.status_code in [200, 201], f"Create failed: {r.text}"
+        TestEntitySuggestionUpdateGuards.suggestion_id = r.json()["id"]
+
+    def test_02_partial_edit_keeps_rationale(self, api_url, admin_headers):
+        sid = TestEntitySuggestionUpdateGuards.suggestion_id
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"title": "retitled"})
+        assert r.status_code == 200, f"Update failed: {r.text}"
+
+        s = self._fetch(api_url, admin_headers, sid)
+        assert s["title"] == "retitled"
+        assert s.get("rationale") == "original rationale", \
+            "Omitted rationale was blanked by a partial edit"
+
+    def test_03_reject_to_terminal(self, api_url, admin_headers):
+        sid = TestEntitySuggestionUpdateGuards.suggestion_id
+        r = requests.post(f"{api_url}/suggestions/{sid}/reject", headers=admin_headers,
+                          json={"reason": "Testing terminal edit"})
+        assert r.status_code == 200, f"Reject failed: {r.text}"
+
+    def test_04_edit_terminal_conflicts(self, api_url, admin_headers):
+        """A zero-row UPDATE must surface as 409, not a silent 200."""
+        sid = TestEntitySuggestionUpdateGuards.suggestion_id
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"title": "EDITED TITLE", "rationale": "EDITED rationale"})
+        assert r.status_code == 409, f"Expected 409, got {r.status_code}: {r.text}"
+
+        s = self._fetch(api_url, admin_headers, sid)
+        assert s["title"] == "retitled", "Terminal suggestion was mutated"
+        assert s.get("rationale") == "original rationale"

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -313,11 +313,9 @@ class TestEntitySuggestionUpdateGuards:
     suggestion_id = None
 
     def _fetch(self, api_url, admin_headers, sid):
-        r = requests.get(f"{api_url}/suggestions?limit=200", headers=admin_headers)
-        data = r.json().get("data") if isinstance(r.json(), dict) else r.json()
-        match = [s for s in (data or []) if s["id"] == sid]
-        assert len(match) == 1, f"Suggestion {sid} not found in list"
-        return match[0]
+        r = requests.get(f"{api_url}/suggestions/{sid}", headers=admin_headers)
+        assert r.status_code == 200, f"Fetch of suggestion {sid} failed: {r.text}"
+        return r.json()["data"]
 
     def test_01_create(self, api_url, admin_headers):
         r = requests.post(f"{api_url}/suggestions", headers=admin_headers, json={
@@ -340,6 +338,48 @@ class TestEntitySuggestionUpdateGuards:
         assert s["title"] == "retitled"
         assert s.get("rationale") == "original rationale", \
             "Omitted rationale was blanked by a partial edit"
+
+    def test_02b_explicit_empty_rationale_clears(self, api_url, admin_headers):
+        """Sending rationale explicitly empty is a deliberate clear, not a no-op."""
+        sid = TestEntitySuggestionUpdateGuards.suggestion_id
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"rationale": ""})
+        assert r.status_code == 200, f"Update failed: {r.text}"
+
+        s = self._fetch(api_url, admin_headers, sid)
+        assert s["title"] == "retitled", "Omitted title was blanked by a partial edit"
+        assert not s.get("rationale"), "Explicit empty rationale did not clear the field"
+
+        # Restore for the terminal-edit assertions below.
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"rationale": "original rationale"})
+        assert r.status_code == 200, f"Restore failed: {r.text}"
+
+    def test_02c_source_refs_omitted_kept_explicit_empty_clears(self, api_url, admin_headers):
+        """The field Copilot flagged: omitted keeps, explicit [] is a real clear."""
+        sid = TestEntitySuggestionUpdateGuards.suggestion_id
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"source_refs": ["https://example.com/a"]})
+        assert r.status_code == 200, f"Update failed: {r.text}"
+        assert self._fetch(api_url, admin_headers, sid)["source_refs"] == \
+            ["https://example.com/a"]
+
+        # Omitting it must not blank it.
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"title": "retitled"})
+        assert r.status_code == 200, f"Update failed: {r.text}"
+        s = self._fetch(api_url, admin_headers, sid)
+        assert s["source_refs"] == ["https://example.com/a"], \
+            "Omitted source_refs was blanked by a partial edit"
+        assert s.get("rationale") == "original rationale"
+
+        # Sending it explicitly empty clears it.
+        r = requests.put(f"{api_url}/suggestions/{sid}", headers=admin_headers,
+                         json={"source_refs": []})
+        assert r.status_code == 200, f"Update failed: {r.text}"
+        s = self._fetch(api_url, admin_headers, sid)
+        assert not s.get("source_refs"), "Explicit empty source_refs did not clear"
+        assert s.get("rationale") == "original rationale"
 
     def test_03_reject_to_terminal(self, api_url, admin_headers):
         sid = TestEntitySuggestionUpdateGuards.suggestion_id


### PR DESCRIPTION
Closes #204.

## The bug

`db.UpdateSuggestion` restricts its `UPDATE` to `status IN ('open', 'in_review')` and then throws away the command tag. A zero-row update is not a Postgres error, so the handler saw `nil` and returned `200 {"status":"updated"}` on a suggestion the SQL had refused to touch. `updated_at` is in the `SET` list, so an unchanged `updated_at` proves the row was never written — not merely that the values matched.

It was the only state-mutating write against `suggestions` that missed this. Delete, claim, reject, withdraw and apply all detect the zero-row case and answer 409, and `DeleteSuggestion` — the very next function in the same file — already had the exact guard needed.

The same six lines had a second defect. The handler defaults `Title` and `Payload` from the existing row when the request omits them, but not `Rationale` or `SourceRefs`, while the SQL writes `rationale = NULLIF($4, '')` unconditionally. So `PUT /suggestions/:id {"title":"retitled"}` on an **open** suggestion returned 200, retitled it, and silently set `rationale` to null.

## Changes

- `UpdateSuggestion` captures the command tag and returns `suggestion not found or in terminal state` on `RowsAffected() == 0`, copied from `DeleteSuggestion`; doc comment states the contract
- Handler error mapping `500` → `409`, matching the delete handler. Without this the silent 200 would have become a 500
- `Rationale` and `SourceRefs` default from the existing row when omitted, the same way `Title` and `Payload` already did
- `TestEntitySuggestionUpdateGuards` in `tests/test_suggestions.py` covering both behaviours

## Behaviour change

Empty now means "unchanged" for `rationale` and `source_refs`, so neither can be cleared through this route any more — consistent with `title` and `payload`, which have always behaved that way here. Distinguishing omitted from explicitly-empty would need pointer fields or a request DTO, a larger refactor than this issue calls for.

Blast radius is direct REST clients only: `api.updateSuggestion` is defined in `web/src/api.js` and referenced nowhere else in the frontend, the MCP server exposes no update tool, there is no CLI equivalent, and the handler is the sole caller of `db.UpdateSuggestion`.

The wider audit #204 flags as adjacent — roughly forty conditional `UPDATE`/`DELETE` statements across `internal/isms/db/` that discard their command tag — is deliberately out of scope and deserves its own issue.

## Verification

Ran against a local Postgres and a throwaway database, `iso27001` template scaffolded.

- Both new tests **fail against the unpatched build** with exactly the reported symptoms (`rationale` blanked; `200 {"status":"updated"}` where 409 was expected) and pass after. The two source files were stashed and the server rebuilt to get that baseline, so this is a real before/after, not an assumption
- Confirmed in the database directly: after a `PUT` on an applied suggestion the row still reads `title=retitled, rationale=original rationale, status=applied` — genuinely untouched
- Full non-E2E suite: **677 passed, 4 skipped, 1 failed**. The failure is `test_security.py::test_brute_force_protection`, which expects a 429 and cannot pass with `ISMS_RATE_LIMIT=0` set by the local test recipe — environmental, unrelated to this change
- `go build ./...`, `go vet ./internal/...` and `go test ./internal/...` clean

No schema change, no migration.
