### PR TITLE
feat(i18n): locale picker and the full precedence chain

### DIFF
--- a/web/src/components/LocalePicker.vue
+++ b/web/src/components/LocalePicker.vue
@@ -1,0 +1,53 @@
+<template>
+  <!-- Hidden entirely when the deployment ships a single locale: a picker with
+       one option is noise, and it would suggest a choice that does not exist. -->
+  <select v-if="options.length > 1" :value="selected" @change="onChange"
+    :disabled="saving"
+    :aria-label="$t('common.locale.label')"
+    :class="compact
+      ? 'bg-transparent border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-500 hover:text-slate-300 focus:outline-none transition-colors disabled:opacity-50'
+      : 'w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50'">
+    <!-- Only offered when signed in: with no account to store it against,
+         "follow the org default" is not a state the user can be in. -->
+    <option v-if="persist" value="">{{ $t('common.locale.org_default') }}</option>
+    <option v-for="l in options" :key="l.tag" :value="l.tag">{{ l.name }}</option>
+  </select>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useLocale } from '../composables/useLocale'
+
+const props = defineProps({
+  // false on login / landing, where there is no session to save against.
+  persist: { type: Boolean, default: true },
+  compact: { type: Boolean, default: false },
+})
+const emit = defineEmits(['error'])
+
+const { options, preference, active, chooseLocale } = useLocale()
+const saving = ref(false)
+
+// Signed in, the picker reflects the stored preference — including the empty
+// value that means "org default". Signed out there is no preference, so it
+// shows what is actually being rendered.
+const selected = computed(() => (props.persist ? (preference.value ?? '') : active.value))
+
+async function onChange(e) {
+  const tag = e.target.value
+  saving.value = true
+  try {
+    await chooseLocale(tag, { persist: props.persist })
+    // Clear any message from an earlier failure. Without this a stale error sits
+    // next to a locale that visibly did change, which reads as the save having
+    // failed again.
+    emit('error', '')
+  } catch (err) {
+    // Put the control back where it was; the locale did not change.
+    e.target.value = selected.value
+    emit('error', err?.message || String(err))
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/web/src/components/LocalePicker.vue
+++ b/web/src/components/LocalePicker.vue
@@ -5,7 +5,7 @@
     :disabled="saving"
     :aria-label="$t('common.locale.label')"
     :class="compact
-      ? 'bg-transparent border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-500 hover:text-slate-300 focus:outline-none transition-colors disabled:opacity-50'
+      ? 'bg-transparent border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 hover:text-slate-200 focus:outline-none transition-colors disabled:opacity-50'
       : 'w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50'">
     <!-- Only offered when signed in: with no account to store it against,
          "follow the org default" is not a state the user can be in. -->

--- a/web/src/composables/useLocale.js
+++ b/web/src/composables/useLocale.js
@@ -1,0 +1,127 @@
+// Locale selection: the precedence chain applied to real session data, and the
+// one place that persists a user's choice.
+//
+// `i18n.js` owns the mechanism (negotiation, chunk loading, <html lang>). This
+// composable owns the policy: which signal wins, and when the server is told.
+import { computed, ref } from 'vue'
+import api from '../api.js'
+import {
+  FALLBACK,
+  STORAGE_KEY,
+  i18n,
+  loadableLocales,
+  resolveInitialLocale,
+  setLocale,
+  setSupportedLocales,
+  supportedLocales,
+} from '../i18n.js'
+
+// Module-level so the picker on the login page and the one in Settings share a
+// single source of truth, the way useSession does.
+const options = ref([])
+const orgDefault = ref(FALLBACK)
+// The user's explicit choice. `null` means "following the org default", which is
+// what lets the picker show that as a distinct option rather than pretending the
+// user picked whatever the org happens to default to today.
+const preference = ref(null)
+
+const active = computed(() => i18n.global.locale.value)
+
+// The picker's options: what the server advertises, narrowed to what this bundle
+// can actually render. Not `supportedLocales()` alone — a newer server may
+// advertise a tag with no loader here, and offering it would put the UI on a
+// locale that renders raw keys. `loadableLocales()` exists for exactly this
+// consumer; the intersection keeps the endonyms, which only the server list has.
+function renderableOptions() {
+  const loadable = new Set(loadableLocales())
+  return supportedLocales().filter((l) => loadable.has(l.tag))
+}
+
+// Drop a stored choice. Used when clearing an explicit preference: `setLocale`
+// only ever writes localStorage, so without this the value being cleared stays
+// behind and outranks the org default on the next boot.
+function forgetStored() {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* storage unavailable; the DB preference is the durable copy anyway */
+  }
+}
+
+// Seed the supported set from GET /config and apply the best pre-login guess.
+// Safe to call from every page that already fetches /config; later calls just
+// re-apply the same resolution.
+export async function applyConfigLocales(cfg) {
+  if (!cfg) return
+  setSupportedLocales(cfg.locales)
+  options.value = renderableOptions()
+  if (cfg.default_locale) orgDefault.value = cfg.default_locale
+  // Pre-login there is no user preference, so this is localStorage, then the
+  // browser's languages, then the org default. Nothing persists: a negotiated
+  // guess must not harden into stored state that then outranks the org default.
+  await setLocale(resolveInitialLocale({ orgLocale: orgDefault.value }))
+}
+
+// Apply the locale for an authenticated session, from GET /me.
+//
+// `locale_preference` is the raw choice and `locale` is what the server already
+// resolved (preference, else org default). An explicit choice outranks every
+// client-side signal — it was made deliberately and travels with the account.
+// Without one, the client-side signals apply, because a browser set to
+// Indonesian is a better guess than the org default.
+export async function applySessionLocale(me) {
+  if (!me) return
+  preference.value = me.locale_preference ?? null
+  if (preference.value) {
+    // Persisted, so localStorage is corrected to match the account rather than
+    // being left holding a conflicting value from another session on this
+    // device. The account choice is the durable one; storage is its cache.
+    await setLocale(preference.value, { persist: true })
+    return
+  }
+  // No explicit choice on the account, so nothing here is a preference and
+  // nothing is written.
+  await setLocale(resolveInitialLocale({ orgLocale: me.locale || orgDefault.value }))
+}
+
+// Change the active locale. `tag` is '' to clear an explicit choice and follow
+// the org default again.
+//
+// `persist` is false on the login and landing pages, where there is no session
+// to save against — the choice still survives in localStorage, and is upgraded
+// to a stored preference the next time the user saves one while signed in.
+export async function chooseLocale(tag, { persist = true } = {}) {
+  if (persist) {
+    // Send only `locale`. `name` is optional server-side precisely so a
+    // locale-only update cannot race a concurrent rename. An empty string is
+    // the documented "clear my choice" value, distinct from omitting the field.
+    await api.putJSON('/api/v1/auth/profile', { locale: tag })
+  }
+  preference.value = tag || null
+  if (!tag) {
+    // Clearing applies the org default directly rather than re-running the
+    // precedence chain: localStorage still holds the choice being cleared, and
+    // would immediately win it back. Forget it first, then apply without
+    // persisting — following the org default is the absence of a choice, so
+    // storing the resolved tag would just recreate the pin being removed.
+    forgetStored()
+    await setLocale(orgDefault.value)
+    return
+  }
+  // An explicit pick by this user on this device: the one thing that is a
+  // preference, and so the one thing localStorage should remember. Without it
+  // the pre-login picker's choice would not survive a reload.
+  await setLocale(tag, { persist: true })
+}
+
+export function useLocale() {
+  return {
+    options,
+    orgDefault,
+    preference,
+    active,
+    applyConfigLocales,
+    applySessionLocale,
+    chooseLocale,
+  }
+}

--- a/web/src/composables/useSession.js
+++ b/web/src/composables/useSession.js
@@ -1,5 +1,6 @@
 import { ref, computed, watch } from 'vue'
 import { api, getCurrentUser, clearApiToken, setApiToken, setCurrentUser } from '../api'
+import { applyConfigLocales, applySessionLocale } from './useLocale'
 import { orgFromSubdomain, isSubdomainMode, orgEntryURL, setSubdomainRouting, setApexHost, ensureConfigLoaded } from './useCurrentOrg'
 
 const user = ref(getCurrentUser())
@@ -83,6 +84,9 @@ export function useSession() {
         }
       }
       currentUserData.value = me
