### PR TITLE
fix(api): version-downgrade guard now floors on the approved milestone, not the current draft

### DIFF
--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1635,9 +1635,20 @@ func (s *Server) handleUpdateDocumentContent(c echo.Context) error {
 
 	// Update metadata fields if provided
 	if req.Version != "" {
-		// Prevent version downgrade
-		if compareVersions(req.Version, pf.Frontmatter.Version) < 0 {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("cannot lower version from %s to %s", pf.Frontmatter.Version, req.Version))
+		// The floor is the last APPROVED milestone, not the document's current
+		// draft value: document_versions rows are written only on approve/
+		// merge/confirm, so while a document sits in draft its frontmatter
+		// version is working state, not a milestone — a user must be free to
+		// correct it either way (e.g. undo a typo'd bump) as long as it never
+		// regresses past what was actually accepted. Comparing against the
+		// current draft value instead locks in whatever was last saved,
+		// mistake or not, and blocks exactly that correction.
+		if latest, err := s.db.LatestVersion(c.Request().Context(), orgID, docID); err == nil {
+			if compareVersions(req.Version, latest.Version) <= 0 {
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf(
+					"cannot set version to %s: must be greater than %s, the last approved version (draft version numbers may otherwise move freely)",
+					req.Version, latest.Version))
+			}
 		}
 		pf.Frontmatter.Version = req.Version
 	}

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"gopkg.in/yaml.v3"
@@ -1365,6 +1366,17 @@ func (s *Server) handleUpdateDocumentMetadata(c echo.Context) error {
 		}
 	}
 
+	// This is the second reachable writer of Frontmatter.Version (the other is
+	// PUT .../content) — the floor must be enforced here too, or it is
+	// advisory rather than real: whichever version-edit affordance a user
+	// happens to touch (the editor's save payload vs. the document header's
+	// version field) would otherwise get a different, inconsistent answer.
+	if v, ok := req.Fields["version"]; ok && v != "" {
+		if err := s.versionFloorError(c.Request().Context(), orgID, docID, v); err != nil {
+			return err
+		}
+	}
+
 	st, err := s.storeForOrg(c.Request().Context(), orgID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -1635,20 +1647,8 @@ func (s *Server) handleUpdateDocumentContent(c echo.Context) error {
 
 	// Update metadata fields if provided
 	if req.Version != "" {
-		// The floor is the last APPROVED milestone, not the document's current
-		// draft value: document_versions rows are written only on approve/
-		// merge/confirm, so while a document sits in draft its frontmatter
-		// version is working state, not a milestone — a user must be free to
-		// correct it either way (e.g. undo a typo'd bump) as long as it never
-		// regresses past what was actually accepted. Comparing against the
-		// current draft value instead locks in whatever was last saved,
-		// mistake or not, and blocks exactly that correction.
-		if latest, err := s.db.LatestVersion(c.Request().Context(), orgID, docID); err == nil {
-			if compareVersions(req.Version, latest.Version) <= 0 {
-				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf(
-					"cannot set version to %s: must be greater than %s, the last approved version (draft version numbers may otherwise move freely)",
-					req.Version, latest.Version))
-			}
+		if err := s.versionFloorError(c.Request().Context(), orgID, docID, req.Version); err != nil {
+			return err
 		}
 		pf.Frontmatter.Version = req.Version
 	}
@@ -3165,6 +3165,44 @@ func (s *Server) handleCreateOverdueTasks(c echo.Context) error {
 		Detail: fmt.Sprintf("Created %d review tasks (%d skipped, already existed)", len(result.Created), result.Skipped),
 	})
 	return c.JSON(http.StatusOK, result)
+}
+
+// versionFloorError returns a 400 if v is not strictly above the last
+// approved milestone for docID (a document_versions row, written only on
+// merge/confirm — see CLAUDE.md). A document with no milestone yet (never
+// approved) is unconstrained: nothing has been accepted for its version to
+// regress past.
+//
+// Called from every writer of Frontmatter.Version reachable over the API —
+// PUT .../content and PUT .../metadata both go through this, so the floor
+// cannot be bypassed by picking the other endpoint.
+//
+// A database error other than "no milestone" (pgx.ErrNoRows) is a 500, not a
+// silent skip: this guard exists to enforce a governance invariant, and
+// "the check didn't run because the database hiccuped" must not read as
+// "the check passed".
+//
+// compareVersions reads major.minor only, so a value exactly equal to the
+// milestone (rejected by this <= 0 comparison, not just < 0) also catches a
+// same-major.minor patch component it cannot see — "1.0.1" reads as equal to
+// "1.0.0". No caller in this repo produces a 3-component version today
+// (incrementVersion only ever emits major.minor), so this is unreachable in
+// practice, but it is reachable the moment an operator types one by hand,
+// since the field is a free-form frontmatter string.
+func (s *Server) versionFloorError(ctx context.Context, orgID int, docID, v string) error {
+	latest, err := s.db.LatestVersion(ctx, orgID, docID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "checking version floor: "+err.Error())
+	}
+	if compareVersions(v, latest.Version) <= 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf(
+			"cannot set version to %s: must be greater than %s, the last approved version (draft version numbers may otherwise move freely)",
+			v, latest.Version))
+	}
+	return nil
 }
 
 // stripFrontmatter removes YAML frontmatter from markdown content.

