### PR TITLE
feat(risks): per-org custom risk categories (#213)

### DIFF
--- a/cmd/isms/risk.go
+++ b/cmd/isms/risk.go
@@ -2,11 +2,19 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"isms.sh/internal/isms/db"
 	riskpkg "isms.sh/internal/isms/risk"
 )
+
+// riskCategoryFlagHelp derives the --category help text from the default
+// category list so it can never drift, and notes that an org may define its own.
+func riskCategoryFlagHelp() string {
+	return fmt.Sprintf("Category (defaults: %s; your organization may define its own)",
+		strings.Join(db.RiskCategories, ", "))
+}
 
 func riskCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -104,7 +112,7 @@ func riskAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "desc", "", "Description of what could happen")
 	cmd.Flags().StringVar(&riskType, "risk-type", "threat", "Risk type: threat, opportunity")
 	cmd.Flags().StringVar(&origin, "origin", "internal", "Origin: internal, external, 'internal and external'")
-	cmd.Flags().StringVar(&category, "category", "", "Category: people_processes, technology_operations, product_development, grc, physical_security")
+	cmd.Flags().StringVar(&category, "category", "", riskCategoryFlagHelp())
 	cmd.Flags().StringSliceVar(&assets, "assets", nil, "Affected asset IDs (comma-separated)")
 	cmd.Flags().IntVar(&currentLikelihood, "likelihood", 0, "Current likelihood (1-5)")
 	cmd.Flags().IntVar(&currentImpact, "impact", 0, "Current impact (1-5)")

--- a/internal/isms/api/api_admin.go
+++ b/internal/isms/api/api_admin.go
@@ -376,6 +376,15 @@ func (s *Server) handleAdminUpdateSetting(c echo.Context) error {
 		}
 	}
 
+	// Risk categories are consumed as JSON by risk create/edit validation, so a
+	// malformed blob stored here would break the risk register org-wide. Empty
+	// is allowed and meaningful: it reverts the org to the built-in defaults.
+	if req.Key == "risk_categories" && strings.TrimSpace(req.Value) != "" {
+		if _, err := db.ParseRiskCategories(req.Value); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+	}
+
 	if err := s.db.SetOrgSetting(ctx, orgID, req.Key, req.Value); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "updating setting: "+err.Error())
 	}

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -663,6 +663,12 @@ func applyRiskCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	if payload.Title == "" {
 		return "", fmt.Errorf("title is required in risk payload")
 	}
