### PR TITLE
feat(i18n): locale picker and the full precedence chain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,21 @@ pytest tests/ -v
 - **Web UI** — Vue 3 single-file components with Tailwind CSS. Follow existing conventions.
 - Keep commits focused. One logical change per commit.
 
+## User-Facing Strings
+
+Every string a user reads in the web UI belongs in a locale file under
+`web/src/locales/`, not in a component. The same goes for dates, numbers and
+enum labels — those go through `useFormat()` and `useEnumLabel()` rather than
+being formatted or de-slugged inline, because neither survives translation.
+
+- [`web/src/locales/README.md`](web/src/locales/README.md) — the key naming
+  convention and the rules for writing translatable copy.
+- [`docs/i18n.md`](docs/i18n.md) — how locale resolution works and how to add a
+  language.
+
+Translations are very welcome, and adding one needs no architectural change:
+copy `web/src/locales/en/`, translate the values, register one loader line.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,122 @@
+# Internationalization
+
+The ISMS web app is localizable. This document is the contract: how locales are
+resolved, how to add one, and where the seams are.
+
+Related: [`web/src/locales/README.md`](../web/src/locales/README.md) holds the key
+naming convention and the rules translators and extractors work to.
+
+## The two halves
+
+**The web app owns the keyspace.** Every string a browser renders — UI copy,
+enum labels, and eventually API error messages and notification titles — is
+translated from `web/src/locales/`. One keyspace means one place a translator
+works.
+
+**The server owns only what it pushes outward.** Email and Slack/Matrix messages
+are delivered when no client exists to render them, so those need a server-side
+catalog. Everything a client can render, a client renders: the API emits stable
+error codes rather than translated prose, and notifications are stored as keys
+plus parameters rather than pre-rendered sentences.
+
+The Go package `internal/isms/i18n` is the single source of truth for *which*
+locales exist. The frontend seeds itself from `GET /config` rather than
+hardcoding a list, so the two cannot drift.
+
+## Locale resolution
+
+Highest precedence first:
+
+1. **`users.locale`** — the user's explicit choice, from the database, so it
+   survives a change of device. Exposed as `locale_preference` on `GET /me`;
+   `null` means "following the org default", which is what lets the picker show
+   *Org default* rather than a concrete language.
+2. **`localStorage.isms_locale`** — pre-login and anonymous pages.
+3. **`navigator.languages`** — in the browser's own order of preference. The
+   server does the equivalent with `Accept-Language`, honouring q-values.
+4. **The organization default** — the `default_locale` setting, editable by an
+   admin.
+5. **`en`** — the fallback, always bundled and always complete.
+
+Matching is region-tolerant in both directions: `id` resolves to `id-ID`, and
+`pt-BR` resolves to `pt-PT` if that is what ships. A tag that matches nothing
+falls through to the next signal rather than being applied — so a stale stored
+value for a dropped locale renders English instead of raw keys.
+
+Malformed tags are rejected by the server with a 400, and only *simple* tags get
+the fallback treatment: anything naming a script, variant or extension
+(`id-Latn-ID-x-junk`) is an error. The locale picker must therefore send tags
+straight from `GET /config` → `locales[].tag`, never a tag it composed itself.
+
+## API surface
+
+| Endpoint | Field | Meaning |
+|---|---|---|
+| `GET /config` | `locales[]` | `{tag, name}`; `name` is the endonym — build the picker from this |
+| `GET /config` | `default_locale` | the org default, already overridden by `Accept-Language` server-side |
+| `GET /me` | `locale` | the resolved locale — what to render in |
+| `GET /me` | `locale_preference` | the raw choice; `null` = following the org default |
+| `PUT /auth/profile` | `{locale}` | omit = unchanged, `""` = clear to the org default, bad tag = 400 |
+
+`PUT /auth/profile` takes `name` as an optional pointer, so a locale-only update
+is `{"locale":"id-ID"}`. Do **not** resend the current name alongside it — that
+is a lost-update race against a concurrent rename.
+
+## Adding a locale
+
+1. **Register it server-side** — add the tag and its endonym to the supported map
+   in `internal/isms/i18n/locale.go`, and extend `locale_test.go`.
+2. **Copy the message bundle** — `cp -r web/src/locales/en web/src/locales/<tag>`
+   and translate the values. Keep the filenames and the keys; change only the
+   right-hand side.
+3. **Register the loader** — add one line to the `loaders` map in
+   `web/src/i18n.js`:
+   ```js
+   '<tag>': () => import('./locales/<tag>/index.js'),
+   ```
+   Locales are lazy-loaded as separate chunks, so locale N+1 costs nothing to
+   users who do not select it. `en` is the exception: it is bundled, because the
+   fallback must always be resident.
+4. **Check the keyset** — the CI keyset script reports keys missing from, and
+   extra in, each non-`en` locale. Missing keys are a warning: `fallbackLocale`
+   renders them in English, and a translation lagging by a few keys must not
+   block an unrelated PR. Extra keys **fail** — they are typos or stale keys with
+   no English counterpart.
+5. **QA the layout.** Translated copy is routinely 20–25% longer than English.
+   Check table headers, status badges, the sidebar and button rows for overflow.
+
+## The five seams
+
+No component formats a date, derives a label from an enum value, or holds a
+literal. Each category of translatable thing has exactly one implementation:
+
+| Seam | Module |
+|---|---|
+| UI copy | `useI18n()` from vue-i18n; `t` exported from `@/i18n` for plain `.js` modules |
+| Enum labels | `composables/useEnumLabel.js` |
+| Dates and numbers | `composables/useFormat.js` |
+| Relative time | `useFormat().relative()`, backed by `Intl.RelativeTimeFormat` |
+| Region names | `Intl.DisplayNames`, so country names need no translation file in any language |
+
+`useI18n()` needs an active component instance, so it is unavailable in `api.js`,
+`utils.js` and router guards. Those import the global scope instead:
+
+```js
+import { t } from '@/i18n'
+```
+
+Same keyspace, no second mechanism.
+
+## Out of scope
+
+**Document and template content.** Templates load from `ISMS_TEMPLATE_PATH` as a
+separate git repository; folder names, `.title` files and markdown bodies are all
+template-maintainer choices. A Portuguese ISO 9001 template directory needs zero
+code changes. Do not add locale awareness to the document engine — templates are
+already the correct seam, and the core stays standard-agnostic.
+
+**User-authored content** — document bodies, comments, risk descriptions. That is
+organization-owned data, not product copy.
+
+**RTL.** No right-to-left locale is requested. `dir` support is a layout project,
+not a translation one.