--- a/tests/test_review_branch.py
+++ b/tests/test_review_branch.py
@@ -259,23 +259,56 @@ class TestStaleMergeConflict:
 
 
 class TestDocumentContentSave:
-    """Test that document edit saves content+metadata in one commit."""
+    """Test that document edit saves content+metadata in one commit.
+
+    iso27001-4-1 is a shared scaffold document touched by many test files, so
+    its version only ever climbs across a persistent stack's repeated runs.
+    These tests only care that a version+author save works at all, not which
+    exact number — so they read the document's current version and bump the
+    MAJOR component, which is always strictly above both it and any approved
+    milestone (an approval can never exceed the draft version it was approved
+    from). A hardcoded literal ("1.0", "1.1") would eventually fall behind
+    that climb and start colliding with the approved-version floor.
+    """
+
+    def _next_major(self, api_url, admin_headers):
+        # The floor this PUT must clear is the last APPROVED milestone
+        # (document_versions), which on a persistent stack can outrun the
+        # document's current draft frontmatter — some other test elsewhere in
+        # the suite may have re-scaffolded or otherwise reset iso27001-4-1's
+        # git content to a lower version after an earlier run already
+        # recorded a higher milestone for it. Reading only the draft value
+        # was not enough; take whichever of the two is higher.
+        majors = [0]
+        r = requests.get(f"{api_url}/documents/iso27001-4-1/body", headers=admin_headers)
+        assert r.status_code == 200, f"reading current version: {r.text}"
+        draft = r.json().get("version") or ""
+        if draft:
+            majors.append(int(draft.split(".")[0]))
+        r = requests.get(f"{api_url}/documents/iso27001-4-1/versions", headers=admin_headers)
+        assert r.status_code == 200, f"reading version history: {r.text}"
+        history = r.json().get("data") or []
+        if history:
+            majors.append(int(history[0]["version"].split(".")[0]))
+        return f"{max(majors) + 1}.0"
 
     def test_save_content_with_version_and_author(self, api_url, admin_headers):
         """PUT /documents/:id/content with version+author should work."""
+        v = self._next_major(api_url, admin_headers)
         r = requests.put(f"{api_url}/documents/iso27001-4-1/content",
                          headers=admin_headers,
                          json={"content": "# Test content\n\nUpdated.",
-                               "version": "1.0",
+                               "version": v,
                                "author": "testadmin@isms-test.local"})
         assert r.status_code == 200, f"Save failed: {r.text}"
         assert "commit" in r.json()
 
     def test_metadata_multi_field_update(self, api_url, admin_headers):
         """PUT /documents/:id/metadata with multiple fields in one commit."""
+        v = self._next_major(api_url, admin_headers)
         r = requests.put(f"{api_url}/documents/iso27001-4-1/metadata",
                          headers=admin_headers,
-                         json={"fields": {"version": "1.1", "status": "draft"}})
+                         json={"fields": {"version": v, "status": "draft"}})
         assert r.status_code == 200, f"Metadata update failed: {r.text}"
         assert "commit" in r.json()
 