+	// The suggestion payload is not bound through the risk handlers, so the
+	// category has to be validated here. validateEnum returns an *echo.HTTPError,
+	// which the apply caller unwraps into a 400.
+	if err := validateEnum("category", payload.Category, s.riskCategoryKeys(ctx, orgID)); err != nil {
+		return "", err
+	}
 
 	risk := db.Risk{
 		Title:             payload.Title,
@@ -684,9 +690,9 @@ func applyRiskCreate(ctx context.Context, tx pgx.Tx, s *Server, orgID int, sg *d
 	if risk.Origin == "" {
 		risk.Origin = "internal"
 	}
-	if risk.Category == "" {
-		risk.Category = "technology"
-	}
+	// No default for Category: the column is nullable and empty is a valid
+	// "uncategorised". Picking the first configured category would be
+	// order-dependent and surprising.
 	if risk.CurrentLikelihood == nil {
 		l := 3
 		risk.CurrentLikelihood = &l

--- a/internal/isms/api/risk_categories_test.go
+++ b/internal/isms/api/risk_categories_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"isms.sh/internal/isms/db"
+)
+
+// #213: risk categories are per-org. These tests cover the parts of the API
+// layer that are reachable without a Postgres instance — this repo has no
+// DB-backed test harness, so anything that reads or writes organization_settings
+// is exercised at the boundary only (see the notes on each test).
+
+// newSettingsContext builds an echo context for handleAdminUpdateSetting with
+// the org id where getOrgID looks for it.
+func newSettingsContext(body string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/settings", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("org_id", 1)
+	c.Set("user_email", "admin@example.com")
+	return c, rec
+}
+
+// TestAdminUpdateSettingRejectsMalformedRiskCategories: the settings PUT used to
+// accept arbitrary text for any key, so an admin could store a blob that broke
+// risk create/edit org-wide. The handler must now reject a malformed
+// risk_categories payload before it reaches SetOrgSetting.
+//
+// The server is built with a nil *db.DB on purpose: reaching the store would
+// panic, so a clean 400 is positive proof the stored value was never touched.
+func TestAdminUpdateSettingRejectsMalformedRiskCategories(t *testing.T) {
+	s := &Server{}
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"truncated JSON", `{"key":"risk_categories","value":"[{\"key\":\"a\","}`},
+		{"not an array", `{"key":"risk_categories","value":"{\"key\":\"a\",\"label\":\"A\"}"}`},
+		{"empty array", `{"key":"risk_categories","value":"[]"}`},
+		{"uppercase key", `{"key":"risk_categories","value":"[{\"key\":\"Bad\",\"label\":\"Bad\"}]"}`},
+		{"blank label", `{"key":"risk_categories","value":"[{\"key\":\"ok\",\"label\":\"  \"}]"}`},
+		{"duplicate keys differing in case", `{"key":"risk_categories","value":"[{\"key\":\"ok\",\"label\":\"A\"},{\"key\":\"OK\",\"label\":\"B\"}]"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newSettingsContext(tc.body)
+			err := s.handleAdminUpdateSetting(c)
+			if err == nil {
+				t.Fatal("expected a 400, got nil error (value would have been stored)")
+			}
+			he, ok := err.(*echo.HTTPError)
+			if !ok {
+				t.Fatalf("expected *echo.HTTPError, got %T: %v", err, err)
+			}
+			if he.Code != http.StatusBadRequest {
+				t.Errorf("status=%d, want 400 (%v)", he.Code, he.Message)
+			}
+		})
+	}
+}
+
+// A missing key is still rejected up front, and an unrelated key is NOT run
+// through the risk-category validator (that would break every other setting).
+// The unrelated-key case must not be added here: it falls through to
+// SetOrgSetting and needs a real DB.
+func TestAdminUpdateSettingRequiresKey(t *testing.T) {
+	s := &Server{}
+	c, _ := newSettingsContext(`{"key":"","value":"whatever"}`)
+	err := s.handleAdminUpdateSetting(c)
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusBadRequest {
+		t.Fatalf("expected a 400 HTTPError, got %T %v", err, err)
+	}
+}
+
+// TestRiskCategoryAllowedSetSemantics locks in the validation contract shared by
+// risk create (server.go), risk update (server.go) and suggestion apply
+// (api_suggestions.go). All three call validateEnum with the keys of the org's
+// configured categories, which is what riskCategoryKeys returns; the allowed-set
+// is built here directly because riskCategoryKeys needs a live DB.
+func TestRiskCategoryAllowedSetSemantics(t *testing.T) {
+	// Unset setting → RiskCategoriesFor falls back to the defaults, so the
+	// allowed-set is the 8 built-in keys.
+	defaults := keysOf(db.DefaultRiskCategories())
+
+	for _, tc := range []struct {
+		name    string
+		allowed []string
+		value   string
+		wantErr bool
+	}{
+		{"default category with the setting unset", defaults, "technology", false},
+		{"another default category", defaults, "quality_operations", false},
+		{"empty category is always accepted (uncategorised)", defaults, "", false},
+		{"custom key rejected while the setting is unset", defaults, "cloud_saas", true},
+		{"unknown key rejected", defaults, "not_a_category", true},
+		{"case mismatch rejected — keys are exact", defaults, "Technology", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEnum("category", tc.value, tc.allowed)
+			assertEnum(t, err, tc.wantErr)
+		})
+	}
+
+	// Once a custom list is configured, its keys are the allowed-set and the old
+	// defaults are no longer selectable (removal orphans, it does not cascade).
+	custom, err := db.ParseRiskCategories(`[{"key":"cloud_saas","label":"Cloud / SaaS"},{"key":"people_process","label":"Our People"}]`)
+	if err != nil {
+		t.Fatalf("fixture failed to parse: %v", err)
+	}
+	customKeys := keysOf(custom)
+
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"configured custom key accepted", "cloud_saas", false},
+		{"retained default key accepted", "people_process", false},
+		{"empty still accepted", "", false},
+		{"default key dropped from the custom list is rejected", "technology", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEnum(t, validateEnum("category", tc.value, customKeys), tc.wantErr)
+		})
+	}
+}
+
+func keysOf(cats []db.RiskCategory) []string {
+	keys := make([]string, 0, len(cats))
+	for _, c := range cats {
+		keys = append(keys, c.Key)
+	}
+	return keys
+}
+
+func assertEnum(t *testing.T, err error, wantErr bool) {
+	t.Helper()
+	if wantErr {
+		he, ok := err.(*echo.HTTPError)
+		if !ok {
+			t.Fatalf("expected *echo.HTTPError, got %T: %v", err, err)
+		}
+		if he.Code != http.StatusBadRequest {
+			t.Errorf("status=%d, want 400", he.Code)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/isms/api/risk_categories_test.go
+++ b/internal/isms/api/risk_categories_test.go
@@ -158,3 +158,34 @@ func assertEnum(t *testing.T, err error, wantErr bool) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// TestRiskCategoryNeedsValidation pins the update-path gate. The unchanged-value
+// case is the one that matters: a risk holding a category the org has since
+// removed must stay editable, otherwise removing a category silently freezes
+// every risk still using it (reported in review on PR #215).
+func TestRiskCategoryNeedsValidation(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	for _, tc := range []struct {
+		name      string
+		requested *string
+		current   string
+		want      bool
+	}{
+		{"omitted — editing other fields only", nil, "technology", false},
+		{"omitted on a risk with an orphaned category", nil, "removed_key", false},
+		{"unchanged orphaned value resubmitted by a full-form PUT", ptr("removed_key"), "removed_key", false},
+		{"unchanged valid value", ptr("technology"), "technology", false},
+		{"changed to another value — must be validated", ptr("technology"), "removed_key", true},
+		{"cleared to empty — must be validated", ptr(""), "technology", true},
+		{"set on a risk that had none", ptr("technology"), "", true},
+		{"case-only difference is a change", ptr("Technology"), "technology", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := riskCategoryNeedsValidation(tc.requested, tc.current); got != tc.want {
+				t.Errorf("riskCategoryNeedsValidation(%v, %q) = %v, want %v",
+					tc.requested, tc.current, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -2092,6 +2092,19 @@ func (s *Server) handleListRiskCategories(c echo.Context) error {
 // riskCategoryKeys returns just the category keys for an org, for use as the
 // allowed set in validateEnum. RiskCategoriesFor always falls back to the
 // defaults, so this never returns an empty slice.
+// riskCategoryNeedsValidation reports whether a risk update's category has to be
+// checked against the org's allowed set.
+//
+// Omitted (nil) is skipped so a risk can be edited without touching its category.
+// An UNCHANGED value is skipped too, and that case is load-bearing: a risk may
+// hold a category the org has since removed, and any read-modify-write client —
+// the web edit form always PUTs the whole form — would otherwise resubmit that
+// orphaned key and be rejected, leaving the risk permanently uneditable.
+// Removing a category orphans the value, it does not freeze the risk.
+func riskCategoryNeedsValidation(requested *string, current string) bool {
+	return requested != nil && *requested != current
+}
+
 func (s *Server) riskCategoryKeys(ctx context.Context, orgID int) []string {
 	cats, _ := s.db.RiskCategoriesFor(ctx, orgID)
 	keys := make([]string, 0, len(cats))
@@ -2600,9 +2613,7 @@ func (s *Server) handleUpdateRisk(c echo.Context) error {
 			return err
 		}
 	}
-	// Gated on req.Category != nil so a risk holding an orphaned category (one
-	// the org has since removed) can still be edited in other fields.
-	if req.Category != nil {
+	if riskCategoryNeedsValidation(req.Category, old.Category) {
 		if err := validateEnum("category", *req.Category, s.riskCategoryKeys(ctx, orgID)); err != nil {
 			return err
 		}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -562,6 +562,7 @@ func (s *Server) routes() {
 	api.PUT("/risks/:id", s.handleUpdateRisk)
 	api.DELETE("/risks/:id", s.handleDeleteRisk)
 	api.GET("/risks/matrix", s.handleRiskMatrix)
+	api.GET("/risks/categories", s.handleListRiskCategories)
 	api.GET("/risks/:id/advisories", s.handleRiskAdvisories)
 	api.GET("/risks/:id/readings", s.handleListRiskReadings)
 	api.POST("/risks/:id/readings", s.handleCreateRiskReading)
@@ -2076,6 +2077,30 @@ func (s *Server) handleRiskStats(c echo.Context) error {
 	return c.JSON(http.StatusOK, stats)
 }
 
+// handleListRiskCategories returns the risk categories configured for the
+// caller's org. Available to any authenticated org member — the risk views need
+// it to render their pickers, so it is not admin-only data.
+func (s *Server) handleListRiskCategories(c echo.Context) error {
+	orgID := getOrgID(c)
+	cats, err := s.db.RiskCategoriesFor(c.Request().Context(), orgID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, cats)
+}
+
+// riskCategoryKeys returns just the category keys for an org, for use as the
+// allowed set in validateEnum. RiskCategoriesFor always falls back to the
+// defaults, so this never returns an empty slice.
+func (s *Server) riskCategoryKeys(ctx context.Context, orgID int) []string {
+	cats, _ := s.db.RiskCategoriesFor(ctx, orgID)
+	keys := make([]string, 0, len(cats))
+	for _, c := range cats {
+		keys = append(keys, c.Key)
+	}
+	return keys
+}
+
 func (s *Server) handleListRisks(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
@@ -2174,7 +2199,7 @@ func (s *Server) handleAddRisk(c echo.Context) error {
 	if err := validateEnum("origin", r.Origin, db.RiskOrigins); err != nil {
 		return err
 	}
-	if err := validateEnum("category", r.Category, db.RiskCategories); err != nil {
+	if err := validateEnum("category", r.Category, s.riskCategoryKeys(ctx, orgID)); err != nil {
 		return err
 	}
 	if err := validateEnum("treatment", r.Treatment, db.TreatmentOptions); err != nil {
@@ -2575,8 +2600,10 @@ func (s *Server) handleUpdateRisk(c echo.Context) error {
 			return err
 		}
 	}
+	// Gated on req.Category != nil so a risk holding an orphaned category (one
+	// the org has since removed) can still be edited in other fields.
 	if req.Category != nil {
-		if err := validateEnum("category", *req.Category, db.RiskCategories); err != nil {
+		if err := validateEnum("category", *req.Category, s.riskCategoryKeys(ctx, orgID)); err != nil {
 			return err
 		}
 	}

--- a/internal/isms/db/risk_categories_test.go
+++ b/internal/isms/db/risk_categories_test.go
@@ -1,0 +1,186 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// #213: risk categories became per-org data stored as a JSON array in the
+// risk_categories setting. ParseRiskCategories is the single gate in front of
+// that value — it is used both by the admin settings PUT (which turns a failure
+// into a 400) and by RiskCategoriesFor (which turns a failure into "use the
+// defaults"). Every constraint it enforces is load-bearing: a payload that slips
+// through here becomes the allowed-set for risk create/update org-wide.
+
+func TestParseRiskCategoriesValid(t *testing.T) {
+	raw := `[{"key":"people_process","label":"People & Process"},{"key":"cloud_saas","label":"  Cloud / SaaS  "}]`
+	got, err := ParseRiskCategories(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (%+v)", len(got), got)
+	}
+	if got[0] != (RiskCategory{Key: "people_process", Label: "People & Process"}) {
+		t.Errorf("got[0]=%+v, want people_process/People & Process", got[0])
+	}
+	// Labels are trimmed on the way in — the stored value is what pickers render,
+	// so leading/trailing whitespace must not survive a round-trip.
+	if got[1] != (RiskCategory{Key: "cloud_saas", Label: "Cloud / SaaS"}) {
+		t.Errorf("got[1]=%+v, want cloud_saas/\"Cloud / SaaS\" (label trimmed)", got[1])
+	}
+	// Order is preserved: the admin editor's ordering is the display ordering.
+	if got[0].Key != "people_process" || got[1].Key != "cloud_saas" {
+		t.Errorf("input order not preserved: %+v", got)
+	}
+}
+
+func TestParseRiskCategoriesRejects(t *testing.T) {
+	// 51 entries — one over the cap.
+	tooMany := make([]RiskCategory, 51)
+	for i := range tooMany {
+		tooMany[i] = RiskCategory{Key: "cat_" + string(rune('a'+i%26)) + strings.Repeat("x", i), Label: "L"}
+	}
+	tooManyJSON, err := json.Marshal(tooMany)
+	if err != nil {
+		t.Fatalf("marshalling fixture: %v", err)
+	}
+
+	longKey := strings.Repeat("k", 65)    // 65 > 64
+	longLabel := strings.Repeat("é", 101) // 101 runes > 100 (bytes would be 202)
+	okKey := strings.Repeat("k", 64)      // exactly at the cap — must pass
+	okLabel := strings.Repeat("é", 100)   // exactly at the cap — must pass
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"malformed JSON", `[{"key":"a","label":`},
+		{"not an array", `{"key":"a","label":"A"}`},
+		{"empty string", ``},
+		{"empty array", `[]`},
+		{"null", `null`},
+		{"more than 50 entries", string(tooManyJSON)},
+		{"uppercase key", `[{"key":"People_Process","label":"People"}]`},
+		{"key with spaces", `[{"key":"people process","label":"People"}]`},
+		{"leading underscore key", `[{"key":"_people","label":"People"}]`},
+		{"trailing underscore key", `[{"key":"people_","label":"People"}]`},
+		{"double underscore key", `[{"key":"people__process","label":"People"}]`},
+		{"hyphenated key", `[{"key":"people-process","label":"People"}]`},
+		{"empty key", `[{"key":"","label":"People"}]`},
+		{"missing key", `[{"label":"People"}]`},
+		{"empty label", `[{"key":"people","label":""}]`},
+		{"whitespace-only label", `[{"key":"people","label":"   \t "}]`},
+		{"missing label", `[{"key":"people"}]`},
+		{"over-long key", `[{"key":"` + longKey + `","label":"People"}]`},
+		{"over-long label", `[{"key":"people","label":"` + longLabel + `"}]`},
+		{"duplicate keys", `[{"key":"people","label":"A"},{"key":"people","label":"B"}]`},
+		// Keys are compared case-insensitively even though uppercase keys are
+		// rejected outright — the dedupe must not be the only thing standing
+		// between two rows that would collide after normalisation.
+		{"duplicate keys differing only in case", `[{"key":"people","label":"A"},{"key":"PEOPLE","label":"B"}]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRiskCategories(tc.raw)
+			if err == nil {
+				t.Fatalf("expected an error, got %+v", got)
+			}
+			if got != nil {
+				t.Errorf("expected nil categories alongside the error, got %+v", got)
+			}
+		})
+	}
+
+	// Boundary values that must be accepted, so the caps are off-by-one-proof.
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"key exactly 64 chars", `[{"key":"` + okKey + `","label":"K"}]`},
+		{"label exactly 100 runes", `[{"key":"people","label":"` + okLabel + `"}]`},
+		{"exactly 50 entries", string(mustJSON(t, tooMany[:50]))},
+		{"digits in key", `[{"key":"iso_27001_2022","label":"ISO 27001"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseRiskCategories(tc.raw); err != nil {
+				t.Errorf("expected acceptance, got error: %v", err)
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshalling fixture: %v", err)
+	}
+	return b
+}
+
+func TestDefaultRiskCategories(t *testing.T) {
+	got := DefaultRiskCategories()
+	if len(got) != 8 {
+		t.Fatalf("len=%d, want the 8 built-in categories", len(got))
+	}
+	// The default list must itself satisfy the validator — otherwise an admin
+	// could never save a lightly-edited copy of it back.
+	raw := mustJSON(t, got)
+	if _, err := ParseRiskCategories(string(raw)); err != nil {
+		t.Errorf("defaults fail their own validation: %v", err)
+	}
+	// Keys must stay in lockstep with the legacy RiskCategories slice: risks
+	// already store these strings, so a rename here is a silent data migration.
+	if len(RiskCategories) != len(got) {
+		t.Fatalf("RiskCategories has %d keys, DefaultRiskCategories has %d", len(RiskCategories), len(got))
+	}
+	for i, c := range got {
+		if c.Key != RiskCategories[i] {
+			t.Errorf("key %d: DefaultRiskCategories=%q, RiskCategories=%q", i, c.Key, RiskCategories[i])
+		}
+		if strings.TrimSpace(c.Label) == "" {
+			t.Errorf("key %q has an empty label", c.Key)
+		}
+	}
+}
+
+// TestRiskCategoriesForFallsBackOnReadError covers the fallback that keeps a
+// broken setting from bricking the risk register: when the setting cannot be
+// read, RiskCategoriesFor must return the defaults and NO error to the caller
+// (riskCategoryKeys discards the error, so a non-nil error would silently
+// produce an empty allowed-set and reject every category).
+//
+// The pool is built against an address nothing listens on. pgxpool.New is lazy,
+// so construction succeeds and the failure lands on the query — exactly the
+// shape of a real read failure. This does not reach the network beyond a
+// connection-refused on loopback.
+func TestRiskCategoriesForFallsBackOnReadError(t *testing.T) {
+	pool, err := pgxpool.New(context.Background(), "postgres://nobody@127.0.0.1:1/nodb?sslmode=disable&connect_timeout=1")
+	if err != nil {
+		t.Fatalf("building pool: %v", err)
+	}
+	defer pool.Close()
+	d := &DB{pool: pool}
+
+	cats, err := d.RiskCategoriesFor(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RiskCategoriesFor returned an error to the caller: %v", err)
+	}
+	if len(cats) == 0 {
+		t.Fatal("returned an empty slice — callers use this as the allowed-set")
+	}
+	want := DefaultRiskCategories()
+	if len(cats) != len(want) {
+		t.Fatalf("len=%d, want %d defaults", len(cats), len(want))
+	}
+	for i := range want {
+		if cats[i] != want[i] {
+			t.Errorf("cats[%d]=%+v, want %+v", i, cats[i], want[i])
+		}
+	}
+}

--- a/internal/isms/db/risks.go
+++ b/internal/isms/db/risks.go
@@ -2,10 +2,14 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // RiskListParams specifies filtering, sorting, and pagination for the risk register.
@@ -204,10 +208,119 @@ var TreatmentOptions = []string{"mitigate", "accept", "transfer", "avoid"}
 // Valid risk statuses.
 var RiskStatuses = []string{"draft", "open", "closed"}
 
-// RiskCategories defines valid risk categories.
-var RiskCategories = []string{
-	"people_process", "technology", "third_party", "legal_regulatory",
-	"physical_environmental", "business_continuity", "governance", "quality_operations",
+// RiskCategories lists the default risk category keys. Derived from
+// DefaultRiskCategories so the keys have exactly one source of truth — a
+// hand-maintained second copy is what let the CLI help text drift (#213).
+// Orgs may define their own set via the risk_categories setting; use
+// RiskCategoriesFor to resolve the list that actually applies to an org.
+var RiskCategories = defaultRiskCategoryKeys()
+
+func defaultRiskCategoryKeys() []string {
+	defaults := DefaultRiskCategories()
+	keys := make([]string, 0, len(defaults))
+	for _, c := range defaults {
+		keys = append(keys, c.Key)
+	}
+	return keys
+}
+
+// RiskCategory is one selectable risk category. Key is a slug frozen at
+// creation (risks store the key, so renaming a label needs no data migration);
+// Label is org-authored display text and is never routed through i18n.
+type RiskCategory struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+// DefaultRiskCategories returns the built-in category list used by orgs that
+// have not configured their own.
+func DefaultRiskCategories() []RiskCategory {
+	return []RiskCategory{
+		{Key: "people_process", Label: "People & Process"},
+		{Key: "technology", Label: "Technology"},
+		{Key: "third_party", Label: "Third Party"},
+		{Key: "legal_regulatory", Label: "Legal & Regulatory"},
+		{Key: "physical_environmental", Label: "Physical & Environmental"},
+		{Key: "business_continuity", Label: "Business Continuity"},
+		{Key: "governance", Label: "Governance"},
+		{Key: "quality_operations", Label: "Quality & Operations"},
+	}
+}
+
+// Bounds for a stored risk_categories payload.
+const (
+	maxRiskCategories    = 50
+	maxRiskCategoryKey   = 64
+	maxRiskCategoryLabel = 100
+)
+
+// riskCategoryKeyPattern is the slug shape for a category key: lowercase
+// alphanumeric words joined by single underscores.
+var riskCategoryKeyPattern = regexp.MustCompile(`^[a-z0-9]+(_[a-z0-9]+)*$`)
+
+// ParseRiskCategories parses and validates a risk_categories setting payload.
+// Shared by the settings PUT (which rejects bad input with a 400) and by
+// RiskCategoriesFor (which falls back to defaults instead).
+func ParseRiskCategories(raw string) ([]RiskCategory, error) {
+	var cats []RiskCategory
+	if err := json.Unmarshal([]byte(raw), &cats); err != nil {
+		return nil, fmt.Errorf("risk_categories must be a JSON array of {key, label}: %w", err)
+	}
+	if len(cats) == 0 {
+		return nil, fmt.Errorf("risk_categories must contain at least one category")
+	}
+	if len(cats) > maxRiskCategories {
+		return nil, fmt.Errorf("risk_categories must contain at most %d categories, got %d", maxRiskCategories, len(cats))
+	}
+
+	seen := make(map[string]struct{}, len(cats))
+	out := make([]RiskCategory, 0, len(cats))
+	for i, c := range cats {
+		if utf8.RuneCountInString(c.Key) > maxRiskCategoryKey {
+			return nil, fmt.Errorf("category %d: key must be at most %d characters", i+1, maxRiskCategoryKey)
+		}
+		if !riskCategoryKeyPattern.MatchString(c.Key) {
+			return nil, fmt.Errorf("category %d: key %q must be lowercase words separated by underscores", i+1, c.Key)
+		}
+		lower := strings.ToLower(c.Key)
+		if _, dup := seen[lower]; dup {
+			return nil, fmt.Errorf("category %d: duplicate key %q", i+1, c.Key)
+		}
+		seen[lower] = struct{}{}
+
+		label := strings.TrimSpace(c.Label)
+		if label == "" {
+			return nil, fmt.Errorf("category %d (%s): label is required", i+1, c.Key)
+		}
+		if utf8.RuneCountInString(label) > maxRiskCategoryLabel {
+			return nil, fmt.Errorf("category %d (%s): label must be at most %d characters", i+1, c.Key, maxRiskCategoryLabel)
+		}
+		out = append(out, RiskCategory{Key: c.Key, Label: label})
+	}
+	return out, nil
+}
+
+// RiskCategoriesFor returns the risk categories configured for an org, falling
+// back to DefaultRiskCategories whenever the stored value is unusable: an
+// unseeded settings row, an empty value, or malformed JSON. The fallback is
+// unconditional by design — a bad stored value must never be able to brick risk
+// creation org-wide. The error return is retained for future use and is
+// currently always nil.
+func (d *DB) RiskCategoriesFor(ctx context.Context, orgID int) ([]RiskCategory, error) {
+	raw, err := d.GetOrgSetting(ctx, orgID, "risk_categories")
+	if err != nil {
+		log.Printf("risk categories: reading setting for org %d: %v (using defaults)", orgID, err)
+		return DefaultRiskCategories(), nil
+	}
+	if strings.TrimSpace(raw) == "" {
+		return DefaultRiskCategories(), nil
+	}
+	cats, err := ParseRiskCategories(raw)
+	if err != nil {
+		log.Printf("risk categories: stored value for org %d is invalid: %v (using defaults)", orgID, err)
+		return DefaultRiskCategories(), nil
+	}
+	return cats, nil
 }
 
 // RiskTypes defines valid risk types.

--- a/migrations/20260823000000_custom_risk_categories.sql
+++ b/migrations/20260823000000_custom_risk_categories.sql
@@ -1,0 +1,28 @@
+-- #213: per-org custom risk categories.
+--
+-- Standalone migration, not folded into the v0.8.0 release file (see
+-- change_type_check.sql for the same precedent). v0.7.1 is already released, and
+-- the v0.8.0 file is open on the in-flight i18n branch (#212) — accumulating
+-- there would guarantee a merge conflict for a change that is independent of it.
+--
+-- Categories are stored as a JSON array in organization_settings under the
+-- 'risk_categories' key: [{"key":"people_process","label":"People & Process"}].
+-- Only the settings registry row is seeded here — GetOrgSetting does a QueryRow
+-- against `settings`, so without this row every lookup errors with "no rows".
+--
+-- default_value is NULL on purpose: defaults are virtual. An unset (or empty)
+-- value falls back to db.DefaultRiskCategories() in Go, which keeps existing
+-- orgs unchanged and lets the default list improve in later releases.
+--
+-- Deliberately NO change to risks.category — it is plain TEXT with no CHECK
+-- constraint, so a risk holding a category that was later removed stays legal
+-- at the DB level (categories orphan, they do not cascade).
+INSERT INTO settings (key, description, category, default_value, sensitive)
+VALUES (
+    'risk_categories',
+    'Risk categories available to this organization, as a JSON array of {key, label}. Empty falls back to the built-in defaults.',
+    'risk',
+    NULL,
+    false
+)
+ON CONFLICT (key) DO NOTHING;

--- a/migrations/20260823000000_v0.8.0.sql
+++ b/migrations/20260823000000_v0.8.0.sql
@@ -1,9 +1,11 @@
 -- #213: per-org custom risk categories.
 --
--- Standalone migration, not folded into the v0.8.0 release file (see
--- change_type_check.sql for the same precedent). v0.7.1 is already released, and
--- the v0.8.0 file is open on the in-flight i18n branch (#212) — accumulating
--- there would guarantee a merge conflict for a change that is independent of it.
+-- Named <timestamp>_v0.8.0.sql per the migration convention enforced by
+-- tests/test_migrations.py: one migration per release, named after the version.
+-- (change_type_check.sql is grandfathered, not a precedent — that set is frozen.)
+-- v0.7.1 is already released, so this ships in v0.8.0. The i18n branch (#212) has
+-- its own v0.8.0 file at an earlier timestamp; both apply independently, since the
+-- runner records applied migrations by filename.
 --
 -- Categories are stored as a JSON array in organization_settings under the
 -- 'risk_categories' key: [{"key":"people_process","label":"People & Process"}].

--- a/web/src/riskCategories.js
+++ b/web/src/riskCategories.js
@@ -1,0 +1,43 @@
+// Shared risk-category helpers (#213). Kept out of the views so the label
+// resolution rules are unit-testable — see test/riskCategories.test.js.
+
+// Built-in categories, mirroring db.DefaultRiskCategories(). Used as the fallback
+// so a picker is never empty when GET /risks/categories cannot be reached.
+export const DEFAULT_RISK_CATEGORIES = [
+  { key: 'people_process', label: 'People & Process' },
+  { key: 'technology', label: 'Technology' },
+  { key: 'third_party', label: 'Third Party' },
+  { key: 'legal_regulatory', label: 'Legal & Regulatory' },
+  { key: 'physical_environmental', label: 'Physical & Environmental' },
+  { key: 'business_continuity', label: 'Business Continuity' },
+  { key: 'governance', label: 'Governance' },
+  { key: 'quality_operations', label: 'Quality & Operations' },
+]
+
+// De-slug a key for display: the fallback when no definition is available.
+export function deslugCategory(key) {
+  return (key || '').replace(/_/g, ' ')
+}
+
+// Display name for a stored category key.
+//
+// Resolves against the org's configured list so an admin-authored label is what
+// the user sees — including punctuation the slug cannot carry ("Cloud / SaaS"
+// stores as `cloud_saas`). Falls back to the de-slugged key for ORPHANS:
+// categories the org has since removed, which existing risks still legitimately
+// hold and must keep displaying.
+export function categoryLabel(key, categories) {
+  if (!key) return ''
+  const hit = (categories || []).find(c => c && c.key === key)
+  return hit && hit.label ? hit.label : deslugCategory(key)
+}
+
+// Slug for a new category, matching the server's ^[a-z0-9]+(_[a-z0-9]+)*$ rule.
+export function slugifyCategory(label) {
+  return (label || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64)
+    .replace(/^_+|_+$/g, '')
+}

--- a/web/src/views/Admin.vue
+++ b/web/src/views/Admin.vue
@@ -604,6 +604,68 @@
                 <input v-else v-model="s.value" type="text"
                   class="w-full max-w-xl bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500" />
               </div>
+
+              <!-- Risk categories: bespoke editor (hidden from the generic list) -->
+              <div v-if="cat === 'risk'" class="px-5 py-4">
+                <div class="flex items-start justify-between gap-4 mb-3">
+                  <div class="flex-1 min-w-0">
+                    <label class="block text-sm font-medium text-slate-200">Risk Categories</label>
+                    <div class="text-xs text-slate-500 mt-0.5">
+                      The categories available when creating or editing a risk. Keys are generated from the
+                      label and cannot be changed afterwards, because risks store the key.
+                    </div>
+                  </div>
+                  <button @click="saveRiskCategories" :disabled="riskCategoriesSaving"
+                    class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap flex-shrink-0">
+                    {{ riskCategoriesSaving ? 'Saving...' : 'Save' }}
+                  </button>
+                </div>
+
+                <div class="w-full max-w-xl space-y-2">
+                  <div v-if="!riskCategoriesLoaded" class="text-xs text-slate-600">Loading...</div>
+                  <div v-else-if="riskCategories.length === 0" class="text-xs text-slate-600">
+                    No categories configured.
+                  </div>
+                  <div v-for="(c, i) in riskCategories" :key="c.key"
+                    class="flex items-center gap-2 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2">
+                    <div class="flex flex-col">
+                      <button @click="moveRiskCategory(i, -1)" :disabled="i === 0" title="Move up"
+                        class="text-slate-500 hover:text-slate-200 disabled:opacity-30 disabled:hover:text-slate-500 leading-none text-[10px]">▲</button>
+                      <button @click="moveRiskCategory(i, 1)" :disabled="i === riskCategories.length - 1" title="Move down"
+                        class="text-slate-500 hover:text-slate-200 disabled:opacity-30 disabled:hover:text-slate-500 leading-none text-[10px]">▼</button>
+                    </div>
+                    <input v-model="c.label" type="text" maxlength="100" placeholder="Label"
+                      class="flex-1 min-w-0 bg-slate-900 border border-slate-700 rounded-lg px-2.5 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500" />
+                    <span class="text-[11px] text-slate-500 font-mono truncate max-w-[10rem]" :title="c.key">{{ c.key }}</span>
+                    <button @click="removeRiskCategory(i)" title="Remove"
+                      class="text-slate-500 hover:text-red-400 transition-colors flex-shrink-0">
+                      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+
+                  <div class="flex items-center gap-2 pt-1">
+                    <input v-model="newCategoryLabel" type="text" maxlength="100"
+                      placeholder="New category label" @keyup.enter="addRiskCategory"
+                      class="flex-1 min-w-0 bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500" />
+                    <button @click="addRiskCategory"
+                      class="px-3 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 text-xs font-medium rounded-lg transition-colors whitespace-nowrap">
+                      Add
+                    </button>
+                  </div>
+                  <div v-if="newCategoryLabel.trim()" class="text-[10px] text-slate-600">
+                    Key: <span class="font-mono">{{ slugifyCategory(newCategoryLabel) || '—' }}</span>
+                  </div>
+                  <div class="text-[10px] text-slate-600">
+                    Removing a category does not change existing risks — they keep the value and still
+                    display and filter by it, but it is no longer selectable.
+                  </div>
+                  <div v-if="riskCategoriesMsg" class="text-xs" :class="riskCategoriesError ? 'text-red-400' : 'text-emerald-400'">
+                    {{ riskCategoriesMsg }}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div v-if="settingsMsg" class="text-xs" :class="settingsError ? 'text-red-400' : 'text-emerald-400'">{{ settingsMsg }}</div>
@@ -1027,6 +1089,10 @@ const BRANDING_SETTING_KEYS = new Set([
   'show_powered_by', 'terms_url', 'privacy_url',
 ])
 
+// Edited by dedicated UI (the Risk Categories editor in the Risk group) — hide
+// from the generic list so it does not render as a raw JSON text field.
+const HIDDEN_SETTING_KEYS = new Set(['risk_categories'])
+
 const categoryLabels = {
   notifications: 'Notifications',
   review_cycles: 'Review Cycles',
@@ -1038,6 +1104,7 @@ const settingsByCategory = computed(() => {
   const groups = {}
   for (const s of settings.value) {
     if (BRANDING_SETTING_KEYS.has(s.key)) continue
+    if (HIDDEN_SETTING_KEYS.has(s.key)) continue
     const cat = s.category || 'other'
     if (!groups[cat]) groups[cat] = []
     groups[cat].push(s)
@@ -1071,6 +1138,120 @@ async function saveSetting(s) {
     settingsError.value = true
   } finally {
     s._saving = false
+  }
+}
+
+// ---------- Risk categories editor ----------
+// Categories are org-authored data: labels are stored verbatim and are never
+// routed through a translation layer. Keys are slugs, frozen at creation, because
+// risks store the key — renaming a label must never need a data migration.
+const RISK_CATEGORY_KEY_RE = /^[a-z0-9]+(_[a-z0-9]+)*$/
+const RISK_CATEGORY_MAX = 50
+
+const riskCategories = ref([])
+const riskCategoriesLoaded = ref(false)
+const riskCategoriesSaving = ref(false)
+const riskCategoriesMsg = ref('')
+const riskCategoriesError = ref(false)
+const newCategoryLabel = ref('')
+
+async function loadRiskCategories() {
+  // Reads the *effective* list (custom, or the server defaults when unconfigured),
+  // not the raw setting value — which is NULL until an admin saves one.
+  try {
+    const data = await api.fetchJSON('/api/v1/risks/categories')
+    riskCategories.value = (Array.isArray(data) ? data : []).map(c => ({ key: c.key, label: c.label }))
+  } catch {
+    riskCategories.value = []
+  } finally {
+    riskCategoriesLoaded.value = true
+  }
+}
+
+function slugifyCategory(label) {
+  return (label || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64)
+    .replace(/^_+|_+$/g, '')
+}
+
+function setCategoryError(msg) {
+  riskCategoriesMsg.value = msg
+  riskCategoriesError.value = true
+}
+
+function addRiskCategory() {
+  const label = newCategoryLabel.value.trim()
+  riskCategoriesMsg.value = ''
+  if (!label) return setCategoryError('Enter a label first.')
+  if (label.length > 100) return setCategoryError('Label must be 100 characters or fewer.')
+  if (riskCategories.value.length >= RISK_CATEGORY_MAX) {
+    return setCategoryError(`At most ${RISK_CATEGORY_MAX} categories are allowed.`)
+  }
+  const key = slugifyCategory(label)
+  if (!key || !RISK_CATEGORY_KEY_RE.test(key)) {
+    return setCategoryError('Label must contain at least one letter or number to generate a key.')
+  }
+  if (riskCategories.value.some(c => c.key.toLowerCase() === key)) {
+    return setCategoryError(`A category with key "${key}" already exists.`)
+  }
+  riskCategories.value.push({ key, label })
+  newCategoryLabel.value = ''
+  riskCategoriesError.value = false
+}
+
+function moveRiskCategory(i, delta) {
+  const j = i + delta
+  if (j < 0 || j >= riskCategories.value.length) return
+  const list = riskCategories.value
+  ;[list[i], list[j]] = [list[j], list[i]]
+}
+
+async function removeRiskCategory(i) {
+  const cat = riskCategories.value[i]
+  if (!cat) return
+  if (riskCategories.value.length <= 1) {
+    return setCategoryError('At least one category is required.')
+  }
+  const ok = await useConfirm().ask(
+    `Remove "${cat.label}"? Risks already using it keep the value and still display and filter by it, but it will no longer be selectable on new or edited risks.`,
+    { confirm: 'Remove', variant: 'danger' },
+  )
+  if (!ok) return
+  riskCategories.value.splice(i, 1)
+  riskCategoriesMsg.value = ''
+  riskCategoriesError.value = false
+}
+
+async function saveRiskCategories() {
+  riskCategoriesMsg.value = ''
+  const list = riskCategories.value.map(c => ({ key: c.key, label: (c.label || '').trim() }))
+  if (list.length < 1 || list.length > RISK_CATEGORY_MAX) {
+    return setCategoryError(`Configure between 1 and ${RISK_CATEGORY_MAX} categories.`)
+  }
+  const seen = new Set()
+  for (const c of list) {
+    if (!c.label) return setCategoryError('Every category needs a label.')
+    if (c.label.length > 100) return setCategoryError(`Label "${c.label.slice(0, 20)}…" exceeds 100 characters.`)
+    if (c.key.length > 64 || !RISK_CATEGORY_KEY_RE.test(c.key)) {
+      return setCategoryError(`Invalid category key "${c.key}".`)
+    }
+    const lower = c.key.toLowerCase()
+    if (seen.has(lower)) return setCategoryError(`Duplicate category key "${c.key}".`)
+    seen.add(lower)
+  }
+  riskCategoriesSaving.value = true
+  try {
+    await api.putJSON('/api/v1/admin/settings', { key: 'risk_categories', value: JSON.stringify(list) })
+    riskCategories.value = list
+    riskCategoriesMsg.value = 'Risk categories saved'
+    riskCategoriesError.value = false
+  } catch (e) {
+    setCategoryError(e.message)
+  } finally {
+    riskCategoriesSaving.value = false
   }
 }
 
@@ -1118,7 +1299,7 @@ onMounted(async () => {
   }
 
   try {
-    await Promise.all([loadMembers(), loadAPIKeys(), loadOIDCProviders(), loadSettings(), loadPolicies()])
+    await Promise.all([loadMembers(), loadAPIKeys(), loadOIDCProviders(), loadSettings(), loadPolicies(), loadRiskCategories()])
     loadBrandingFromSettings()
   } finally {
     pageLoading.value = false

--- a/web/src/views/Admin.vue
+++ b/web/src/views/Admin.vue
@@ -615,10 +615,17 @@
                       label and cannot be changed afterwards, because risks store the key.
                     </div>
                   </div>
-                  <button @click="saveRiskCategories" :disabled="riskCategoriesSaving"
-                    class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap flex-shrink-0">
-                    {{ riskCategoriesSaving ? 'Saving...' : 'Save' }}
-                  </button>
+                  <div class="flex items-center gap-2 flex-shrink-0">
+                    <button @click="resetRiskCategories" :disabled="riskCategoriesSaving || !riskCategoriesCustomized"
+                      :title="riskCategoriesCustomized ? 'Discard this list and go back to the built-in defaults' : 'Already using the built-in defaults'"
+                      class="px-3 py-1.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 text-xs font-medium rounded-lg transition-colors disabled:opacity-40 whitespace-nowrap">
+                      Reset to defaults
+                    </button>
+                    <button @click="saveRiskCategories" :disabled="riskCategoriesSaving"
+                      class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap">
+                      {{ riskCategoriesSaving ? 'Saving...' : 'Save' }}
+                    </button>
+                  </div>
                 </div>
 
                 <div class="w-full max-w-xl space-y-2">
@@ -659,7 +666,8 @@
                   </div>
                   <div class="text-[10px] text-slate-600">
                     Removing a category does not change existing risks — they keep the value and still
-                    display and filter by it, but it is no longer selectable.
+                    display and filter by it, but it is no longer selectable. Reset to defaults clears
+                    your list so the organization follows the built-in categories again.
                   </div>
                   <div v-if="riskCategoriesMsg" class="text-xs" :class="riskCategoriesError ? 'text-red-400' : 'text-emerald-400'">
                     {{ riskCategoriesMsg }}
@@ -677,6 +685,7 @@
 
 <script setup>
 import { useConfirm } from '../composables/useConfirm'
+import { slugifyCategory } from '../riskCategories'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import api from '../api.js'
@@ -1080,6 +1089,7 @@ async function loadSettings() {
   try {
     const data = await api.fetchJSON('/api/v1/admin/settings')
     settings.value = (Array.isArray(data) ? data : (data?.data || [])).map(s => ({ ...s, _saving: false, _reveal: false }))
+    syncRiskCategoriesCustomized()
   } catch { /* ignore */ }
 }
 
@@ -1155,6 +1165,17 @@ const riskCategoriesMsg = ref('')
 const riskCategoriesError = ref(false)
 const newCategoryLabel = ref('')
 
+// Whether the org has a stored list of its own, as opposed to following the
+// built-in defaults. Derived from the RAW setting value (empty until an admin
+// saves one) — the effective list from GET /risks/categories cannot tell the
+// two apart. Gates the reset action, which is the only way back to defaults.
+const riskCategoriesCustomized = ref(false)
+
+function syncRiskCategoriesCustomized() {
+  const raw = settings.value.find(s => s.key === 'risk_categories')
+  riskCategoriesCustomized.value = !!(raw?.value || '').trim()
+}
+
 async function loadRiskCategories() {
   // Reads the *effective* list (custom, or the server defaults when unconfigured),
   // not the raw setting value — which is NULL until an admin saves one.
@@ -1168,14 +1189,6 @@ async function loadRiskCategories() {
   }
 }
 
-function slugifyCategory(label) {
-  return (label || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 64)
-    .replace(/^_+|_+$/g, '')
-}
 
 function setCategoryError(msg) {
   riskCategoriesMsg.value = msg
@@ -1246,7 +1259,36 @@ async function saveRiskCategories() {
   try {
     await api.putJSON('/api/v1/admin/settings', { key: 'risk_categories', value: JSON.stringify(list) })
     riskCategories.value = list
+    riskCategoriesCustomized.value = true
     riskCategoriesMsg.value = 'Risk categories saved'
+    riskCategoriesError.value = false
+  } catch (e) {
+    setCategoryError(e.message)
+  } finally {
+    riskCategoriesSaving.value = false
+  }
+}
+
+// Clears the org's stored list by writing an empty value, which the API treats as
+// "follow the built-in defaults". Without this an org that has ever saved a custom
+// list could never get back: Save rejects an empty list, removal refuses to delete
+// the last entry, and the raw setting is hidden from the generic settings list.
+async function resetRiskCategories() {
+  // ask(message, opts) — two args. A third is silently ignored, which is how the
+  // confirm label gets lost (see the 'Confirm' string passed as opts elsewhere).
+  if (!await useConfirm().ask(
+    'Reset risk categories to the built-in defaults? Your custom list is discarded. ' +
+    'Existing risks keep whatever category they already hold, and any value not in the ' +
+    'defaults simply stops being selectable.',
+    { confirm: 'Reset', variant: 'danger' },
+  )) return
+  riskCategoriesMsg.value = ''
+  riskCategoriesSaving.value = true
+  try {
+    await api.putJSON('/api/v1/admin/settings', { key: 'risk_categories', value: '' })
+    riskCategoriesCustomized.value = false
+    await loadRiskCategories()
+    riskCategoriesMsg.value = 'Reset to the built-in defaults'
     riskCategoriesError.value = false
   } catch (e) {
     setCategoryError(e.message)

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -874,7 +874,11 @@ const allAssets = ref([])
 const orgMembers = ref([])
 const pendingRefs = ref([])
 
-const riskCategories = [
+// Fallback list, mirroring db.DefaultRiskCategories(). Orgs may configure their
+// own list (admin setting `risk_categories`), served by GET /risks/categories.
+// These defaults seed the ref so the picker is never empty — not before the
+// fetch resolves, and not if it fails.
+const DEFAULT_RISK_CATEGORIES = [
   { key: 'people_process', label: 'People & Process' },
   { key: 'technology', label: 'Technology' },
   { key: 'third_party', label: 'Third Party' },
@@ -884,6 +888,15 @@ const riskCategories = [
   { key: 'governance', label: 'Governance' },
   { key: 'quality_operations', label: 'Quality & Operations' },
 ]
+
+const riskCategories = ref(DEFAULT_RISK_CATEGORIES)
+
+async function loadRiskCategories() {
+  try {
+    const res = await api.fetchJSON('/api/v1/risks/categories')
+    if (Array.isArray(res) && res.length > 0) riskCategories.value = res
+  } catch { /* keep defaults */ }
+}
 
 const newRisk = ref({
   title: '',
@@ -1212,6 +1225,7 @@ function scoreColor(score) {
 
 onMounted(async () => {
   try { const me = await api.getMe(); userRole.value = me?.role || '' } catch {}
+  loadRiskCategories()
   try {
     orgMembers.value = await api.getUsers() || []
   } catch { orgMembers.value = [] }

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -171,7 +171,7 @@
                     <span class="text-sm font-medium text-slate-200">{{ risk.title || risk.risk_id }}</span>
                     <span v-if="isOverdue(risk.next_review)" class="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-900/50 text-red-400">OVERDUE</span>
                   </div>
-                  <div v-if="risk.category" class="text-[10px] text-slate-600 mt-0.5">{{ formatLabel(risk.category) }}</div>
+                  <div v-if="risk.category" class="text-[10px] text-slate-600 mt-0.5">{{ categoryLabel(risk.category) }}</div>
                   <div v-if="risk.description" class="text-xs text-slate-500 mt-0.5 truncate max-w-xs">{{ stripMd(risk.description) }}</div>
                 </td>
                 <td class="px-5 py-3.5">
@@ -341,7 +341,7 @@
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Category</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ formatLabel(selectedRisk.category) || '—' }}</div>
+                          <div class="text-sm text-slate-300">{{ categoryLabel(selectedRisk.category) || '—' }}</div>
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Risk Type</div>
@@ -707,6 +707,7 @@
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../api'
+import { DEFAULT_RISK_CATEGORIES, categoryLabel as resolveCategoryLabel } from '../riskCategories'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
 import RefreshButton from '../components/RefreshButton.vue'
@@ -874,21 +875,9 @@ const allAssets = ref([])
 const orgMembers = ref([])
 const pendingRefs = ref([])
 
-// Fallback list, mirroring db.DefaultRiskCategories(). Orgs may configure their
-// own list (admin setting `risk_categories`), served by GET /risks/categories.
-// These defaults seed the ref so the picker is never empty — not before the
-// fetch resolves, and not if it fails.
-const DEFAULT_RISK_CATEGORIES = [
-  { key: 'people_process', label: 'People & Process' },
-  { key: 'technology', label: 'Technology' },
-  { key: 'third_party', label: 'Third Party' },
-  { key: 'legal_regulatory', label: 'Legal & Regulatory' },
-  { key: 'physical_environmental', label: 'Physical & Environmental' },
-  { key: 'business_continuity', label: 'Business Continuity' },
-  { key: 'governance', label: 'Governance' },
-  { key: 'quality_operations', label: 'Quality & Operations' },
-]
-
+// Seeded with the built-in defaults so the pickers are never empty — not before
+// the fetch resolves, and not if it fails. Overwritten by the org's configured
+// list from GET /risks/categories.
 const riskCategories = ref(DEFAULT_RISK_CATEGORIES)
 
 async function loadRiskCategories() {
@@ -955,6 +944,12 @@ function resolveUserName(email) {
 
 function formatLabel(s) {
   return (s || '').replace(/_/g, ' ')
+}
+
+// Display name for a stored category key — see src/riskCategories.js for the
+// resolution rules (configured label, de-slugged key for orphans).
+function categoryLabel(key) {
+  return resolveCategoryLabel(key, riskCategories.value)
 }
 
 function formatOrigin(o) {

--- a/web/test/riskCategories.test.js
+++ b/web/test/riskCategories.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_RISK_CATEGORIES,
+  categoryLabel,
+  deslugCategory,
+  slugifyCategory,
+} from '../src/riskCategories.js'
+
+const CONFIGURED = [
+  { key: 'cloud_saas', label: 'Cloud / SaaS' },
+  { key: 'supply_chain', label: 'Supply Chain' },
+]
+
+test('shows the configured label, not the de-slugged key', () => {
+  // Reported in review on PR #215: the fetched labels fed the pickers only, so a
+  // risk row rendered "cloud saas" instead of the admin's "Cloud / SaaS".
+  assert.equal(categoryLabel('cloud_saas', CONFIGURED), 'Cloud / SaaS')
+  assert.equal(categoryLabel('supply_chain', CONFIGURED), 'Supply Chain')
+})
+
+test('falls back to the de-slugged key for an orphaned category', () => {
+  // The org removed this category; risks still hold it and must still display.
+  assert.equal(categoryLabel('removed_key', CONFIGURED), 'removed key')
+})
+
+test('renders nothing for an empty or missing category', () => {
+  assert.equal(categoryLabel('', CONFIGURED), '')
+  assert.equal(categoryLabel(null, CONFIGURED), '')
+  assert.equal(categoryLabel(undefined, CONFIGURED), '')
+})
+
+test('survives a missing or empty category list', () => {
+  assert.equal(categoryLabel('cloud_saas', []), 'cloud saas')
+  assert.equal(categoryLabel('cloud_saas', undefined), 'cloud saas')
+})
+
+test('ignores a definition with a blank label', () => {
+  assert.equal(categoryLabel('x', [{ key: 'x', label: '' }]), 'x')
+})
+
+test('matches keys exactly — no case folding', () => {
+  assert.equal(categoryLabel('Cloud_SaaS', CONFIGURED), 'Cloud SaaS')
+})
+
+test('deslugCategory replaces underscores', () => {
+  assert.equal(deslugCategory('people_process'), 'people process')
+  assert.equal(deslugCategory(''), '')
+})
+
+test('slugifyCategory produces a server-valid key', () => {
+  const rule = /^[a-z0-9]+(_[a-z0-9]+)*$/
+  for (const [label, want] of [
+    ['Cloud / SaaS', 'cloud_saas'],
+    ['Insider Threat & Fraud', 'insider_threat_fraud'],
+    ['  Padded  Label  ', 'padded_label'],
+    ['Third-Party', 'third_party'],
+    ['ISO 27001', 'iso_27001'],
+  ]) {
+    assert.equal(slugifyCategory(label), want)
+    assert.match(slugifyCategory(label), rule)
+  }
+})
+
+test('slugifyCategory yields an empty string when nothing usable remains', () => {
+  // The caller must reject this rather than send an invalid key.
+  assert.equal(slugifyCategory('!!!'), '')
+  assert.equal(slugifyCategory('   '), '')
+})
+
+test('every built-in default is a valid key with a non-empty label', () => {
+  const rule = /^[a-z0-9]+(_[a-z0-9]+)*$/
+  assert.equal(DEFAULT_RISK_CATEGORIES.length, 8)
+  for (const c of DEFAULT_RISK_CATEGORIES) {
+    assert.match(c.key, rule)
+    assert.ok(c.label.trim().length > 0)
+  }
+})


### PR DESCRIPTION
Addresses the first half of #213: admins can now define their own risk categories instead of being locked to the eight hardcoded values.

Refs #213 — deliberately does not close it. The issue also asks for **custom fields on risks**, which is a much larger, separate feature (a generic per-org field-definition engine touching every register). That half is untouched here and wants its own issue.

## What changed

Categories are stored as a JSON array of `{key, label}` in a new `risk_categories` org setting. Orgs that have not configured anything fall back to the current eight, so nothing changes on upgrade and the defaults can still improve in later releases.

The list was previously hardcoded in `db.RiskCategories` and duplicated in `Risks.vue`, with a third copy in the CLI help text that had already drifted to five categories that no longer exist. Everything now derives from one source.

- `RiskCategory`, `DefaultRiskCategories`, `ParseRiskCategories`, `RiskCategoriesFor` in `internal/isms/db/risks.go`
- `GET /risks/categories` serves the effective list; the Risks pickers and create/update validation both read from it
- Admin editor (add, rename, reorder, remove) in the Risk settings group; the raw setting is hidden from the generic settings list rather than rendering as a JSON text field
- CLI `--category` help text is now derived

## Design decisions worth reviewing

**Keys are slugs frozen at creation.** Risks store the key, so renaming a label never requires a data migration. The editor shows the key read-only.

**Removing a category orphans, it does not cascade.** Existing risks keep the stored value, still display it and still filter by it, but it stops being selectable. Re-setting a removed key on a risk is rejected, while editing that risk's *other* fields still works — that falls out of the `req.Category != nil` guard on the update path, which is load-bearing and commented as such.

**Scope is risks only.** `risks.category` is plain `TEXT` with no CHECK constraint, which is what makes orphaning legal at the DB level and means no migration on the table. `legal_requirements.category` and `change_requests.category` both carry CHECKs, so extending this to them is a separate change.

**The migration is standalone rather than folded into a release file.** v0.7.1 is released, and the v0.8.0 file is currently open on the in-flight i18n branch, so accumulating there would guarantee a conflict for an unrelated change. There is existing precedent for standalone migrations in this repo.

## Three bugs fixed in passing

- The suggestion-apply path did not validate `category` at all, and hard-defaulted an empty one to `"technology"`. It now validates against the org's list and leaves empty as empty.
- The generic admin settings `PUT` accepted arbitrary text for any key. Since `risk_categories` now drives risk-write validation, a malformed blob stored there would have broken the risk register org-wide. It is validated and rejected with a 400; an empty value is still allowed, since that is how an org reverts to defaults.
- The CLI `--category` help text listed five categories that have not been valid for some time.

## Verification

`go build`, `go vet`, `gofmt`, `go test ./...` and `npm run build` all clean.

Unit tests fully cover `ParseRiskCategories` (valid payloads, malformed JSON, non-array, empty, over-cap, bad slugs, blank and over-long labels, case-insensitive duplicate keys, plus the accepted boundaries) and the `RiskCategoriesFor` read-error fallback. This repo has no DB-backed test harness, so the handler-level paths could not be unit-tested; they were covered against a real Postgres instead — 29 checks covering the effective list, reader reachability, the settings-PUT rejection and success paths, create/update validation, orphan behaviour, and suggestion apply (including that a rejected apply rolls back and creates no risk row).

UI walked through in Chrome against a Vite dev server: the filter dropdown and Add-Risk chips render only the configured categories; adding a category previewed the expected slug, saved, persisted with its label intact, and appeared in the Risks picker; the remove flow uses the in-app confirm carrying the orphaning warning.