--- a/web/index.html
+++ b/web/index.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- lang is the pre-boot value only; setLocale() in src/i18n.js keeps
+     document.documentElement.lang in sync with the active locale. -->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,6 +34,7 @@
         "turndown": "^7.2.2",
         "turndown-plugin-gfm": "^1.0.2",
         "vue": "^3.5.30",
+        "vue-i18n": "^11.4.9",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -246,6 +247,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -292,6 +294,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -358,6 +361,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -384,6 +388,67 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "11.4.9",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.9.tgz",
+      "integrity": "sha512-qbGZHXBUwodVCxm6E/IXY0yVLGHuh0GDxnoeCZ5FB75Wq5koKHLrANw5cFhC8fT3WyrkDyvesRzMoFOWsLpPOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/devtools-types": "11.4.9",
+        "@intlify/message-compiler": "11.4.9",
+        "@intlify/shared": "11.4.9"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.9",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.9.tgz",
+      "integrity": "sha512-DFwTGShMQBK9ODzt+EKTRdoHdD65fTA/KbgxBq5gSEsbwYZKVFUKfHwnOYvZnZDL+h56swwXcP6jYRmQMOomvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.9",
+        "@intlify/shared": "11.4.9"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.4.9",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.9.tgz",
+      "integrity": "sha512-4vlAQsttSX1NgyDOY3sXAEq7HiQPvy21YgBeQUc7Ylu66MwLYVvtqOYSYudDR/SyOahttXvezuNs52s+G104xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.4.9",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.4.9",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.9.tgz",
+      "integrity": "sha512-4qMBu3D64EN5KbkAj9Mv3TFjiPHtKG/YNd5LU5bpb0DZMR+bKh9/uGNx2GovzxWn2Wnyh5uvEhbPR718EVSkCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -980,6 +1045,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
       "integrity": "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1063,6 +1129,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz",
       "integrity": "sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1245,6 +1312,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.21.0.tgz",
       "integrity": "sha512-KeBlEtLrGce2d3dgL89hmwWEtREuzlW4XY5bYWpKNvCbFqvdSb3n7vkdkw32YclZmMWxAcABgW6ucCStkE0rsQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1337,6 +1405,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.21.0.tgz",
       "integrity": "sha512-/iPVM/5TtRy7wGrLW/uL+qjMHsor26P/nH2nHasgPr/EIwliLGhHp9Gwjhix3OTyM2UK+VNcuhH6X50UbcByTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1403,6 +1472,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.21.0.tgz",
       "integrity": "sha512-MI/3X75D45Wa/+0Fp8nYfNJq5makkjtG7B2/lIzNUe0kEKJ56RVQoV1GQSXxAiFNyAYRfKFq8dJslhesW3EkWA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1429,6 +1499,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.21.0.tgz",
       "integrity": "sha512-MN1uh5PmHT1F2BNsbc21MIS0AMFFA73oODlp/4ckpBR4o5AxRwV+8f43Cd52UL4MgMkKj/A+QfZ7iK9IDb0h5A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1443,6 +1514,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
       "integrity": "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -2056,6 +2128,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
       "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2456,6 +2529,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2757,6 +2831,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3182,6 +3257,7 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -3385,6 +3461,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3918,6 +3995,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -3995,6 +4073,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",
@@ -4009,6 +4088,27 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.4.9",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.9.tgz",
+      "integrity": "sha512-SJoEYcmt+g8IW1Ro9zuF6GyYEi/2t4kYlg0y7bUPKAyciR4Zhg6f+RTxgEZ9H2o9LrxJdcr50OH2OkGweRzRiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.9",
+        "@intlify/devtools-types": "11.4.9",
+        "@intlify/shared": "11.4.9",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
     "vue": "^3.5.30",
