### PR TITLE
feat(i18n): ship the id-ID message bundle

### DIFF
--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -149,10 +149,20 @@ let applySeq = 0
 // value (browser order, org default, fallback) never hardens into stored state
 // that would then outrank the org default on the next visit.
 //
+// One case suppresses the write even with `persist: true`: degrading to FALLBACK
+// because the chunk failed to load. That degrade is a transient failure, not a
+// choice of English, and `stored` outranks navigator.languages in the resolution
+// chain — so writing it would turn one bad network moment or one stale
+// index.html into a permanent silent downgrade that survives the chunk becoming
+// loadable again. Leaving storage untouched lets the next load retry the tag.
+//
 // Returns the applied tag, or null when a newer call superseded this one.
 export async function setLocale(tag, { persist = false } = {}) {
   const seq = ++applySeq
   let locale = negotiate(tag) ?? FALLBACK
+  // Distinguishes "ended up on English because the chunk broke" from every other
+  // route to English, which stay persistable.
+  let loadFailed = false
   if (locale !== FALLBACK && !i18n.global.availableLocales.includes(locale)) {
     try {
       const m = await loaders[locale]()
@@ -161,11 +171,12 @@ export async function setLocale(tag, { persist = false } = {}) {
     } catch {
       if (seq !== applySeq) return null
       locale = FALLBACK // chunk failed to load (offline, bad deploy)
+      loadFailed = true
     }
   }
   i18n.global.locale.value = locale
   if (typeof document !== 'undefined') document.documentElement.lang = locale
-  if (persist) {
+  if (persist && !loadFailed) {
     try {
       if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, locale)
     } catch {

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -24,7 +24,7 @@ export const STORAGE_KEY = 'isms_locale'
 // Exported so tests can register a controllable loader; production code adds a
 // static line here rather than mutating it at runtime.
 export const loaders = {
-  // 'id-ID': () => import('./locales/id-ID/index.js'),
+  'id-ID': () => import('./locales/id-ID/index.js'),
 }
 
 // Locales the server says it supports, as {tag, name} — name is the endonym, for

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -1,0 +1,30 @@
+{
+  "action": {
+    "save": "Simpan",
+    "cancel": "Batal",
+    "confirm": "Konfirmasi",
+    "close": "Tutup",
+    "create": "Buat",
+    "edit": "Ubah",
+    "delete": "Hapus",
+    "search": "Cari"
+  },
+  "state": {
+    "loading": "Memuat…",
+    "empty": "Belum ada apa pun di sini",
+    "error": "Terjadi kesalahan"
+  },
+  "validation": {
+    "required": "Kolom ini wajib diisi"
+  },
+  "entity": {},
+  "field": {},
+  "enum": {},
+  "error": {},
+  "region": {
+    "global": "Global",
+    "eu": "UE",
+    "eea": "EEA",
+    "apac": "APAC"
+  }
+}

--- a/web/src/locales/id-ID/index.js
+++ b/web/src/locales/id-ID/index.js
@@ -1,0 +1,18 @@
+// The `id-ID` message bundle: one file per area, merged into a single nested
+// keyspace. Area = the top-level key, and it is also the filename — so
+// `risks.table.header.likelihood` will live in `risks.json` and nowhere else.
+//
+// This directory mirrors `en/` file for file and key for key. Only the values
+// are translated. A key missing here is not an error: `fallbackLocale` renders
+// it in English, so a lagging translation degrades gracefully rather than
+// showing a raw key — which is also why an area file only appears here once the
+// matching `en/` one exists.
+//
+// Import attributes (`with { type: 'json' }`) are required by Node for JSON
+// modules, and understood by Vite/Rollup — the same file therefore loads both
+// in the bundler and under `node --test`.
+import common from './common.json' with { type: 'json' }
+
+export default {
+  common,
+}

--- a/web/test/i18n.test.js
+++ b/web/test/i18n.test.js
@@ -67,8 +67,14 @@ test('loadable locales always include the bundled fallback', () => {
   // A server list that omits `en` must not empty the set: `en` is bundled, so it
   // is always renderable, and a picker built from this function would otherwise
   // have no options.
-  withServerLocales([{ tag: 'id-ID', name: 'Bahasa Indonesia' }], () => {
+  // fr-FR, not id-ID: id-ID now ships a loader, so it would be renderable and
+  // the assertion would stop being about the fallback.
+  withServerLocales([{ tag: 'fr-FR', name: 'Français' }], () => {
     assert.deepEqual(loadableLocales(), ['en'])
+  })
+  // And a shipped tag is listed alongside it, in server order after the fallback.
+  withServerLocales([{ tag: 'id-ID', name: 'Bahasa Indonesia' }], () => {
+    assert.deepEqual(loadableLocales(), ['en', 'id-ID'])
   })
 })
 
@@ -100,8 +106,8 @@ test('resolution precedence: user choice beats every weaker signal', () => {
 })
 
 test('resolution falls through unrenderable signals instead of stopping', () => {
-  // Only `en` is loadable in this build, so a stored/navigator/org value naming
-  // anything else must be skipped, not returned.
+  // de-DE, fr and ja-JP are not shipped, so each must be skipped rather than
+  // returned; en-GB is the first signal that resolves.
   assert.equal(
     resolveInitialLocale({
       userLocale: 'de-DE',
@@ -110,6 +116,16 @@ test('resolution falls through unrenderable signals instead of stopping', () => 
       orgLocale: 'id-ID',
     }),
     'en',
+  )
+  // ...and with nothing renderable above it, the org default applies.
+  assert.equal(
+    resolveInitialLocale({
+      userLocale: 'de-DE',
+      stored: null,
+      navigatorLocales: ['ja-JP'],
+      orgLocale: 'id-ID',
+    }),
+    'id-ID',
   )
 })
 
@@ -180,6 +196,9 @@ test('a superseded locale load does not overwrite the newer one', async () => {
   const gate = new Promise((resolve) => {
     release = resolve
   })
+  // id-ID now ships a real static loader, so stash it and put it back rather
+  // than deleting the entry and leaving later tests with no bundle to load.
+  const realIdLoader = loaders['id-ID']
   loaders['id-ID'] = async () => {
     await gate
     return { default: { common: { action: { save: 'Simpan' } } } }
@@ -196,8 +215,37 @@ test('a superseded locale load does not overwrite the newer one', async () => {
     assert.equal(await slow, null)
     assert.equal(i18n.global.locale.value, 'fr-FR')
   } finally {
-    delete loaders['id-ID']
+    loaders['id-ID'] = realIdLoader
     delete loaders['fr-FR']
     await setLocale(FALLBACK)
   }
+})
+
+test('setLocale loads the id-ID chunk and renders it', async () => {
+  // The whole point of shipping a second locale in the foundation: prove the
+  // resolution chain against something other than the fallback bundle.
+  assert.equal(await setLocale('id-ID'), 'id-ID')
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  assert.equal(i18n.global.t('common.action.save'), 'Simpan')
+  assert.equal(i18n.global.t('common.state.loading'), 'Memuat\u2026')
+  // A bare 'id' resolves to the region variant we actually ship.
+  assert.equal(await setLocale('id'), 'id-ID')
+  await setLocale(FALLBACK)
+  assert.equal(i18n.global.t('common.action.save'), 'Save')
+})
+
+test('a key missing from a translation falls back to English', async () => {
+  // A translation lagging the keyset must render English, not a raw key — this
+  // is what lets CI warn rather than fail on missing keys.
+  await setLocale('id-ID')
+  const full = i18n.global.getLocaleMessage('id-ID')
+  const { save: _dropped, ...rest } = full.common.action
+  i18n.global.setLocaleMessage('id-ID', {
+    ...full,
+    common: { ...full.common, action: rest },
+  })
+  assert.equal(i18n.global.t('common.action.save'), 'Save')
+  assert.equal(i18n.global.t('common.action.cancel'), 'Batal')
+  i18n.global.setLocaleMessage('id-ID', full)
+  await setLocale(FALLBACK)
 })

--- a/web/test/i18n.test.js
+++ b/web/test/i18n.test.js
@@ -189,6 +189,47 @@ test('setLocale does not persist a negotiated locale unless asked', async () => 
   }
 })
 
+test('a failed chunk load does not persist the fallback over the stored tag', async () => {
+  // The degrade in setLocale's catch is reachable in production for the first
+  // time now that a locale actually ships a loader. Persisting the FALLBACK it
+  // lands on would be permanent: `stored` outranks navigator.languages, so one
+  // transient chunk failure would pin the user to English across every later
+  // load, long after the chunk became fetchable again.
+  const writes = []
+  const original = globalThis.localStorage
+  globalThis.localStorage = {
+    getItem: () => 'id-ID',
+    setItem: (k, v) => writes.push([k, v]),
+  }
+  // Mock tags, not the real id-ID: loading the shipped bundle would leave it
+  // resident in availableLocales and silently change what later tests exercise.
+  loaders['fr-FR'] = () => Promise.reject(new Error('chunk 404 — stale index.html'))
+  loaders['de-DE'] = async () => ({ default: { common: { action: { save: 'Speichern' } } } })
+  try {
+    assert.equal(await setLocale('fr-FR', { persist: true }), FALLBACK)
+    assert.deepEqual(writes, [], 'a failed load must leave stored state alone')
+    // The app still renders rather than throwing or showing raw keys.
+    assert.equal(i18n.global.t('common.action.save'), 'Save')
+    // The boundary: reaching English any other way is still a real preference.
+    // Choosing it outright...
+    assert.equal(await setLocale('en', { persist: true }), 'en')
+    assert.deepEqual(writes, [[STORAGE_KEY, 'en']])
+    // ...and a load that actually succeeds still persists, so the guard is
+    // scoped to the catch and has not disabled persistence at large.
+    assert.equal(await setLocale('de-DE', { persist: true }), 'de-DE')
+    assert.deepEqual(writes, [
+      [STORAGE_KEY, 'en'],
+      [STORAGE_KEY, 'de-DE'],
+    ])
+  } finally {
+    delete loaders['fr-FR']
+    delete loaders['de-DE']
+    if (original === undefined) delete globalThis.localStorage
+    else globalThis.localStorage = original
+    await setLocale(FALLBACK)
+  }
+})
+
 test('a superseded locale load does not overwrite the newer one', async () => {
   // main.js starts a load without awaiting it; an explicit pick can land while
   // that chunk is still in flight. The slow one must discard itself.


### PR DESCRIPTION
Part of #212. Rebased onto master now that the foundation has landed as #217 — this diff is only the locale, and the branch is a single commit on top of master.

Adds `web/src/locales/id-ID/`, mirroring `en/` file for file and key for key, and registers its lazy loader.

## Why id-ID and not pt-BR

The foundation needs a second locale that is not the fallback to prove the resolution chain, and it has to be one we can author and review ourselves.

pt-BR remains the goal of #212 and gets contributed later, against the frozen keyset — at which point adding it is one entry in the loader map plus a locale directory. Nothing here is id-ID-specific.

## Scope

The keyset is deliberately small. Nothing is extracted from components yet, so `common.json` is all there is to mirror; area files appear here as the matching `en/` ones land with their extraction PRs. What this proves is the mechanism, not coverage.

Two tests are added:

- the load-and-render path for a non-fallback locale;
- the fallback path — a key removed from the id-ID bundle at runtime renders English rather than a raw key, which is what lets CI warn instead of fail on a lagging translation.

## Two of #217's tests had to be retargeted

Both were written while id-ID was the stock example of a tag the build *cannot* render, so shipping it invalidated their premise rather than their intent:

- `loadable locales always include the bundled fallback` now uses `fr-FR` as the unrenderable tag, and gains an assertion that a shipped tag *is* listed;
- `a superseded locale load does not overwrite the newer one` stashes and restores the real static `id-ID` loader instead of `delete`-ing the entry, which would otherwise have left every later test with no bundle to load.

## Verification

`npm test` 59/59, `npm run build` clean — id-ID is a separate 0.39 kB chunk (0.29 kB gzipped), so it costs nothing to users who do not select it. `localeKeyset.test.js` from #217 now covers id-ID; the keyset diff against `en` is clean in both directions, and the three identical values are acronyms (Global, EEA, APAC).

Exercised in a browser against a local server: with `isms_locale=id-ID` the app loads the id-ID chunk on demand, `<html lang>` becomes `id-ID`, a temporarily-bound placeholder rendered "Cari", and switching back to `en` restored "Search".

## The notification-keying blocker is cleared

This PR opens the window where a second locale is reachable through `navigator.languages` alone, with no picker required — which is why it could not merge while `notifications.title` and `body` were plain pre-rendered English `TEXT`. #220 has since landed, so that is no longer a reason to hold this back.