--- a/tests/test_version_downgrade_guard.py
+++ b/tests/test_version_downgrade_guard.py
@@ -1,0 +1,98 @@
+"""Regression: the version-downgrade guard on PUT /documents/:docId/content must
+compare a requested version against the last APPROVED milestone
+(document_versions, written only on merge/confirm), not against the document's
+current draft frontmatter value.
+
+A draft's version field is working state until it is re-approved — nothing
+depends on it staying monotonic against its own prior unapproved saves. Before
+this fix, comparing against the current draft value locked in whatever was
+last saved (including a typo) as a new floor, so a user correcting an
+over-bumped draft version (e.g. 0.3 -> 0.2, still well above the 0.1 that was
+actually approved) was permanently blocked.
+"""
+import uuid
+import requests
+from conftest import READER_EMAIL
+
+BODY = "# Heading\n\nBody content for the version-downgrade-guard regression test.\n"
+
+
+def _approve_and_merge(api_url, admin_headers, reader_headers, doc_id):
+    r = requests.post(f"{api_url}/documents/{doc_id}/reviews", headers=admin_headers,
+                      json={"reviewers": [READER_EMAIL], "message": "review"})
+    assert r.status_code in (200, 201), f"send for review: {r.text}"
+    rid = r.json()["review_id"]
+    r = requests.post(f"{api_url}/reviews/{rid}/approve", headers=reader_headers,
+                      json={"decision": "approved", "comment": "LGTM"})
+    assert r.status_code == 200, f"approve: {r.text}"
+    r = requests.post(f"{api_url}/reviews/{rid}/merge", headers=admin_headers, json={})
+    assert r.status_code == 200, f"merge: {r.text}"
+
+
+def _current_version(api_url, admin_headers, doc_id):
+    # PUT .../content returns only {"commit", "status"} — the applied version
+    # has to be read back separately.
+    r = requests.get(f"{api_url}/documents/{doc_id}/body", headers=admin_headers)
+    assert r.status_code == 200, f"reading back version: {r.text}"
+    return r.json()["version"]
+
+
+class TestVersionDowngradeGuardComparesAgainstApprovedFloor:
+    def test_draft_version_may_correct_downward_above_the_approved_floor(self, api_url, admin_headers, reader_headers):
+        # Unique per run — the assertions below pin absolute version numbers
+        # ("0.2", "0.3"), which only hold for a document that has never been
+        # approved before this test creates it. A fixed id would keep
+        # climbing on a persistent test stack across repeated runs.
+        DOC = f"version-guard-test-{uuid.uuid4().hex[:8]}"
+
+        # 1. Create a document, pin its starting version, approve + merge.
+        #    No milestone exists yet at this point, so the floor check is
+        #    inert here regardless of the fix.
+        r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+            "folder": "iso27001", "filename": DOC + ".md",
+            "document_id": DOC, "title": "Version Guard Test", "content": BODY,
+        })
+        assert r.status_code in (200, 201), r.text
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY, "version": "0.1"})
+        assert r.status_code == 200, f"pin initial version: {r.text}"
+
+        _approve_and_merge(api_url, admin_headers, reader_headers, DOC)
+        # The approved milestone is now 0.1 — the floor every later check in
+        # this test is measured against.
+
+        # 2. Edit the approved doc with no explicit version: auto-bumps to
+        #    0.2 and drops back to draft, exactly like a normal edit in the UI.
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY + "\nAn edit.\n"})
+        assert r.status_code == 200, f"auto-bump edit: {r.text}"
+        assert _current_version(api_url, admin_headers, DOC) == "0.2", \
+            f"expected auto-bump to 0.2, got {_current_version(api_url, admin_headers, DOC)}"
+
+        # 3. User (mis)types 0.3 and saves — still draft, still above the 0.1
+        #    floor, so this must succeed both before and after the fix.
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY + "\nAn edit.\n", "version": "0.3"})
+        assert r.status_code == 200, f"manual bump to 0.3: {r.text}"
+
+        # 4. THE FIX: correcting back to 0.2 must now succeed — 0.2 is still
+        #    above the 0.1 that was actually approved, even though it is
+        #    below the document's current (mistaken) draft value of 0.3.
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY + "\nAn edit.\n", "version": "0.2"})
+        assert r.status_code == 200, \
+            f"correcting an over-bumped draft version above the approved floor must be allowed: {r.text}"
+        assert _current_version(api_url, admin_headers, DOC) == "0.2"
+
+        # 5. The floor itself still holds: 0.1 (equal to the approved
+        #    milestone) and anything below it must still be rejected, with a
+        #    message that explains why rather than just restating the numbers.
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY, "version": "0.1"})
+        assert r.status_code == 400, "setting version back to the approved milestone itself must be rejected"
+        assert "approved" in r.json()["message"].lower(), \
+            f"error should explain the approved-version floor, got: {r.json()}"
+
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY, "version": "0.0"})
+        assert r.status_code == 400, "setting version below the approved milestone must be rejected"