+    "vue-i18n": "^11.4.9",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/web/src/components/LocalePicker.vue
+++ b/web/src/components/LocalePicker.vue
@@ -1,0 +1,49 @@
+<template>
+  <!-- Hidden entirely when the deployment ships a single locale: a picker with
+       one option is noise, and it would suggest a choice that does not exist. -->
+  <select v-if="options.length > 1" :value="selected" @change="onChange"
+    :disabled="saving"
+    :aria-label="$t('common.locale.label')"
+    :class="compact
+      ? 'bg-transparent border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-500 hover:text-slate-300 focus:outline-none transition-colors disabled:opacity-50'
+      : 'w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50'">
+    <!-- Only offered when signed in: with no account to store it against,
+         "follow the org default" is not a state the user can be in. -->
+    <option v-if="persist" value="">{{ $t('common.locale.org_default') }}</option>
+    <option v-for="l in options" :key="l.tag" :value="l.tag">{{ l.name }}</option>
+  </select>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useLocale } from '../composables/useLocale'
+
+const props = defineProps({
+  // false on login / landing, where there is no session to save against.
+  persist: { type: Boolean, default: true },
+  compact: { type: Boolean, default: false },
+})
+const emit = defineEmits(['error'])
+
+const { options, preference, active, chooseLocale } = useLocale()
+const saving = ref(false)
+
+// Signed in, the picker reflects the stored preference — including the empty
+// value that means "org default". Signed out there is no preference, so it
+// shows what is actually being rendered.
+const selected = computed(() => (props.persist ? (preference.value ?? '') : active.value))
+
+async function onChange(e) {
+  const tag = e.target.value
+  saving.value = true
+  try {
+    await chooseLocale(tag, { persist: props.persist })
+  } catch (err) {
+    // Put the control back where it was; the locale did not change.
+    e.target.value = selected.value
+    emit('error', err?.message || String(err))
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/web/src/composables/useLocale.js
+++ b/web/src/composables/useLocale.js
@@ -1,0 +1,79 @@
+// Locale selection: the precedence chain applied to real session data, and the
+// one place that persists a user's choice.
+//
+// `i18n.js` owns the mechanism (negotiation, chunk loading, <html lang>). This
+// composable owns the policy: which signal wins, and when the server is told.
+import { computed, ref } from 'vue'
+import api from '../api.js'
+import {
+  FALLBACK,
+  i18n,
+  resolveInitialLocale,
+  setLocale,
+  setSupportedLocales,
+  supportedLocales,
+} from '../i18n.js'
+
+// Module-level so the picker on the login page and the one in Settings share a
+// single source of truth, the way useSession does.
+const options = ref([])
+const orgDefault = ref(FALLBACK)
+// The user's explicit choice. `null` means "following the org default", which is
+// what lets the picker show that as a distinct option rather than pretending the
+// user picked whatever the org happens to default to today.
+const preference = ref(null)
+
+const active = computed(() => i18n.global.locale.value)
+
+// Seed the supported set from GET /config and apply the best pre-login guess.
+// Safe to call from every page that already fetches /config; later calls just
+// re-apply the same resolution.
+export async function applyConfigLocales(cfg) {
+  if (!cfg) return
+  setSupportedLocales(cfg.locales)
+  options.value = supportedLocales()
+  if (cfg.default_locale) orgDefault.value = cfg.default_locale
+  // Pre-login there is no user preference, so this is localStorage, then the
+  // browser's languages, then the org default.
+  await setLocale(resolveInitialLocale({ orgLocale: orgDefault.value }))
+}
+
+// Apply the locale for an authenticated session, from GET /me.
+//
+// `locale_preference` is the raw choice and `locale` is what the server already
+// resolved (preference, else org default). An explicit choice outranks every
+// client-side signal — it was made deliberately and travels with the account.
+// Without one, the client-side signals apply, because a browser set to
+// Indonesian is a better guess than the org default.
+export async function applySessionLocale(me) {
+  if (!me) return
+  preference.value = me.locale_preference ?? null
+  if (preference.value) {
+    await setLocale(preference.value)
+    return
+  }
+  await setLocale(resolveInitialLocale({ orgLocale: me.locale || orgDefault.value }))
+}
+
+// Change the active locale. `tag` is '' to clear an explicit choice and follow
+// the org default again.
+//
+// `persist` is false on the login and landing pages, where there is no session
+// to save against — the choice still survives in localStorage, and is upgraded
+// to a stored preference the next time the user saves one while signed in.
+export async function chooseLocale(tag, { persist = true } = {}) {
+  if (persist) {
+    // Send only `locale`. `name` is optional server-side precisely so a
+    // locale-only update cannot race a concurrent rename.
+    await api.putJSON('/api/v1/auth/profile', { locale: tag })
+  }
+  preference.value = tag || null
+  // Clearing applies the org default directly rather than re-running the
+  // precedence chain: localStorage still holds the choice being cleared, and
+  // would immediately win it back.
+  await setLocale(tag || orgDefault.value)
+}
+
+export function useLocale() {
+  return { options, orgDefault, preference, active, applyConfigLocales, applySessionLocale, chooseLocale }
+}

--- a/web/src/composables/useSession.js
+++ b/web/src/composables/useSession.js
@@ -1,5 +1,6 @@
 import { ref, computed, watch } from 'vue'
 import { api, getCurrentUser, clearApiToken, setApiToken, setCurrentUser } from '../api'
+import { applyConfigLocales, applySessionLocale } from './useLocale'
 import { orgFromSubdomain, isSubdomainMode, orgEntryURL, setSubdomainRouting, setApexHost, ensureConfigLoaded } from './useCurrentOrg'
 
 const user = ref(getCurrentUser())
@@ -83,6 +84,9 @@ export function useSession() {
         }
       }
       currentUserData.value = me
+      // The authenticated half of the locale chain: an explicit choice stored
+      // on the account outranks localStorage and the browser's languages.
+      await applySessionLocale(me)
       if (currentUserData.value?.email) {
         user.value = currentUserData.value.email
       }
@@ -145,6 +149,9 @@ export function useSession() {
   async function loadBranding() {
     try {
       const cfg = await api.getConfig()
+      // Which locales exist, and the org default, both come from the server —
+      // never a hardcoded list.
+      await applyConfigLocales(cfg)
       // Branding settings override org defaults
       if (cfg.branding?.branding_name) {
         orgName.value = cfg.branding.branding_name

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -1,0 +1,129 @@
+// vue-i18n wiring and the locale resolution chain.
+//
+// Runtime-only: messages are plain JSON imports, so no @intlify Vite plugin is
+// needed. The plugin only buys precompiled messages and <i18n> custom blocks;
+// neither is worth a build-time dependency at this stage.
+//
+// The single source of truth for which locales exist is the Go package
+// internal/isms/i18n, surfaced on GET /config as `locales`. This module is
+// seeded from that response (see setSupportedLocales) rather than hardcoding a
+// list, so the two cannot drift. FALLBACK stays a constant because the fallback
+// bundle has to be known at build time — it is the one locale always resident.
+import { createI18n } from 'vue-i18n'
+import en from './locales/en/index.js'
+
+export const FALLBACK = 'en'
+
+export const STORAGE_KEY = 'isms_locale'
+
+// Lazy loaders for every non-fallback locale. `en` is deliberately absent: it
+// is bundled. A locale the server advertises but that has no loader here cannot
+// be rendered, which is why applicability is checked against this map and not
+// against the server list alone.
+const loaders = {
+  // 'id-ID': () => import('./locales/id-ID/index.js'),
+}
+
+// Locales the server says it supports, as {tag, name} — name is the endonym, for
+// the picker. Empty until /config is read; loadable() falls back to what is
+// bundled so boot works before (and without) that call.
+let serverLocales = []
+
+export function setSupportedLocales(locales) {
+  serverLocales = Array.isArray(locales) ? locales.filter((l) => l && l.tag) : []
+}
+
+export function supportedLocales() {
+  return serverLocales
+}
+
+// The tags this build can actually render: the fallback, plus every server tag
+// with a loader. A tag advertised by a newer server than this bundle is skipped
+// rather than selected and left rendering raw keys.
+export function loadableLocales() {
+  const advertised = serverLocales.map((l) => l.tag)
+  const tags = advertised.length ? advertised : [FALLBACK, ...Object.keys(loaders)]
+  return tags.filter((t) => t === FALLBACK || Object.hasOwn(loaders, t))
+}
+
+export const i18n = createI18n({
+  legacy: false, // Composition API; the repo has no Options-API i18n usage
+  globalInjection: true, // $t in templates without per-component setup
+  locale: FALLBACK, // the real value is applied by setLocale() during boot
+  fallbackLocale: FALLBACK,
+  messages: { en },
+  missingWarn: import.meta.env?.DEV ?? false,
+  fallbackWarn: import.meta.env?.DEV ?? false,
+})
+
+// `t` for plain .js modules (api.js, router guards, utils) where useI18n() is
+// unavailable because there is no component instance. Same keyspace, so there is
+// exactly one mechanism, not two.
+export const t = i18n.global.t
+export const te = i18n.global.te
+
+// Region-tolerant match of a requested tag against what this build can render:
+// an exact hit first, then the same primary subtag ('id' -> 'id-ID', 'pt-BR' ->
+// 'pt'). Returns null when nothing matches, so callers can fall through the
+// precedence chain rather than being handed a wrong locale.
+export function negotiate(tag, available = loadableLocales()) {
+  if (!tag || typeof tag !== 'string') return null
+  const want = tag.trim().toLowerCase()
+  if (!want) return null
+  const exact = available.find((a) => a.toLowerCase() === want)
+  if (exact) return exact
+  const base = want.split('-')[0]
+  return available.find((a) => a.toLowerCase().split('-')[0] === base) ?? null
+}
+
+// Precedence, highest first (plan 80 §5):
+//   1. the user's explicit choice, from the DB (survives a device change)
+//   2. localStorage, for pre-login and anonymous pages
+//   3. navigator.languages, in the browser's own order of preference
+//   4. the organization default
+//   5. FALLBACK
+export function resolveInitialLocale({
+  userLocale = null,
+  orgLocale = null,
+  stored = readStored(),
+  navigatorLocales = typeof navigator === 'undefined' ? [] : (navigator.languages ?? []),
+} = {}) {
+  const candidates = [userLocale, stored, ...navigatorLocales, orgLocale]
+  for (const c of candidates) {
+    const hit = negotiate(c)
+    if (hit) return hit
+  }
+  return FALLBACK
+}
+
+function readStored() {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null // Safari private mode and friends throw rather than returning null
+  }
+}
+
+// Apply a locale: load its chunk if needed, switch vue-i18n, and keep <html lang>
+// in sync so screen readers, spellcheckers and :lang() CSS follow. An unsupported
+// or unloadable tag degrades to FALLBACK instead of throwing — a stale stored
+// value must not brick the app.
+export async function setLocale(tag) {
+  let locale = negotiate(tag) ?? FALLBACK
+  if (locale !== FALLBACK && !i18n.global.availableLocales.includes(locale)) {
+    try {
+      const m = await loaders[locale]()
+      i18n.global.setLocaleMessage(locale, m.default)
+    } catch {
+      locale = FALLBACK // chunk failed to load (offline, bad deploy)
+    }
+  }
+  i18n.global.locale.value = locale
+  if (typeof document !== 'undefined') document.documentElement.lang = locale
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, locale)
+  } catch {
+    /* storage unavailable; the DB preference is the durable copy anyway */
+  }
+  return locale
+}

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -21,7 +21,7 @@ export const STORAGE_KEY = 'isms_locale'
 // be rendered, which is why applicability is checked against this map and not
 // against the server list alone.
 const loaders = {
-  // 'id-ID': () => import('./locales/id-ID/index.js'),
+  'id-ID': () => import('./locales/id-ID/index.js'),
 }
 
 // Locales the server says it supports, as {tag, name} — name is the endonym, for

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -1,0 +1,84 @@
+# Locale files
+
+Every user-facing string in the web app lives here. A component never holds a
+literal, never derives a label from a database value by string munging, and
+never formats a date with a hardcoded locale.
+
+## Layout
+
+```
+locales/
+├── en/                  ← the fallback; always bundled, always complete
+│   ├── index.js         ← imports and merges every area file
+│   ├── common.json      ← shared copy: actions, enums, entities, fields, errors
+│   ├── risks.json       ← one file per register / workflow area, added by the
+│   └── …                  PR that extracts that area
+└── <tag>/               ← same filenames, mirrored
+```
+
+Only `common.json` exists up front — the shared vocabulary every area draws on.
+Area files arrive with the PR that extracts their view, because extraction is one
+PR per view and a single `en.json` would make them all collide on one file.
+
+Adding an **area**: one JSON file plus one import line in `index.js`.
+Adding a **locale**: copy `en/`, translate the values, register the loader — see
+[`docs/i18n.md`](../../../docs/i18n.md).
+
+## Key convention
+
+```
+<area>.<group>.<key>
+```
+
+| Rule | Example |
+|---|---|
+| The area is the filename | `risks.*` lives in `risks.json` |
+| Copy used in more than one area goes in `common.*` | `common.action.save` |
+| Enum values | `common.enum.<enum>.<db_value>` → `common.enum.status.changes_requested` |
+| Validation messages | `common.validation.required` |
+| Entity names | `common.entity.risk` |
+| Field names | `common.field.title` |
+| API error codes | `common.error.not_found` |
+| Group by UI structure, not by phrasing | `risks.table.header.likelihood` |
+| Keys are `snake_case`, and enum keys mirror the DB value verbatim | `changes_requested`, never `changesRequested` |
+
+## Hard rules
+
+**Never concatenate a key at runtime.** `t('common.enum.' + name)` defeats keyset
+extraction and unused-key detection. The composables `useEnumLabel` and the API
+error renderer are the only sanctioned dynamic lookups; they exist precisely so
+nothing else needs to do it.
+
+**Never build a sentence from fragments.** Word order is language-specific.
+
+```js
+t('risks.owner_assigned', { name })   // ✅ one key, interpolated
+t('risks.owner') + ' ' + name          // ❌ unreachable in most languages
+```
+
+**Interpolated entity and field names must themselves be translated.** An API
+error arrives as `{code: 'not_found', params: {entity: 'risk'}}`. Splicing the
+English `"risk"` into an Indonesian sentence produces neither language. The
+render helper resolves `entity` and `field` params through `common.entity.*` and
+`common.field.*` first — which is why those two groups exist and why every
+`entity` value the server emits must have a key here.
+
+**Use vue-i18n pluralization, not a `count === 1` branch.**
+
+```json
+{ "count": "no risks | one risk | {count} risks" }
+```
+
+Indonesian has no grammatical plural and Portuguese shares English's two-form
+rule, so neither exercises this — which is exactly why it has to be built in
+now, rather than retrofitted when a locale with real plural rules arrives.
+
+**Key renames are breaking.** They invalidate in-flight translation work across
+every locale. Adding a key is cheap; renaming one is not.
+
+## What belongs in `common.json`
+
+Copy reused across two or more areas, plus the four cross-cutting groups
+(`enum`, `entity`, `field`, `error`). Everything else belongs to its area, even
+if the English happens to read the same in two places — the translations may
+diverge.

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1,0 +1,30 @@
+{
+  "action": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "close": "Close",
+    "create": "Create",
+    "edit": "Edit",
+    "delete": "Delete",
+    "search": "Search"
+  },
+  "state": {
+    "loading": "Loading…",
+    "empty": "Nothing here yet",
+    "error": "Something went wrong"
+  },
+  "validation": {
+    "required": "This field is required"
+  },
+  "entity": {},
+  "field": {},
+  "enum": {},
+  "error": {},
+  "region": {
+    "global": "Global",
+    "eu": "EU",
+    "eea": "EEA",
+    "apac": "APAC"
+  }
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -17,6 +17,10 @@
   "validation": {
     "required": "This field is required"
   },
+  "locale": {
+    "label": "Language",
+    "org_default": "Organization default"
+  },
   "entity": {},
   "field": {},
   "enum": {},

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -1,0 +1,18 @@
+// The `en` message bundle: one file per area, merged into a single nested
+// keyspace. Area = the top-level key, and it is also the filename — so
+// `risks.table.header.likelihood` will live in `risks.json` and nowhere else.
+//
+// The split is not cosmetic. Extraction is one PR per view, and a single
+// en.json would make ~21 concurrent PRs collide on one file. Each area file
+// therefore arrives with the PR that extracts that area: one new file plus one
+// import line here. Only `common.json` exists up front, because the shared
+// vocabulary is what every area draws on.
+//
+// Import attributes (`with { type: 'json' }`) are required by Node for JSON
+// modules, and understood by Vite/Rollup — the same file therefore loads both
+// in the bundler and under `node --test`.
+import common from './common.json' with { type: 'json' }
+
+export default {
+  common,
+}

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -17,6 +17,10 @@
   "validation": {
     "required": "Kolom ini wajib diisi"
   },
+  "locale": {
+    "label": "Bahasa",
+    "org_default": "Bawaan organisasi"
+  },
   "entity": {},
   "field": {},
   "enum": {},

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -1,0 +1,30 @@
+{
+  "action": {
+    "save": "Simpan",
+    "cancel": "Batal",
+    "confirm": "Konfirmasi",
+    "close": "Tutup",
+    "create": "Buat",
+    "edit": "Ubah",
+    "delete": "Hapus",
+    "search": "Cari"
+  },
+  "state": {
+    "loading": "Memuat…",
+    "empty": "Belum ada apa pun di sini",
+    "error": "Terjadi kesalahan"
+  },
+  "validation": {
+    "required": "Kolom ini wajib diisi"
+  },
+  "entity": {},
+  "field": {},
+  "enum": {},
+  "error": {},
+  "region": {
+    "global": "Global",
+    "eu": "UE",
+    "eea": "EEA",
+    "apac": "APAC"
+  }
+}

--- a/web/src/locales/id-ID/index.js
+++ b/web/src/locales/id-ID/index.js
@@ -1,0 +1,18 @@
+// The `id-ID` message bundle: one file per area, merged into a single nested
+// keyspace. Area = the top-level key, and it is also the filename — so
+// `risks.table.header.likelihood` will live in `risks.json` and nowhere else.
+//
+// This directory mirrors `en/` file for file and key for key. Only the values
+// are translated. A key missing here is not an error: `fallbackLocale` renders
+// it in English, so a lagging translation degrades gracefully rather than
+// showing a raw key — which is also why an area file only appears here once the
+// matching `en/` one exists.
+//
+// Import attributes (`with { type: 'json' }`) are required by Node for JSON
+// modules, and understood by Vite/Rollup — the same file therefore loads both
+// in the bundler and under `node --test`.
+import common from './common.json' with { type: 'json' }
+
+export default {
+  common,
+}

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,9 +1,17 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import { i18n, resolveInitialLocale, setLocale } from './i18n.js'
 import mermaidDirective from './directives/mermaid.js'
 import './style.css'
 
 const app = createApp(App)
 app.directive('mermaid', mermaidDirective)
+app.use(i18n)
+
+// Apply the best locale we can know pre-login (localStorage, then the browser's
+// languages). The authenticated value from GET /me and the org default from
+// GET /config both arrive later and re-apply through the same seam.
+setLocale(resolveInitialLocale())
+
 app.use(router).mount('#app')

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -162,11 +162,16 @@
 
     <!-- Footer -->
     <footer class="relative z-10 border-t border-slate-800/50 px-8 py-8 mt-8">
-      <div class="max-w-6xl mx-auto flex items-center justify-between text-sm text-slate-500">
+      <div class="max-w-6xl mx-auto flex items-center justify-between gap-4 text-sm text-slate-500">
         <span>{{ brandFooter }}</span>
+        <div class="flex items-center gap-4">
+        <!-- Pre-login, so the choice is local only: there is no account to save
+             it against yet. -->
+        <LocalePicker :persist="false" compact class="shrink-0" />
         <span v-if="showPoweredBy">
           Powered by <a href="https://isms.sh" target="_blank" rel="noopener" class="text-slate-400 hover:text-white transition-colors">isms.sh</a>
         </span>
+        </div>
       </div>
     </footer>
   </div>
@@ -175,6 +180,8 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import api from '../api'
+import { applyConfigLocales } from '../composables/useLocale'
+import LocalePicker from '../components/LocalePicker.vue'
 
 const brandName = ref('isms.sh')
 const brandFooter = ref('')
@@ -208,6 +215,7 @@ const frameworks = [
 onMounted(async () => {
   try {
     const cfg = await api.getConfig()
+    await applyConfigLocales(cfg)
     if (cfg.branding?.branding_name) {
       brandName.value = cfg.branding.branding_name
     } else if (cfg.organization_name) {

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -196,6 +196,12 @@
         </div>
       </div>
       </template>
+
+      <!-- Pre-login language choice, so a user can read the app before they have
+           an account. Local only — nothing to persist against yet. -->
+      <div class="mt-8 flex justify-center">
+        <LocalePicker :persist="false" compact />
+      </div>
     </div>
     <div class="fixed bottom-4 left-0 right-0 text-center text-xs text-slate-600">
       <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">Privacy Policy</a>
@@ -213,6 +219,8 @@ import { useRouter, useRoute } from 'vue-router'
 import { login, getApiToken, setApiToken } from '../api'
 import api from '../api'
 import { orgFromSubdomain, isSubdomainMode, orgEntryURL, canHostSubdomain } from '../composables/useCurrentOrg'
+import { applyConfigLocales } from '../composables/useLocale'
+import LocalePicker from '../components/LocalePicker.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -476,6 +484,7 @@ onMounted(async () => {
   let configOrgSlug = ''
   try {
     const cfg = await api.getConfig()
+    await applyConfigLocales(cfg)
     if (cfg.organization?.name) orgName.value = cfg.organization.name
     if (cfg.organization_name) orgName.value = cfg.organization_name
     if (cfg.branding?.branding_name) orgName.value = cfg.branding.branding_name

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -23,6 +23,11 @@
           <div v-if="nameMsg" class="text-xs mt-1" :class="nameError ? 'text-red-400' : 'text-emerald-400'">{{ nameMsg }}</div>
         </div>
         <div>
+          <label class="block text-xs text-slate-500 mb-1">{{ $t('common.locale.label') }}</label>
+          <LocalePicker @error="localeMsg = $event" />
+          <div v-if="localeMsg" class="text-xs mt-1 text-red-400">{{ localeMsg }}</div>
+        </div>
+        <div>
           <label class="block text-xs text-slate-500 mb-1">Role</label>
           <span class="inline-block px-2 py-0.5 text-xs font-medium rounded-full"
             :class="user?.role === 'admin' ? 'bg-purple-500/20 text-purple-300' :
@@ -305,6 +310,7 @@ import { useConfirm } from '../composables/useConfirm'
 import { ref, nextTick, onMounted, computed } from 'vue'
 import QRCode from 'qrcode'
 import api from '../api.js'
+import LocalePicker from '../components/LocalePicker.vue'
 
 const user = ref(null)
 
@@ -325,6 +331,7 @@ const passkeyError = ref(false)
 const passkeyAvailable = computed(() => typeof window !== 'undefined' && window.PublicKeyCredential !== undefined)
 
 // Profile
+const localeMsg = ref('')
 const profileName = ref('')
 const savingName = ref(false)
 const nameMsg = ref('')

--- a/web/test/i18n.test.js
+++ b/web/test/i18n.test.js
@@ -72,8 +72,8 @@ test('resolution precedence: user choice beats every weaker signal', () => {
 })
 
 test('resolution falls through unrenderable signals instead of stopping', () => {
-  // Only `en` is loadable in this build, so a stored/navigator/org value naming
-  // anything else must be skipped, not returned.
+  // de-DE, fr and ja-JP are not shipped, so each must be skipped rather than
+  // returned; en-GB is the first signal that resolves.
   assert.equal(
     resolveInitialLocale({
       userLocale: 'de-DE',
@@ -82,6 +82,16 @@ test('resolution falls through unrenderable signals instead of stopping', () => 
       orgLocale: 'id-ID',
     }),
     'en',
+  )
+  // ...and with nothing renderable above it, the org default applies.
+  assert.equal(
+    resolveInitialLocale({
+      userLocale: 'de-DE',
+      stored: null,
+      navigatorLocales: ['ja-JP'],
+      orgLocale: 'id-ID',
+    }),
+    'id-ID',
   )
 })
 
@@ -122,4 +132,33 @@ test('each area file is merged under its own filename as the area key', () => {
     // through a looser check and read wrong next to `common.enum.status`.
     assert.ok(/^[a-z][a-z0-9_]*$/.test(area), `area ${area} must be snake_case`)
   }
+})
+
+test('setLocale loads the id-ID chunk and renders it', async () => {
+  // The whole point of shipping a second locale in the foundation: prove the
+  // resolution chain against something other than the fallback bundle.
+  assert.equal(await setLocale('id-ID'), 'id-ID')
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  assert.equal(i18n.global.t('common.action.save'), 'Simpan')
+  assert.equal(i18n.global.t('common.state.loading'), 'Memuat\u2026')
+  // A bare 'id' resolves to the region variant we actually ship.
+  assert.equal(await setLocale('id'), 'id-ID')
+  await setLocale(FALLBACK)
+  assert.equal(i18n.global.t('common.action.save'), 'Save')
+})
+
+test('a key missing from a translation falls back to English', async () => {
+  // A translation lagging the keyset must render English, not a raw key — this
+  // is what lets CI warn rather than fail on missing keys.
+  await setLocale('id-ID')
+  const full = i18n.global.getLocaleMessage('id-ID')
+  const { save: _dropped, ...rest } = full.common.action
+  i18n.global.setLocaleMessage('id-ID', {
+    ...full,
+    common: { ...full.common, action: rest },
+  })
+  assert.equal(i18n.global.t('common.action.save'), 'Save')
+  assert.equal(i18n.global.t('common.action.cancel'), 'Batal')
+  i18n.global.setLocaleMessage('id-ID', full)
+  await setLocale(FALLBACK)
 })

--- a/web/test/i18n.test.js
+++ b/web/test/i18n.test.js
@@ -1,0 +1,125 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  FALLBACK,
+  i18n,
+  loadableLocales,
+  negotiate,
+  resolveInitialLocale,
+  setLocale,
+  setSupportedLocales,
+  supportedLocales,
+} from '../src/i18n.js'
+
+// Every test that touches the supported set restores it, since the module holds
+// it as process-wide state.
+function withServerLocales(locales, fn) {
+  setSupportedLocales(locales)
+  try {
+    return fn()
+  } finally {
+    setSupportedLocales([])
+  }
+}
+
+test('negotiate matches exactly, then region-tolerantly', () => {
+  const available = ['en', 'id-ID']
+  assert.equal(negotiate('en', available), 'en')
+  assert.equal(negotiate('id-ID', available), 'id-ID')
+  // Case is not part of a BCP 47 identity: ID-id is the same tag as id-ID.
+  assert.equal(negotiate('ID-id', available), 'id-ID')
+  // A bare primary subtag resolves to the region variant we ship.
+  assert.equal(negotiate('id', available), 'id-ID')
+  // ...and so does a different region of the same language: a pt-BR speaker is
+  // better served by pt-PT copy than by English.
+  assert.equal(negotiate('pt-BR', ['en', 'pt-PT']), 'pt-PT')
+})
+
+test('negotiate returns null rather than guessing', () => {
+  const available = ['en', 'id-ID']
+  assert.equal(negotiate('de', available), null)
+  assert.equal(negotiate('', available), null)
+  assert.equal(negotiate(null, available), null)
+  assert.equal(negotiate(undefined, available), null)
+  assert.equal(negotiate(42, available), null)
+})
+
+test('loadable locales exclude a server tag this build cannot render', () => {
+  // A newer server advertising a locale whose chunk does not exist in this
+  // bundle must not become selectable — that renders raw keys.
+  withServerLocales([{ tag: 'en' }, { tag: 'fr-FR', name: 'Français' }], () => {
+    assert.deepEqual(loadableLocales(), ['en'])
+  })
+})
+
+test('supported locales survive a malformed /config payload', () => {
+  withServerLocales(null, () => assert.deepEqual(supportedLocales(), []))
+  withServerLocales([{ name: 'no tag' }, null], () => {
+    assert.deepEqual(supportedLocales(), [])
+  })
+})
+
+test('resolution precedence: user choice beats every weaker signal', () => {
+  assert.equal(
+    resolveInitialLocale({
+      userLocale: 'en',
+      orgLocale: 'id-ID',
+      stored: 'id-ID',
+      navigatorLocales: ['id-ID'],
+    }),
+    'en',
+  )
+})
+
+test('resolution falls through unrenderable signals instead of stopping', () => {
+  // Only `en` is loadable in this build, so a stored/navigator/org value naming
+  // anything else must be skipped, not returned.
+  assert.equal(
+    resolveInitialLocale({
+      userLocale: 'de-DE',
+      stored: 'fr',
+      navigatorLocales: ['ja-JP', 'en-GB'],
+      orgLocale: 'id-ID',
+    }),
+    'en',
+  )
+})
+
+test('resolution ends at the fallback when nothing matches', () => {
+  assert.equal(
+    resolveInitialLocale({ stored: null, navigatorLocales: [], orgLocale: null }),
+    FALLBACK,
+  )
+  assert.equal(resolveInitialLocale({}), FALLBACK)
+})
+
+test('setLocale degrades an unsupported tag to the fallback', async () => {
+  // A stored value for a locale that was dropped from the build must not brick
+  // the app: it renders English.
+  assert.equal(await setLocale('kl-GL'), FALLBACK)
+  assert.equal(i18n.global.locale.value, FALLBACK)
+  assert.equal(await setLocale(undefined), FALLBACK)
+})
+
+test('the fallback bundle is resident and its keys resolve', () => {
+  assert.ok(i18n.global.availableLocales.includes(FALLBACK))
+  assert.equal(i18n.global.t('common.action.save'), 'Save')
+  assert.equal(i18n.global.te('common.action.save'), true)
+  assert.equal(i18n.global.te('common.action.no_such_key'), false)
+})
+
+test('each area file is merged under its own filename as the area key', () => {
+  // The convention is <area>.<group>.<key> where area IS the filename; a file
+  // that is imported but not exported under its own name breaks that silently.
+  // Only `common` exists until extraction starts adding areas, so this asserts
+  // the shape every area must hold rather than a list that would go stale on
+  // every extraction PR.
+  const messages = i18n.global.getLocaleMessage(FALLBACK)
+  assert.equal(typeof messages.common, 'object')
+  for (const [area, groups] of Object.entries(messages)) {
+    assert.equal(typeof groups, 'object', `area ${area} must be a group object`)
+    // snake_case, mirroring the key convention — `correctiveactions` would slip
+    // through a looser check and read wrong next to `common.enum.status`.
+    assert.ok(/^[a-z][a-z0-9_]*$/.test(area), `area ${area} must be snake_case`)
+  }
+})

--- a/web/test/useLocale.test.js
+++ b/web/test/useLocale.test.js
@@ -1,0 +1,174 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import api from '../src/api.js'
+import { FALLBACK, i18n, setLocale, setSupportedLocales } from '../src/i18n.js'
+import {
+  applyConfigLocales,
+  applySessionLocale,
+  chooseLocale,
+  useLocale,
+} from '../src/composables/useLocale.js'
+
+const CONFIG = {
+  locales: [
+    { tag: 'en', name: 'English' },
+    { tag: 'id-ID', name: 'Bahasa Indonesia' },
+  ],
+  default_locale: 'id-ID',
+}
+
+// Node exposes a real localStorage, and setLocale writes to it — so a value left
+// by an earlier test would win precedence step 2 over the org default and make
+// these assertions order-dependent. Clear it explicitly: "the user has no stored
+// locale" is the state each test means to start from.
+function clearStored() {
+  try {
+    localStorage.removeItem('isms_locale')
+  } catch {
+    /* no storage in this environment; nothing to clear */
+  }
+}
+
+// Node's `navigator.languages` is ['en-US'], which legitimately outranks the org
+// default (precedence step 3 beats step 4). To exercise the org-default path at
+// all, the browser signal has to name something this build does not ship.
+const realNavigator = globalThis.navigator
+function navigatorSays(...languages) {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { ...realNavigator, languages },
+    configurable: true,
+    writable: true,
+  })
+}
+function restoreNavigator() {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: realNavigator,
+    configurable: true,
+    writable: true,
+  })
+}
+
+// The composable is module-level state, shared the way useSession is, so each
+// test puts it back.
+async function reset() {
+  setSupportedLocales([])
+  await setLocale(FALLBACK)
+  clearStored()
+  restoreNavigator()
+}
+
+test('applyConfigLocales seeds the picker from the server, not a constant', async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('ja-JP')
+  await applyConfigLocales(CONFIG)
+  const { options, orgDefault } = useLocale()
+  assert.deepEqual(
+    options.value.map((l) => l.name),
+    ['English', 'Bahasa Indonesia'],
+  )
+  assert.equal(orgDefault.value, 'id-ID')
+  // Nothing above the org default applies here — no stored value, and the
+  // browser asks for a language this build does not ship — so the org default
+  // is what renders.
+  assert.equal(i18n.global.locale.value, 'id-ID')
+})
+
+test('applyConfigLocales tolerates a config call that returned nothing', async (t) => {
+  t.after(reset)
+  clearStored()
+  await applyConfigLocales(null)
+  await applyConfigLocales({})
+  assert.equal(i18n.global.locale.value, FALLBACK)
+})
+
+test('an explicit stored preference outranks the org default', async (t) => {
+  t.after(reset)
+  await applyConfigLocales(CONFIG)
+  await applySessionLocale({ locale: 'en', locale_preference: 'en' })
+  const { preference } = useLocale()
+  assert.equal(preference.value, 'en')
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+test('no preference means follow the org default, and the picker says so', async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('ja-JP')
+  await applyConfigLocales(CONFIG)
+  await applySessionLocale({ locale: 'id-ID', locale_preference: null })
+  const { preference } = useLocale()
+  // null, not 'id-ID' — the difference is what lets the picker show "Organization
+  // default" rather than pinning the user to today's default.
+  assert.equal(preference.value, null)
+  assert.equal(i18n.global.locale.value, 'id-ID')
+})
+
+test('choosing a locale persists only the locale field', async (t) => {
+  t.after(reset)
+  const calls = []
+  const original = api.putJSON
+  api.putJSON = async (path, body) => {
+    calls.push([path, body])
+    return {}
+  }
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en')
+  // `name` must be absent, not echoed back: sending it would race a concurrent
+  // rename and silently revert it.
+  assert.deepEqual(calls, [['/api/v1/auth/profile', { locale: 'en' }]])
+  assert.equal(useLocale().preference.value, 'en')
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+test('clearing the choice returns to the org default, not the cleared value', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => ({})
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en')
+  await chooseLocale('')
+  // localStorage still holds 'en' at this point, so re-running the precedence
+  // chain would win the cleared choice straight back. The org default has to be
+  // applied directly.
+  assert.equal(useLocale().preference.value, null)
+  assert.equal(i18n.global.locale.value, 'id-ID')
+})
+
+test('the pre-login picker changes the locale without calling the API', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => {
+    throw new Error('must not be called before login')
+  }
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en', { persist: false })
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+test("the browser's language outranks the org default", async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('id', 'en-US')
+  // A user whose browser asks for Indonesian gets Indonesian even though the org
+  // defaults to English — a deliberate browser setting is a better signal than
+  // an org-wide default the user never saw. A bare 'id' still resolves to the
+  // 'id-ID' bundle.
+  await applyConfigLocales({ ...CONFIG, default_locale: 'en' })
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  // ...but an explicit account preference still beats it.
+  await applySessionLocale({ locale: 'en', locale_preference: 'en' })
+  assert.equal(i18n.global.locale.value, 'en')
+})


### PR DESCRIPTION
Part of #212. **Stacked on #218** (id-ID bundle), which is stacked on #217 (foundation). Review those first; this diff is only the picker and its policy.

Completes the resolution chain against real session data and adds the control that lets a user change it. `i18n.js` (from #217) owns the mechanism; the new `composables/useLocale.js` owns the policy — which signal wins, and when the server is told.

Seeded from `GET /config` at the three places that already fetch it (`useSession.loadBranding`, `Login.vue`, `Landing.vue`), and applied from `GET /me` in `loadUserData`.

## The picker

A `<select>` in Settings → Profile, plus a compact one on the login and landing pages so a user can read the app before they have an account. It hides itself entirely when the deployment ships a single locale — one option is noise, and it implies a choice that does not exist.

Three decisions that are easy to get subtly wrong:

- **A null `locale_preference` is a distinct state, not a value.** The picker shows "Organization default" for it, so a user following the default is not silently pinned to whatever that default happens to be today.
- **Clearing a choice applies the org default directly** rather than re-running the precedence chain — `localStorage` still holds the choice being cleared and would win it straight back.
- **The pre-login picker has no "Organization default" option and never calls the API.** With no account there is nothing to store a preference against; the choice lives in `localStorage` until the user saves one while signed in.

Saving sends `{locale}` alone. `name` is optional server-side precisely so a locale-only update cannot race a concurrent rename.

## Verification

`npm test` 50/50 (8 new in `web/test/useLocale.test.js`), `npm run build` clean.

Exercised in a browser against a local server:

- an account preference of `id-ID` overrode a deliberately-conflicting `en` in `localStorage` on boot, and corrected the stored value;
- selecting a locale persisted it and re-rendered without a reload;
- clearing returned to the org default;
- the login-page picker switched locale with zero network calls;
- no console errors on any page.

The failure path — server rejects the save, the control snaps back and surfaces the message — is code-reviewed but not live-tested. `chooseLocale` persists before mutating `preference`, so the computed `selected` still holds the pre-change value when it throws.

## Draft

Inherits the merge gate from #218: notification keying should land before a non-English UI is reachable in a deployed build.