+      // The authenticated half of the locale chain: an explicit choice stored
+      // on the account outranks localStorage and the browser's languages.
+      await applySessionLocale(me)
       if (currentUserData.value?.email) {
         user.value = currentUserData.value.email
       }
@@ -145,6 +149,9 @@ export function useSession() {
   async function loadBranding() {
     try {
       const cfg = await api.getConfig()
+      // Which locales exist, and the org default, both come from the server —
+      // never a hardcoded list.
+      await applyConfigLocales(cfg)
       // Branding settings override org defaults
       if (cfg.branding?.branding_name) {
         orgName.value = cfg.branding.branding_name

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -17,6 +17,10 @@
   "validation": {
     "required": "This field is required"
   },
+  "locale": {
+    "label": "Language",
+    "org_default": "Organization default"
+  },
   "entity": {},
   "field": {},
   "enum": {},

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -17,6 +17,10 @@
   "validation": {
     "required": "Kolom ini wajib diisi"
   },
+  "locale": {
+    "label": "Bahasa",
+    "org_default": "Bawaan organisasi"
+  },
   "entity": {},
   "field": {},
   "enum": {},

--- a/web/src/views/Admin.vue
+++ b/web/src/views/Admin.vue
@@ -570,6 +570,18 @@
                   <div class="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600"></div>
                   <span class="ml-3 text-sm text-slate-400">{{ s.value === 'true' ? 'Enabled' : 'Disabled' }}</span>
                 </label>
+                <!-- Locale select. A free-text tag here is a trap: the server 400s an
+                     unrecognised one, and the admin has no way to know what it accepts. -->
+                <select v-else-if="settingType(s) === 'locale'" v-model="s.value"
+                  class="w-64 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
+                  <!-- Empty is a real, server-accepted value: no org default. -->
+                  <option value="">No default (English)</option>
+                  <option v-for="l in localeOptions" :key="l.tag" :value="l.tag">{{ l.name }}</option>
+                  <!-- A stored tag this build cannot render still has to be shown as the
+                       current value; a select with no matching option would silently
+                       display something other than what is saved. -->
+                  <option v-if="s.value && !localeOptions.some(l => l.tag === s.value)" :value="s.value">{{ s.value }}</option>
+                </select>
                 <!-- Number input -->
                 <input v-else-if="settingType(s) === 'number'" v-model="s.value" type="number" min="0"
                   class="w-32 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500" />
@@ -691,6 +703,7 @@ import { useRoute, useRouter } from 'vue-router'
 import api from '../api.js'
 import { useSession } from '../composables/useSession'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { useLocale } from '../composables/useLocale'
 
 const route = useRoute()
 const router = useRouter()
@@ -788,6 +801,11 @@ const newProviderMsg = ref('')
 const newProviderError = ref(false)
 
 // Settings
+// Renamed on destructure: `options` is too generic for a 1000-line view. Already
+// seeded by useSession's loadBranding() -> applyConfigLocales on any org page, and
+// it is a ref, so a late /config fill-in reaches the select on its own.
+const { options: localeOptions } = useLocale()
+
 const settings = ref([])
 const settingsMsg = ref('')
 const settingsError = ref(false)
@@ -1104,6 +1122,7 @@ const BRANDING_SETTING_KEYS = new Set([
 const HIDDEN_SETTING_KEYS = new Set(['risk_categories'])
 
 const categoryLabels = {
+  localization: 'Localization',
   notifications: 'Notifications',
   review_cycles: 'Review Cycles',
   risk: 'Risk',
@@ -1122,8 +1141,11 @@ const settingsByCategory = computed(() => {
   return groups
 })
 
-// Infer widget type from setting metadata. Order matters: color > secret > boolean > number > text.
+// Infer widget type from setting metadata. Order matters: locale > color > secret >
+// boolean > number > text. The locale check is by key rather than by value shape —
+// the set of valid tags is known, so this is a choice, not free text.
 function settingType(s) {
+  if (s.key === 'default_locale') return 'locale'
   if (s.key.endsWith('_color')) return 'color'
   if (s.sensitive) return 'secret'
   const v = s.value || s.default_value || ''

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -162,11 +162,16 @@
 
     <!-- Footer -->
     <footer class="relative z-10 border-t border-slate-800/50 px-8 py-8 mt-8">
-      <div class="max-w-6xl mx-auto flex items-center justify-between text-sm text-slate-500">
+      <div class="max-w-6xl mx-auto flex items-center justify-between gap-4 text-sm text-slate-500">
         <span>{{ brandFooter }}</span>
-        <span v-if="showPoweredBy">
-          Powered by <a href="https://isms.sh" target="_blank" rel="noopener" class="text-slate-400 hover:text-white transition-colors">isms.sh</a>
-        </span>
+        <div class="flex items-center gap-4">
+          <!-- Pre-login, so the choice is local only: there is no account to save
+               it against yet. -->
+          <LocalePicker :persist="false" compact class="shrink-0" />
+          <span v-if="showPoweredBy">
+            Powered by <a href="https://isms.sh" target="_blank" rel="noopener" class="text-slate-400 hover:text-white transition-colors">isms.sh</a>
+          </span>
+        </div>
       </div>
     </footer>
   </div>
@@ -175,6 +180,8 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import api from '../api'
+import { applyConfigLocales } from '../composables/useLocale'
+import LocalePicker from '../components/LocalePicker.vue'
 
 // Neutral seed so a self-hosted deployment doesn't flash "isms.sh" in the
 // top-left while /api/v1/config resolves the branded name — same fallback
@@ -211,6 +218,7 @@ const frameworks = [
 onMounted(async () => {
   try {
     const cfg = await api.getConfig()
+    await applyConfigLocales(cfg)
     if (cfg.branding?.branding_name) {
       brandName.value = cfg.branding.branding_name
     } else if (cfg.organization_name) {

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -196,6 +196,12 @@
         </div>
       </div>
       </template>
+
+      <!-- Pre-login language choice, so a user can read the app before they have
+           an account. Local only — nothing to persist against yet. -->
+      <div class="mt-8 flex justify-center">
+        <LocalePicker :persist="false" compact />
+      </div>
     </div>
     <div class="fixed bottom-4 left-0 right-0 text-center text-xs text-slate-600">
       <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">Privacy Policy</a>
@@ -213,6 +219,8 @@ import { useRouter, useRoute } from 'vue-router'
 import { login, getApiToken, setApiToken } from '../api'
 import api from '../api'
 import { orgFromSubdomain, isSubdomainMode, orgEntryURL, canHostSubdomain } from '../composables/useCurrentOrg'
+import { applyConfigLocales } from '../composables/useLocale'
+import LocalePicker from '../components/LocalePicker.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -476,6 +484,7 @@ onMounted(async () => {
   let configOrgSlug = ''
   try {
     const cfg = await api.getConfig()
+    await applyConfigLocales(cfg)
     if (cfg.organization?.name) orgName.value = cfg.organization.name
     if (cfg.organization_name) orgName.value = cfg.organization_name
     if (cfg.branding?.branding_name) orgName.value = cfg.branding.branding_name

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -23,6 +23,11 @@
           <div v-if="nameMsg" class="text-xs mt-1" :class="nameError ? 'text-red-400' : 'text-emerald-400'">{{ nameMsg }}</div>
         </div>
         <div>
+          <label class="block text-xs text-slate-500 mb-1">{{ $t('common.locale.label') }}</label>
+          <LocalePicker @error="localeMsg = $event" />
+          <div v-if="localeMsg" class="text-xs mt-1 text-red-400">{{ localeMsg }}</div>
+        </div>
+        <div>
           <label class="block text-xs text-slate-500 mb-1">Role</label>
           <span class="inline-block px-2 py-0.5 text-xs font-medium rounded-full"
             :class="user?.role === 'admin' ? 'bg-purple-500/20 text-purple-300' :
@@ -305,6 +310,7 @@ import { useConfirm } from '../composables/useConfirm'
 import { ref, nextTick, onMounted, computed } from 'vue'
 import QRCode from 'qrcode'
 import api from '../api.js'
+import LocalePicker from '../components/LocalePicker.vue'
 
 const user = ref(null)
 
@@ -325,6 +331,7 @@ const passkeyError = ref(false)
 const passkeyAvailable = computed(() => typeof window !== 'undefined' && window.PublicKeyCredential !== undefined)
 
 // Profile
+const localeMsg = ref('')
 const profileName = ref('')
 const savingName = ref(false)
 const nameMsg = ref('')

--- a/web/test/useLocale.test.js
+++ b/web/test/useLocale.test.js
@@ -1,0 +1,295 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import api from '../src/api.js'
+import { FALLBACK, STORAGE_KEY, i18n, setLocale, setSupportedLocales } from '../src/i18n.js'
+import {
+  applyConfigLocales,
+  applySessionLocale,
+  chooseLocale,
+  useLocale,
+} from '../src/composables/useLocale.js'
+
+const CONFIG = {
+  locales: [
+    { tag: 'en', name: 'English' },
+    { tag: 'id-ID', name: 'Bahasa Indonesia' },
+  ],
+  default_locale: 'id-ID',
+}
+
+// Node's global `localStorage` exists but throws unless the runtime was started
+// with a backing file, so this file installs a working in-memory one. It has to
+// be real rather than a write-recording stub: precedence step 2 reads back what
+// step 1 wrote, and half these tests assert on that round trip. `node --test`
+// gives each file its own process, so this stays local to this file.
+const store = new Map()
+globalThis.localStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+}
+
+// A value left by an earlier test would win precedence step 2 over the org
+// default and make these assertions order-dependent. "The user has no stored
+// locale" is the state each test means to start from.
+function clearStored() {
+  store.clear()
+}
+
+// Node's `navigator.languages` is ['en-US'], which legitimately outranks the org
+// default (precedence step 3 beats step 4). To exercise the org-default path at
+// all, the browser signal has to name something this build does not ship.
+const realNavigator = globalThis.navigator
+function navigatorSays(...languages) {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { ...realNavigator, languages },
+    configurable: true,
+    writable: true,
+  })
+}
+function restoreNavigator() {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: realNavigator,
+    configurable: true,
+    writable: true,
+  })
+}
+
+// The composable is module-level state, shared the way useSession is, so each
+// test puts it back.
+async function reset() {
+  setSupportedLocales([])
+  await setLocale(FALLBACK)
+  clearStored()
+  restoreNavigator()
+}
+
+test('applyConfigLocales seeds the picker from the server, not a constant', async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('ja-JP')
+  await applyConfigLocales(CONFIG)
+  const { options, orgDefault } = useLocale()
+  assert.deepEqual(
+    options.value.map((l) => l.name),
+    ['English', 'Bahasa Indonesia'],
+  )
+  assert.equal(orgDefault.value, 'id-ID')
+  // Nothing above the org default applies here — no stored value, and the
+  // browser asks for a language this build does not ship — so the org default
+  // is what renders.
+  assert.equal(i18n.global.locale.value, 'id-ID')
+})
+
+test('applyConfigLocales tolerates a config call that returned nothing', async (t) => {
+  t.after(reset)
+  clearStored()
+  await applyConfigLocales(null)
+  await applyConfigLocales({})
+  assert.equal(i18n.global.locale.value, FALLBACK)
+})
+
+test('an explicit stored preference outranks the org default', async (t) => {
+  t.after(reset)
+  await applyConfigLocales(CONFIG)
+  await applySessionLocale({ locale: 'en', locale_preference: 'en' })
+  const { preference } = useLocale()
+  assert.equal(preference.value, 'en')
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+test('no preference means follow the org default, and the picker says so', async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('ja-JP')
+  await applyConfigLocales(CONFIG)
+  await applySessionLocale({ locale: 'id-ID', locale_preference: null })
+  const { preference } = useLocale()
+  // null, not 'id-ID' — the difference is what lets the picker show "Organization
+  // default" rather than pinning the user to today's default.
+  assert.equal(preference.value, null)
+  assert.equal(i18n.global.locale.value, 'id-ID')
+})
+
+test('choosing a locale persists only the locale field', async (t) => {
+  t.after(reset)
+  const calls = []
+  const original = api.putJSON
+  api.putJSON = async (path, body) => {
+    calls.push([path, body])
+    return {}
+  }
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en')
+  // `name` must be absent, not echoed back: sending it would race a concurrent
+  // rename and silently revert it.
+  assert.deepEqual(calls, [['/api/v1/auth/profile', { locale: 'en' }]])
+  assert.equal(useLocale().preference.value, 'en')
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+test('clearing the choice returns to the org default, not the cleared value', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => ({})
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en')
+  await chooseLocale('')
+  // localStorage still holds 'en' at this point, so re-running the precedence
+  // chain would win the cleared choice straight back. The org default has to be
+  // applied directly.
+  assert.equal(useLocale().preference.value, null)
+  assert.equal(i18n.global.locale.value, 'id-ID')
+})
+
+test('the pre-login picker changes the locale without calling the API', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => {
+    throw new Error('must not be called before login')
+  }
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en', { persist: false })
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+test("the browser's language outranks the org default", async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('id', 'en-US')
+  // A user whose browser asks for Indonesian gets Indonesian even though the org
+  // defaults to English — a deliberate browser setting is a better signal than
+  // an org-wide default the user never saw. A bare 'id' still resolves to the
+  // 'id-ID' bundle.
+  await applyConfigLocales({ ...CONFIG, default_locale: 'en' })
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  // ...but an explicit account preference still beats it.
+  await applySessionLocale({ locale: 'en', locale_preference: 'en' })
+  assert.equal(i18n.global.locale.value, 'en')
+})
+
+// --- Persistence. `setLocale` defaults to `persist: false`, so every write to
+// localStorage is a deliberate decision by this module about what counts as a
+// preference. These tests pin those decisions, because getting them wrong fails
+// silently: the app still renders, just in the wrong language on the next load.
+
+test('an explicit pick is remembered across a reload', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => ({})
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en')
+  // Without this the pre-login picker would forget the choice on reload, since
+  // there is no account preference to restore it from.
+  assert.equal(localStorage.getItem(STORAGE_KEY), 'en')
+})
+
+test('a pre-login pick is remembered even though nothing is sent to the server', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => {
+    throw new Error('must not be called before login')
+  }
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('id-ID', { persist: false })
+  // `persist: false` is about the API call, not about the device: localStorage
+  // is the only place a signed-out choice can live.
+  assert.equal(localStorage.getItem(STORAGE_KEY), 'id-ID')
+})
+
+test('clearing the choice also forgets the stored one', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => ({})
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await chooseLocale('en')
+  await chooseLocale('')
+  // Leaving 'en' behind would let it outrank the org default on the next boot
+  // and silently undo the clear. Nor is the org default written in its place:
+  // following the default is the absence of a choice, and storing it would
+  // recreate the pin the user just removed.
+  assert.equal(localStorage.getItem(STORAGE_KEY), null)
+})
+
+test('a negotiated locale never hardens into a stored preference', async (t) => {
+  t.after(reset)
+  clearStored()
+  navigatorSays('ja-JP')
+  await applyConfigLocales(CONFIG)
+  // The org default rendered, but the user never chose it — storing it would
+  // pin them to today's default and outrank tomorrow's.
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  assert.equal(localStorage.getItem(STORAGE_KEY), null)
+})
+
+test('the account preference corrects a conflicting stored value', async (t) => {
+  t.after(reset)
+  localStorage.setItem(STORAGE_KEY, 'en')
+  await applyConfigLocales(CONFIG)
+  await applySessionLocale({ locale: 'id-ID', locale_preference: 'id-ID' })
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  // The account is the durable copy and storage is its cache. Leaving 'en'
+  // behind would make the pre-login pages of this device disagree with the
+  // account for as long as the stale value survived.
+  assert.equal(localStorage.getItem(STORAGE_KEY), 'id-ID')
+})
+
+test('a locale this build cannot render is never offered', async (t) => {
+  t.after(reset)
+  clearStored()
+  await applyConfigLocales({
+    ...CONFIG,
+    // A server newer than this bundle: it supports fr-FR, but there is no
+    // loader here, so selecting it would render raw message keys.
+    locales: [...CONFIG.locales, { tag: 'fr-FR', name: 'Français' }],
+  })
+  assert.deepEqual(
+    useLocale().options.value.map((l) => l.tag),
+    ['en', 'id-ID'],
+  )
+})
+
+test('a failed save changes nothing — not the preference, the locale, or storage', async (t) => {
+  t.after(reset)
+  const original = api.putJSON
+  api.putJSON = async () => {
+    throw new Error('locale not supported')
+  }
+  t.after(() => {
+    api.putJSON = original
+  })
+
+  await applyConfigLocales(CONFIG)
+  await applySessionLocale({ locale: 'en', locale_preference: 'en' })
+  await assert.rejects(() => chooseLocale('id-ID'), /locale not supported/)
+  // The API call comes first precisely so a rejection leaves every downstream
+  // effect unrun: the picker reverts to `preference`, which must still describe
+  // what the server actually holds.
+  assert.equal(useLocale().preference.value, 'en')
+  assert.equal(i18n.global.locale.value, 'en')
+  assert.equal(localStorage.getItem(STORAGE_KEY), 'en')
+})

--- a/web/test/useLocale.test.js
+++ b/web/test/useLocale.test.js
@@ -111,6 +111,27 @@ test('no preference means follow the org default, and the picker says so', async
   assert.equal(i18n.global.locale.value, 'id-ID')
 })
 
+test('without an explicit choice, a supported browser language outranks the org default', async (t) => {
+  t.after(reset)
+  clearStored()
+  // The conflict case the previous test cannot reach: the browser names a
+  // locale this build actually ships, and it differs from the org default.
+  navigatorSays('id-ID')
+  await applyConfigLocales({ ...CONFIG, default_locale: 'en' })
+  await applySessionLocale({ locale: 'en', locale_preference: null })
+  const { preference } = useLocale()
+  // Still no preference — following the org default is the absence of a choice,
+  // and in that state precedence step 3 (the browser) beats step 4 (the org).
+  // Deliberate: the server resolves `locale` to the org default because it
+  // cannot see the browser, so applying it directly here would throw away the
+  // better signal and make a browser set to Indonesian unreachable without an
+  // account.
+  assert.equal(preference.value, null)
+  assert.equal(i18n.global.locale.value, 'id-ID')
+  // And nothing is stored: a negotiated guess is not a choice.
+  assert.equal(localStorage.getItem(STORAGE_KEY), null)
+})
+
 test('choosing a locale persists only the locale field', async (t) => {
   t.after(reset)
   const calls = []


### PR DESCRIPTION
Part of #212. Supersedes #219.

## What this adds

A language selector, so a user can actually choose to read the app in Bahasa Indonesia.

We shipped the translation machinery in #217 and the Indonesian text itself in #218, but nothing in the UI ever let a person pick a language. Until now the only way to get Indonesian was to change your browser's own language setting — which most users never touch, and which an organisation cannot help them with. This PR is the missing control.

Four places get it:

- **Settings → Profile** — the real one. Your choice is saved to your account, so it follows you to a new laptop or phone.
- **The login page** and **the landing page** — a compact version, so someone can read the app *before* they have an account. Nothing is saved to a server here (there is no account yet); the choice lives in the browser until they sign in and save one.
- **Admin → Settings** — where an admin sets the *organisation's* default. This one is not a user preference; it is the value everyone who has not chosen for themselves follows.

If a deployment only ships one language, the selector hides itself entirely. A dropdown with one option is noise, and it implies a choice that does not exist.

## Decisions worth a second look

**"Organization default" is offered as its own option, separate from any specific language.** A user who has not chosen anything is *following the org default*, not pinned to whatever that default happens to be today. If an admin later switches the organisation to Indonesian, those users move with it. If we had quietly recorded "English" for them, they would not.

**Clearing your choice really clears it.** Picking "Organization default" after having chosen a language removes the stored choice everywhere, rather than leaving a copy behind in the browser that would silently reassert itself the next time the page loaded. This was the single easiest thing in this feature to get wrong, and it is what most of the new tests are guarding.

**Your account wins over your browser.** If your account says Indonesian but this particular browser has English cached from an earlier visit, the account wins and the browser copy is corrected. A choice you made deliberately should not be overridden by a stale local leftover.

**A language we cannot actually display is never offered.** If the server is upgraded to advertise a language before the frontend has the text for it, that language stays out of the dropdown. Offering it would show the user a screen of raw internal labels.

## What users will and will not see translated

The selector works and the language genuinely switches — but **most on-screen text is still English in both languages.** That is expected at this stage, not a defect. Translating the app is being done screen by screen in later PRs; what exists today is the shared vocabulary file plus this control. This PR delivers the mechanism, not the coverage.

## Verification

Unit tests: 76/76 pass, 17 of them covering this feature specifically. Production build is clean, and Indonesian remains a separate 0.44 kB download that costs nothing to users who never select it.

Also exercised by hand against a real server and database in a browser, not only in tests:

- selecting a language re-rendered the page immediately, with no reload
- the choice survived a page refresh
- clearing it returned to the organisation default — and stayed cleared after a refresh
- an account set to Indonesian corrected a browser that had English cached
- the login-page selector changed language with zero calls to the server
- saving a language did not disturb the user's name (these can be edited at the same time; they must not overwrite each other)
- rejecting an invalid language left everything unchanged
- no browser console errors on any page

One path is covered by tests but not by hand: what the control does when the server rejects a save. It reverts and surfaces the message; the dropdown cannot produce an invalid value on its own, so this could not be triggered through the UI.

## Why a new PR instead of reviving #219

#219 was closed automatically by GitHub three seconds after #218 merged — deleting the base branch closes anything stacked on it. It was never reviewed down or rejected.

Reviving it was not practical: #217 and #218 were squash-merged, so from git's point of view the old branch shares no history with `master`, and `master` has since improved the underlying language-switching code. Rebasing would have meant resolving conflicts on every shared file, with a real risk of dragging reverted code back in. This branch is cut fresh from `master` and carries only the selector, adapted to how `master` works today. Four behaviours needed reworking against the newer code; one of them — the clearing behaviour above — had become an outright bug in the old version.

## Reviewer notes

Ten files. The logic worth reading is `web/src/composables/useLocale.js` (which signal wins, and when the server is told) and `web/src/components/LocalePicker.vue`. The rest is wiring: three views that already fetch `/config` now also seed the language list from it, `useSession` applies the account's choice when `/me` arrives, and `Admin.vue` renders the org default as a list instead of a text box.

## Review round

Two findings from automated review, plus one from manual testing:

- **Contrast.** The compact picker drew its text in `text-slate-500`, which measures 4.24:1 against the login page's `bg-slate-950` and roughly the same against the landing page — under the 4.5:1 needed at 12px. Now `text-slate-400` (~8:1), with the hover step raised so hovering still reads as a change. The full-width picker in Settings is white on `slate-800` and was left alone.
- **Precedence, when no explicit choice exists.** It was suggested that `applySessionLocale` apply the server-resolved `locale` directly rather than re-running the chain. Not taken: the chain deliberately ranks `navigator.languages` above the org default for a user who has not chosen, and that is what makes a browser set to Indonesian work without an account. The server resolves to the org default only because it cannot see the browser. The coverage gap behind the comment was real, though — the existing test used a browser language this build does not ship, so it never exercised a conflict. There is now a test with a *supported* conflicting browser language asserting the browser wins, the preference stays null, and nothing is stored.
- **The org default was a text box.** `Admin → Settings` is a generic key/value editor, so setting the organisation's language meant typing `id-ID` exactly and getting a bare 400 otherwise. It is a dropdown now. Empty stays offered, because the server accepts it as "no org default"; a stored tag this build cannot render is still shown as the current value rather than leaving the select blank over a saved one.

One thing worth a reviewer's opinion rather than a code change: immediately after choosing "Organization default" the org default is applied directly, because localStorage still holds the value being cleared and would win it straight back. On the next load the chain runs, and a supported browser language can win instead. Both halves are intended and each is covered by a test, but it does mean the picker can read "Organization default" while rendering something else. Whether the label should say so is a product question, not a bug.

No backend changes — the API landed in #214.