--- a/tests/test_version_downgrade_guard.py
+++ b/tests/test_version_downgrade_guard.py
@@ -1,7 +1,8 @@
-"""Regression: the version-downgrade guard on PUT /documents/:docId/content must
-compare a requested version against the last APPROVED milestone
-(document_versions, written only on merge/confirm), not against the document's
-current draft frontmatter value.
+"""Regression: the version-downgrade guard must compare a requested version
+against the last APPROVED milestone (document_versions, written only on
+merge/confirm), not against the document's current draft frontmatter value —
+and it must be enforced on every reachable writer of Frontmatter.Version, not
+just PUT /documents/:docId/content.
 
 A draft's version field is working state until it is re-approved — nothing
 depends on it staying monotonic against its own prior unapproved saves. Before
@@ -9,6 +10,13 @@ this fix, comparing against the current draft value locked in whatever was
 last saved (including a typo) as a new floor, so a user correcting an
 over-bumped draft version (e.g. 0.3 -> 0.2, still well above the 0.1 that was
 actually approved) was permanently blocked.
+
+The fix is a single versionFloorError() helper called from both
+PUT .../content AND PUT .../metadata (review finding F1 on this PR): the
+metadata endpoint is what the document header's own version field uses
+(Documents.vue saveVersion), and it whitelisted `version` with no comparison
+at all — enforcing the floor on only one of the two writers would have made it
+advisory rather than real.
 """
 import uuid
 import requests
@@ -96,3 +104,66 @@ class TestVersionDowngradeGuardComparesAgainstApprovedFloor:
         r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
                          json={"content": BODY, "version": "0.0"})
         assert r.status_code == 400, "setting version below the approved milestone must be rejected"
+
+
+class TestVersionFloorEnforcedOnBothWriters:
+    def test_metadata_endpoint_enforces_the_same_floor_as_content(self, api_url, admin_headers, reader_headers):
+        DOC = f"version-guard-metadata-{uuid.uuid4().hex[:8]}"
+
+        r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+            "folder": "iso27001", "filename": DOC + ".md",
+            "document_id": DOC, "title": "Version Guard Metadata Test", "content": BODY,
+        })
+        assert r.status_code in (200, 201), r.text
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY, "version": "0.1"})
+        assert r.status_code == 200, f"pin initial version: {r.text}"
+        _approve_and_merge(api_url, admin_headers, reader_headers, DOC)
+        # Approved milestone is 0.1.
+
+        # The bypass this test guards against: the document header's version
+        # field (Documents.vue saveVersion) goes through PUT .../metadata, not
+        # .../content — before the fix this endpoint applied any string with
+        # no check, so it could push a version below an approved milestone
+        # (or to anything at all) with no git access needed.
+        r = requests.put(f"{api_url}/documents/{DOC}/metadata", headers=admin_headers,
+                         json={"fields": {"version": "0.0"}})
+        assert r.status_code == 400, \
+            "the metadata endpoint must enforce the same floor as the content endpoint"
+        assert "approved" in r.json()["message"].lower(), \
+            f"error should explain the approved-version floor, got: {r.json()}"
+        assert _current_version(api_url, admin_headers, DOC) == "0.1", \
+            "a rejected metadata update must not have touched the frontmatter"
+
+        # Sanity: a version legitimately above the floor still goes through.
+        r = requests.put(f"{api_url}/documents/{DOC}/metadata", headers=admin_headers,
+                         json={"fields": {"version": "0.5"}})
+        assert r.status_code == 200, f"a version above the floor must still be settable: {r.text}"
+        assert _current_version(api_url, admin_headers, DOC) == "0.5"
+
+    def test_never_approved_document_has_no_floor_on_either_writer(self, api_url, admin_headers):
+        # Documented, intentional widening (review finding F3): a document with
+        # no approval history has nothing to regress past, so both writers
+        # leave it unconstrained — this pins that as the actual contract
+        # rather than an accident, since the old code happened to constrain
+        # this case too (by comparing against the draft value, which every
+        # document has, approved or not).
+        DOC = f"version-guard-never-approved-{uuid.uuid4().hex[:8]}"
+        r = requests.post(f"{api_url}/documents", headers=admin_headers, json={
+            "folder": "iso27001", "filename": DOC + ".md",
+            "document_id": DOC, "title": "Never Approved Version Test", "content": BODY,
+        })
+        assert r.status_code in (200, 201), r.text
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY, "version": "0.5"})
+        assert r.status_code == 200, f"pin 0.5: {r.text}"
+
+        r = requests.put(f"{api_url}/documents/{DOC}/content", headers=admin_headers,
+                         json={"content": BODY, "version": "0.1"})
+        assert r.status_code == 200, "a never-approved document has no floor via .../content"
+        assert _current_version(api_url, admin_headers, DOC) == "0.1"
+
+        r = requests.put(f"{api_url}/documents/{DOC}/metadata", headers=admin_headers,
+                         json={"fields": {"version": "0.0"}})
+        assert r.status_code == 200, "a never-approved document has no floor via .../metadata"
+        assert _current_version(api_url, admin_headers, DOC) == "0.0"


### PR DESCRIPTION
Fixes https://github.com/unidoc/isms/issues/226.

The version-downgrade guard on `PUT /documents/:docId/content` compared a requested version against the document's current draft frontmatter value instead of the last **approved** milestone (`document_versions`, written only on merge/confirm). A draft's version field is working state until re-approved, so locking against its own prior draft saves — rather than against what was actually accepted — blocked a legitimate correction: a document approved at 0.1, auto-bumped to 0.2 on edit, manually over-bumped to 0.3 by mistake, could never be corrected back to 0.2 even though 0.2 is still above the 0.1 floor that actually matters.

Now compares against `db.LatestVersion()` via a shared `versionFloorError()` helper, called from **both** `PUT .../content` and `PUT .../metadata` — the latter is what the document header's own version field uses, and was left completely unguarded until this update (review finding F1). A database error other than "no milestone" is now a 500, not a silent skip (F2).

**A document with no approval history yet (no milestone) is unconstrained — this is a real widening from prior behavior, not "same as before"** (the earlier draft said otherwise; corrected per review finding F3). The old guard compared against the draft frontmatter, which every document has regardless of approval history, so it also constrained never-approved documents; the new one has nothing to compare against until a milestone exists.

The rejection message names the actual floor instead of just restating the two numbers.

New regression tests in `tests/test_version_downgrade_guard.py` walk: the full correction sequence (create → pin 0.1 → approve → merge → auto-bump → over-bump → correct downward → at-or-below-floor rejected), the metadata-endpoint enforcement (mutation-checked — fails without the fix), and the never-approved case being unconstrained on both writers by design.

**Verified locally**, not just claimed: `go build`/`vet`/`test` clean; full non-e2e pytest suite (691 passed, 1 skipped) and `test_e2e_browser.py` (69 passed) both green against a fresh database, run repeatedly for idempotency on a persistent stack — which also surfaced and fixed a latent idempotency gap in `test_review_branch.py::TestDocumentContentSave` unrelated to this PR's own scope but exposed by the new, real floor.

Surfaced live on a production self-hosted deployment — a user hit this exact sequence and had to bypass the API by editing the frontmatter directly via git to get unblocked.