### PR TITLE
feat(i18n): fill the shared enum catalogue and translate StatusBadge (#212)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,15 @@ reaches the picker — then copy `web/src/locales/en/`, translate the values, an
 add one loader line. [`docs/i18n.md`](docs/i18n.md#adding-a-locale) has the full
 steps.
 
+One part of a translation is not a matter of fluency: the ISO audit terms and the
+information-classification levels. Take those from your language's national
+adoption of ISO/IEC 27001 or 9001 rather than translating the English, and record
+what you took in
+[`web/src/locales/README.md`](web/src/locales/README.md#iso-terminology) — it
+carries the procedure, a term checklist keyed to the clauses of the standard, and
+the traps that recur across languages. A wrong choice here reads perfectly and
+still says the wrong thing, so a reviewer cannot catch it for you.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -108,6 +108,12 @@ literal. Each category of translatable thing has exactly one implementation:
 | Relative time | `useFormat().relative()`, backed by `Intl.RelativeTimeFormat` |
 | Region names | `Intl.DisplayNames`, so country names need no translation file in any language |
 
+Enum labels are keyed `common.enum.<group>.<db_value>`, with the group named
+after the notification param that interpolates it where one does, and after the
+column otherwise. `status` is deliberately one flat group across every register.
+The full rule, and the escape hatch if a language needs per-register status
+wording, is in [`web/src/locales/README.md`](../web/src/locales/README.md).
+
 `useI18n()` needs an active component instance, so it is unavailable in `api.js`,
 `utils.js` and router guards. Those import the global scope instead:
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -75,10 +75,20 @@ is a lost-update race against a concurrent rename.
 
 1. **Register it server-side** — add the tag and its endonym to the supported map
    in `internal/isms/i18n/locale.go`, and extend `locale_test.go`.
-2. **Copy the message bundle** — `cp -r web/src/locales/en web/src/locales/<tag>`
+2. **Settle the ISO vocabulary before you translate a single value.** The audit
+   terms (nonconformity, corrective action, opportunity for improvement,
+   conformity) and the information-classification levels are the ones a fluent
+   translator gets wrong invisibly, because the wrong choice reads perfectly.
+   `web/src/locales/README.md` has the procedure, a language-independent term
+   checklist keyed to the clauses of the standard, the three traps that recur
+   across languages, and a worked example. Take the terms from your language's
+   national adoption of ISO/IEC 27001 or 9001, and record your table there —
+   this is a step, not a suggestion: two of the three Indonesian terms it
+   catches were wrong on the first pass.
+3. **Copy the message bundle** — `cp -r web/src/locales/en web/src/locales/<tag>`
    and translate the values. Keep the filenames and the keys; change only the
    right-hand side.
-3. **Register the loader** — add one line to the `loaders` map in
+4. **Register the loader** — add one line to the `loaders` map in
    `web/src/i18n.js`:
    ```js
    '<tag>': () => import('./locales/<tag>/index.js'),
@@ -86,13 +96,13 @@ is a lost-update race against a concurrent rename.
    Locales are lazy-loaded as separate chunks, so locale N+1 costs nothing to
    users who do not select it. `en` is the exception: it is bundled, because the
    fallback must always be resident.
-4. **Check the keyset** — run `npm test` in `web/`. `test/localeKeyset.test.js`
+5. **Check the keyset** — run `npm test` in `web/`. `test/localeKeyset.test.js`
    compares every locale directory against `en` and runs in CI with the rest of
    the suite. Missing keys are a warning: `fallbackLocale` renders them in
    English, and a translation lagging by a few keys must not block an unrelated
    PR. Extra keys **fail** — they are typos or stale keys with no English
    counterpart.
-5. **QA the layout.** Translated copy is routinely 20–25% longer than English.
+6. **QA the layout.** Translated copy is routinely 20–25% longer than English.
    Check table headers, status badges, the sidebar and button rows for overflow.
 
 ## The five seams

--- a/web/src/components/StatusBadge.vue
+++ b/web/src/components/StatusBadge.vue
@@ -4,18 +4,29 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
 
 const props = defineProps({
   status: String,
+  // The enum family the value belongs to. Almost every caller passes a status
+  // column, and status values are distinct across registers — the colour map
+  // below has always been one flat table for the same reason — so `status` is
+  // one shared group rather than one per register. The few callers rendering a
+  // different family (classification, criticality, an audit result) name it.
+  group: { type: String, default: 'status' },
 })
 
+const { t } = useI18n()
+const { enumLabel } = useEnumLabel()
+
 const label = computed(() => {
-  if (!props.status) return 'unknown'
-  return props.status.replace(/_/g, ' ')
+  if (!props.status) return t('common.state.unknown')
+  return enumLabel(props.group, props.status)
 })
 
 const classes = computed(() => {
-  const base = 'inline-block px-2 py-0.5 rounded text-xs font-semibold capitalize'
+  const base = 'inline-block px-2 py-0.5 rounded text-xs font-semibold'
   const map = {
     // Document statuses
     draft: 'bg-slate-700 text-slate-300',

--- a/web/src/composables/useEnumLabel.js
+++ b/web/src/composables/useEnumLabel.js
@@ -8,7 +8,7 @@
 // A value with no key falls back to the de-slugged form rather than rendering a
 // raw key, so a locale file that lags behind a new enum member degrades to
 // today's English-ish output instead of showing `common.enum.status.foo`.
-import { i18n } from '../i18n.js'
+import { FALLBACK, i18n } from '../i18n.js'
 
 // De-slug of last resort: `changes_requested` -> `Changes requested`.
 function humanize(value) {
@@ -21,7 +21,12 @@ function humanize(value) {
 export function enumLabel(group, value) {
   if (value === null || value === undefined || value === '') return ''
   const key = `common.enum.${group}.${value}`
-  return i18n.global.te(key) ? i18n.global.t(key) : humanize(value)
+  // te() checks one locale only and does not consult fallbackLocale, so probe
+  // the fallback catalogue: it is complete by contract, and a locale that lags
+  // behind then renders the English label through fallbackLocale rather than
+  // dropping to humanize(). The difference is visible — `major_nc` is "Major
+  // non-conformity", not "Major nc".
+  return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : humanize(value)
 }
 
 // Component-facing form. Deliberately thin: the implementation lives in

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -93,6 +93,30 @@ now, rather than retrofitted when a locale with real plural rules arrives.
   `audit_result`).
 - **Everything else is named after its column**: `suggestion_type` for
   `suggestions.suggestion_type`, `audit_result` for `audit_items.result`.
+- **A group is really named after its value set, and the column name is just the
+  usual way to say that.** Where two columns share a name but not a value set,
+  the column name belongs to one of them and the other is named after its
+  taxonomy. There is one such collision today, and it is the trap to check for
+  before picking a group:
+
+  | Column | Value set | Group |
+  |---|---|---|
+  | `incidents.severity` | critical … low | `severity` |
+  | `corrective_actions.severity` | major_nc … opportunity | **`finding_type`** |
+  | `audit_findings.finding_type` | major_nc … opportunity | `finding_type` |
+  | `audit_items.result` | the four above plus `not_assessed`, `conforming` | `audit_result` |
+
+  Reaching for `severity` because the column says `severity` would render a
+  corrective action's `major_nc` against the incident scale, which has no such
+  member — so it would de-slug to "Major nc" in every language. `finding_type`
+  and `audit_result` deliberately overlap: a finding is always one of the four,
+  while an audit item may also be unassessed or conforming.
+- **One value may need two different renderings**, and that is an area-file job,
+  not a second enum group. `Audit.vue` and `CorrectiveActions.vue` show these
+  same four values as compact chips reading "Major NC" and "OFI", while a table
+  column has room for "Major non-conformity". The catalogue holds the full form;
+  an abbreviation is copy belonging to the view that needs it, and goes in that
+  view's area file when it is extracted.
 
 If a language ever needs two different translations for one status value —
 Portuguese gender agreement on *aberto* / *aberta*, for instance — splitting the
@@ -147,8 +171,8 @@ your subsection and fill the right-hand column.
 |---|---|---|
 | improvement | clause 10 heading | — |
 | continual improvement | clause 10.3 heading | — |
-| opportunity for improvement | clause 9.3.2 f, 10.1 a | `enum.audit_result.opportunity` |
-| nonconformity | clause 10.2 heading | `enum.audit_result.{minor_nc,major_nc}` |
+| opportunity for improvement | clause 9.3.2 f, 10.1 a | `enum.{audit_result,finding_type}.opportunity` |
+| nonconformity | clause 10.2 heading | `enum.{audit_result,finding_type}.{minor_nc,major_nc}` |
 | corrective action | clause 10.2 heading | `entity.corrective_action` |
 | conformity | throughout | `enum.audit_result.conforming` |
 | objective | clause 6.2 | `entity.objective`, `enum.status.*` |

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -113,13 +113,76 @@ diverge.
 ## ISO terminology
 
 The audit vocabulary is the part of this app most easily mistranslated, because
-the wrong choice is always fluent. ISO separates *correction* from *improvement*
-and *conformity* from *compliance*, and a translator who has not audited before
-will reasonably collapse them. Where a national adoption of the standard exists,
-it decides — not general fluency, and not this file.
+**the wrong choice is always fluent**. ISO separates *correction* from
+*improvement*, *conformity* from *compliance*, and a nonconformity from an
+observation. A translator who has not sat an audit will reasonably collapse
+those pairs, and nothing about the result looks wrong — which is why this cannot
+be caught by proofreading, and why the procedure below is not optional.
 
-**Indonesian.** Verified against the bilingual SNI ISO 9001:2015, whose clauses
-4–10 are the Annex SL structure that SNI ISO/IEC 27001:2022 shares verbatim:
+The rule for every language: **where a national adoption of the standard exists,
+it decides.** Not general fluency, not a dictionary, and not this file.
+
+### Procedure — do this before translating anything else
+
+1. **Find the national adoption of ISO/IEC 27001** in your language. If there is
+   none, ISO 9001 works just as well for this vocabulary: clauses 4–10 are the
+   Annex SL structure the two standards share verbatim, and every term in the
+   checklist below lives in those clauses. Many adoptions are published
+   bilingually, which gives you the term pairs directly.
+2. **Fill in the checklist** from that text, quoting the clause you took each
+   term from. Do not translate the English; copy what the standard prints.
+3. **Watch for the recurring traps** — the three below have bitten us or are
+   known to bite in more than one language.
+4. **Record your table** as a subsection here, with citations. That is what makes
+   the next contributor's job smaller than yours, and what lets a reviewer who
+   does not speak your language still check your work.
+
+### The checklist
+
+These are the terms the enum catalogue actually uses. The clause reference is
+the same in every adoption, so this table is language-independent — copy it into
+your subsection and fill the right-hand column.
+
+| English | Defined in | Used by |
+|---|---|---|
+| improvement | clause 10 heading | — |
+| continual improvement | clause 10.3 heading | — |
+| opportunity for improvement | clause 9.3.2 f, 10.1 a | `enum.audit_result.opportunity` |
+| nonconformity | clause 10.2 heading | `enum.audit_result.{minor_nc,major_nc}` |
+| corrective action | clause 10.2 heading | `entity.corrective_action` |
+| conformity | throughout | `enum.audit_result.conforming` |
+| objective | clause 6.2 | `entity.objective`, `enum.status.*` |
+| monitoring | clause 9.1 heading | `enum.status.monitoring` |
+| review (management) | clause 9.3 heading | `enum.status.{in_review,under_review}` |
+| internal audit | clause 9.2 heading | `entity.audit` |
+
+### Recurring traps
+
+**Correction is not improvement.** Most languages have distinct words, and ISO
+relies on the distinction: an opportunity for improvement is explicitly *not* a
+nonconformity requiring correction. Picking the correction word collapses the
+only thing that separates the two categories. Indonesian *perbaikan* vs
+*peningkatan*, Portuguese *correção* vs *melhoria*, Spanish *corrección* vs
+*mejora*, French *correction* vs *amélioration* — check which one your adoption
+uses in clause 10.1 before writing `enum.audit_result.opportunity`.
+
+**Classification levels follow your national ladder, not the English words.**
+`public` → `internal` → `confidential` → `restricted` is ordered by increasing
+sensitivity, and the badge colours say so. Many countries have a legally defined
+classification ladder whose terms do not line up word-for-word with the English.
+Translate the *position in the ladder*, not the label: a literal rendering that
+lands a reader on the wrong rung is worse than a loose one that preserves the
+order.
+
+**Nonconformity grading is not in the standard.** Major/minor/observation come
+from certification-body practice under ISO/IEC 17021, not from ISO 27001 or
+9001, so no adopted text can arbitrate them. Follow the usage of certification
+bodies operating in your language and say in your subsection that you did.
+
+### Worked example — Indonesian (`id-ID`)
+
+Verified against the bilingual SNI ISO 9001:2015, whose clauses 4–10 are the
+Annex SL structure SNI ISO/IEC 27001:2022 shares verbatim:
 
 | English | Indonesian | Where it comes from |
 |---|---|---|
@@ -136,27 +199,22 @@ it decides — not general fluency, and not this file.
 
 Note what the standard does **not** contain: the word *perbaikan* appears
 nowhere in it. *Perbaikan* is correction/repair; improvement is *peningkatan*.
-"Peluang perbaikan" for an opportunity for improvement therefore inverts the one
-distinction the category exists to draw, and was corrected to *peluang
-peningkatan* on that basis.
+"Peluang perbaikan" therefore inverted the distinction the category exists to
+draw, and was corrected on that basis — trap 1, found only by checking.
 
-Also absent: any grading of nonconformities. *Mayor* / *minor* / *observasi* come
-from certification-body practice under ISO/IEC 17021, not from the standard, so
-they follow Indonesian industry usage and no adopted text can arbitrate them.
+Classification follows ANRI Perka 7/2016 (and the ministry regulations adopting
+it), which orders the national ladder *Biasa/Terbuka → Terbatas → Rahasia →
+Sangat Rahasia* by increasing sensitivity. `restricted` is our most sensitive
+level, so it is *Sangat Rahasia*; the literal *Terbatas* put it below *Rahasia*
+in a reader's mind while the badge beside it was red — trap 2.
 
-**Information classification follows the national ladder**, not a literal
-translation. ANRI Perka 7/2016 (and the ministry regulations adopting it) order
-it *Biasa/Terbuka → Terbatas → Rahasia → Sangat Rahasia*, by increasing
-sensitivity. Our `restricted` is the most sensitive level, so it is
-*Sangat Rahasia*; rendering it *Terbatas* put it below *Rahasia* in a reader's
-mind and inverted the hierarchy the colours already communicate.
+*Mayor* / *minor* / *observasi* follow Indonesian certification-body usage —
+trap 3, not sourced from the standard.
 
-**When adding a locale**, find the national adoption of ISO/IEC 27001 (or 9001 —
-the shared clauses are identical) and take these terms from it before writing
-anything else. Portuguese has the same trap in the same place: *correção* is not
-*melhoria*.
+### Two keys may share a translation
 
-**Two keys may share a translation.** `suggestion_type.reassess` and
-`suggestion_type.reading` are both *Nilai ulang* because they are the same
-operation — `api_suggestions.go` registers one handler for both. Keep them as
-separate keys; the duplication is the honest encoding.
+That is fine, and sometimes it is the honest encoding.
+`suggestion_type.reassess` and `suggestion_type.reading` are both *Nilai ulang*
+in `id-ID` because they are the same operation — `api_suggestions.go` registers
+one handler for both. Keep them as separate keys anyway: the English distinction
+may matter to a future locale, and a key removed is a key renamed.

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -109,3 +109,54 @@ Copy reused across two or more areas, plus the four cross-cutting groups
 (`enum`, `entity`, `field`, `error`). Everything else belongs to its area, even
 if the English happens to read the same in two places — the translations may
 diverge.
+
+## ISO terminology
+
+The audit vocabulary is the part of this app most easily mistranslated, because
+the wrong choice is always fluent. ISO separates *correction* from *improvement*
+and *conformity* from *compliance*, and a translator who has not audited before
+will reasonably collapse them. Where a national adoption of the standard exists,
+it decides — not general fluency, and not this file.
+
+**Indonesian.** Verified against the bilingual SNI ISO 9001:2015, whose clauses
+4–10 are the Annex SL structure that SNI ISO/IEC 27001:2022 shares verbatim:
+
+| English | Indonesian | Where it comes from |
+|---|---|---|
+| improvement | peningkatan | clause 10 heading |
+| continual improvement | peningkatan berkelanjutan | clause 10.3 heading |
+| opportunity for improvement | **peluang peningkatan** | clause 9.3.2 f, 10.1 a |
+| nonconformity | ketidaksesuaian | clause 10.2 heading |
+| corrective action | tindakan korektif | clause 10.2 heading |
+| conformity | kesesuaian | throughout |
+| objective | sasaran | clause 6.2 (*sasaran mutu*) |
+| monitoring | pemantauan | clause 9.1 heading |
+| review (management) | tinjauan | clause 9.3 heading |
+| internal audit | audit internal | clause 9.2 heading |
+
+Note what the standard does **not** contain: the word *perbaikan* appears
+nowhere in it. *Perbaikan* is correction/repair; improvement is *peningkatan*.
+"Peluang perbaikan" for an opportunity for improvement therefore inverts the one
+distinction the category exists to draw, and was corrected to *peluang
+peningkatan* on that basis.
+
+Also absent: any grading of nonconformities. *Mayor* / *minor* / *observasi* come
+from certification-body practice under ISO/IEC 17021, not from the standard, so
+they follow Indonesian industry usage and no adopted text can arbitrate them.
+
+**Information classification follows the national ladder**, not a literal
+translation. ANRI Perka 7/2016 (and the ministry regulations adopting it) order
+it *Biasa/Terbuka → Terbatas → Rahasia → Sangat Rahasia*, by increasing
+sensitivity. Our `restricted` is the most sensitive level, so it is
+*Sangat Rahasia*; rendering it *Terbatas* put it below *Rahasia* in a reader's
+mind and inverted the hierarchy the colours already communicate.
+
+**When adding a locale**, find the national adoption of ISO/IEC 27001 (or 9001 —
+the shared clauses are identical) and take these terms from it before writing
+anything else. Portuguese has the same trap in the same place: *correção* is not
+*melhoria*.
+
+**Two keys may share a translation.** `suggestion_type.reassess` and
+`suggestion_type.reading` are both *Nilai ulang* because they are the same
+operation — `api_suggestions.go` registers one handler for both. Keep them as
+separate keys; the duplication is the honest encoding.

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -74,6 +74,32 @@ Indonesian has no grammatical plural and Portuguese shares English's two-form
 rule, so neither exercises this — which is exactly why it has to be built in
 now, rather than retrofitted when a locale with real plural rules arrives.
 
+## Enum groups
+
+`common.enum.<group>.<db_value>`, and the group name is not free-form:
+
+- **A group a backend notification interpolates is named after the param.** The
+  notification renderer resolves translatable params as
+  `common.enum.<param>.<value>` — so `severity`, `status`, `action` and
+  `suggestion_type` are group names because those are the param names emitted by
+  `internal/isms/api`. The `entity` param is the one exception: it resolves
+  through `common.entity.*`, because an entity name is a noun the whole app
+  reuses rather than a member of an enum.
+- **`status` is one flat group across every register**, not one group per table.
+  Status values are distinct app-wide (`draft`, `investigating`, `awaiting_approval`),
+  and `StatusBadge` receives a bare value with no family attached — the same
+  reason its colour table has always been flat. Its `group` prop names the family
+  for the few callers rendering something else (`classification`, `criticality`,
+  `audit_result`).
+- **Everything else is named after its column**: `suggestion_type` for
+  `suggestions.suggestion_type`, `audit_result` for `audit_items.result`.
+
+If a language ever needs two different translations for one status value —
+Portuguese gender agreement on *aberto* / *aberta*, for instance — splitting the
+flat group is purely additive: add `risk_status.*`, pass `group="risk_status"` at
+those call sites, and leave `status.*` for everyone else. No key is renamed, so
+no in-flight translation is invalidated.
+
 **Key renames are breaking.** They invalidate in-flight translation work across
 every locale. Adding a key is cheap; renaming one is not.
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -12,7 +12,8 @@
   "state": {
     "loading": "Loading…",
     "empty": "Nothing here yet",
-    "error": "Something went wrong"
+    "error": "Something went wrong",
+    "unknown": "Unknown"
   },
   "validation": {
     "required": "This field is required"
@@ -21,9 +22,106 @@
     "label": "Language",
     "org_default": "Organization default"
   },
-  "entity": {},
+  "entity": {
+    "risk": "Risk",
+    "supplier": "Supplier",
+    "incident": "Incident",
+    "legal_requirement": "Legal requirement",
+    "change_request": "Change request",
+    "corrective_action": "Corrective action",
+    "objective": "Objective",
+    "task": "Task",
+    "system": "System",
+    "asset": "Asset",
+    "audit": "Audit",
+    "audit_finding": "Audit finding",
+    "program": "Program",
+    "checkin": "Check-in",
+    "access_review": "Access review"
+  },
   "field": {},
-  "enum": {},
+  "enum": {
+    "status": {
+      "draft": "Draft",
+      "open": "Open",
+      "in_review": "In review",
+      "approved": "Approved",
+      "changes_requested": "Changes requested",
+      "proposed_revision": "Proposed revision",
+      "merged": "Merged",
+      "retired": "Retired",
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "applied": "Applied",
+      "rejected": "Rejected",
+      "withdrawn": "Withdrawn",
+      "resolved": "Resolved",
+      "closed": "Closed",
+      "investigating": "Investigating",
+      "contained": "Contained",
+      "todo": "To do",
+      "in_progress": "In progress",
+      "done": "Done",
+      "cancelled": "Cancelled",
+      "proposed": "Proposed",
+      "not_started": "Not started",
+      "implemented": "Implemented",
+      "verified": "Verified",
+      "planned": "Planned",
+      "completed": "Completed",
+      "active": "Active",
+      "at_risk": "At risk",
+      "paused": "Paused",
+      "complete": "Complete",
+      "assessment": "Assessment",
+      "awaiting_approval": "Awaiting approval",
+      "implementation": "Implementation",
+      "monitoring": "Monitoring",
+      "under_review": "Under review",
+      "suspended": "Suspended",
+      "terminated": "Terminated",
+      "decommissioned": "Decommissioned",
+      "archived": "Archived"
+    },
+    "severity": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    },
+    "criticality": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    },
+    "classification": {
+      "public": "Public",
+      "internal": "Internal",
+      "confidential": "Confidential",
+      "restricted": "Restricted"
+    },
+    "audit_result": {
+      "not_assessed": "Not assessed",
+      "conforming": "Conforming",
+      "minor_nc": "Minor non-conformity",
+      "major_nc": "Major non-conformity",
+      "observation": "Observation",
+      "opportunity": "Opportunity for improvement"
+    },
+    "action": {
+      "applied": "applied",
+      "rejected": "rejected"
+    },
+    "suggestion_type": {
+      "create": "Create",
+      "update": "Update",
+      "reassess": "Reassess",
+      "link": "Link",
+      "review": "Review",
+      "reading": "Reading"
+    }
+  },
   "error": {},
   "region": {
     "global": "Global",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -109,6 +109,12 @@
       "observation": "Observation",
       "opportunity": "Opportunity for improvement"
     },
+    "finding_type": {
+      "major_nc": "Major non-conformity",
+      "minor_nc": "Minor non-conformity",
+      "observation": "Observation",
+      "opportunity": "Opportunity for improvement"
+    },
     "action": {
       "applied": "applied",
       "rejected": "rejected"

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -12,7 +12,8 @@
   "state": {
     "loading": "Memuat…",
     "empty": "Belum ada apa pun di sini",
-    "error": "Terjadi kesalahan"
+    "error": "Terjadi kesalahan",
+    "unknown": "Tidak diketahui"
   },
   "validation": {
     "required": "Kolom ini wajib diisi"
@@ -21,9 +22,106 @@
     "label": "Bahasa",
     "org_default": "Bawaan organisasi"
   },
-  "entity": {},
+  "entity": {
+    "risk": "Risiko",
+    "supplier": "Pemasok",
+    "incident": "Insiden",
+    "legal_requirement": "Persyaratan hukum",
+    "change_request": "Permintaan perubahan",
+    "corrective_action": "Tindakan korektif",
+    "objective": "Sasaran",
+    "task": "Tugas",
+    "system": "Sistem",
+    "asset": "Aset",
+    "audit": "Audit",
+    "audit_finding": "Temuan audit",
+    "program": "Program",
+    "checkin": "Check-in",
+    "access_review": "Tinjauan akses"
+  },
   "field": {},
-  "enum": {},
+  "enum": {
+    "status": {
+      "draft": "Draf",
+      "open": "Terbuka",
+      "in_review": "Dalam tinjauan",
+      "approved": "Disetujui",
+      "changes_requested": "Perlu perubahan",
+      "proposed_revision": "Usulan revisi",
+      "merged": "Digabungkan",
+      "retired": "Tidak berlaku",
+      "pending": "Menunggu",
+      "accepted": "Diterima",
+      "applied": "Diterapkan",
+      "rejected": "Ditolak",
+      "withdrawn": "Ditarik",
+      "resolved": "Selesai ditangani",
+      "closed": "Ditutup",
+      "investigating": "Sedang diselidiki",
+      "contained": "Terkendali",
+      "todo": "Akan dikerjakan",
+      "in_progress": "Sedang berjalan",
+      "done": "Selesai",
+      "cancelled": "Dibatalkan",
+      "proposed": "Diusulkan",
+      "not_started": "Belum dimulai",
+      "implemented": "Sudah diimplementasikan",
+      "verified": "Terverifikasi",
+      "planned": "Direncanakan",
+      "completed": "Selesai",
+      "active": "Aktif",
+      "at_risk": "Berisiko",
+      "paused": "Dijeda",
+      "complete": "Tuntas",
+      "assessment": "Penilaian",
+      "awaiting_approval": "Menunggu persetujuan",
+      "implementation": "Implementasi",
+      "monitoring": "Pemantauan",
+      "under_review": "Sedang ditinjau",
+      "suspended": "Ditangguhkan",
+      "terminated": "Dihentikan",
+      "decommissioned": "Dinonaktifkan",
+      "archived": "Diarsipkan"
+    },
+    "severity": {
+      "critical": "Kritis",
+      "high": "Tinggi",
+      "medium": "Sedang",
+      "low": "Rendah"
+    },
+    "criticality": {
+      "critical": "Kritis",
+      "high": "Tinggi",
+      "medium": "Sedang",
+      "low": "Rendah"
+    },
+    "classification": {
+      "public": "Publik",
+      "internal": "Internal",
+      "confidential": "Rahasia",
+      "restricted": "Terbatas"
+    },
+    "audit_result": {
+      "not_assessed": "Belum dinilai",
+      "conforming": "Sesuai",
+      "minor_nc": "Ketidaksesuaian minor",
+      "major_nc": "Ketidaksesuaian mayor",
+      "observation": "Observasi",
+      "opportunity": "Peluang perbaikan"
+    },
+    "action": {
+      "applied": "diterapkan",
+      "rejected": "ditolak"
+    },
+    "suggestion_type": {
+      "create": "Buat",
+      "update": "Perbarui",
+      "reassess": "Nilai ulang",
+      "link": "Tautkan",
+      "review": "Tinjau",
+      "reading": "Bacaan"
+    }
+  },
   "error": {},
   "region": {
     "global": "Global",

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -99,7 +99,7 @@
       "public": "Publik",
       "internal": "Internal",
       "confidential": "Rahasia",
-      "restricted": "Terbatas"
+      "restricted": "Sangat Rahasia"
     },
     "audit_result": {
       "not_assessed": "Belum dinilai",
@@ -107,7 +107,7 @@
       "minor_nc": "Ketidaksesuaian minor",
       "major_nc": "Ketidaksesuaian mayor",
       "observation": "Observasi",
-      "opportunity": "Peluang perbaikan"
+      "opportunity": "Peluang peningkatan"
     },
     "action": {
       "applied": "diterapkan",
@@ -119,7 +119,7 @@
       "reassess": "Nilai ulang",
       "link": "Tautkan",
       "review": "Tinjau",
-      "reading": "Bacaan"
+      "reading": "Nilai ulang"
     }
   },
   "error": {},

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -109,6 +109,12 @@
       "observation": "Observasi",
       "opportunity": "Peluang peningkatan"
     },
+    "finding_type": {
+      "major_nc": "Ketidaksesuaian mayor",
+      "minor_nc": "Ketidaksesuaian minor",
+      "observation": "Observasi",
+      "opportunity": "Peluang peningkatan"
+    },
     "action": {
       "applied": "diterapkan",
       "rejected": "ditolak"

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -820,7 +820,7 @@
                           <option value="observation">Observation</option>
                           <option value="opportunity">Opportunity</option>
                         </select>
-                        <span v-else class="text-xs"><StatusBadge :status="item.result || 'not_assessed'" /></span>
+                        <span v-else class="text-xs"><StatusBadge :status="item.result || 'not_assessed'" group="audit_result" /></span>
                         <button v-if="canWrite && (item.result === 'minor_nc' || item.result === 'major_nc')"
                           @click="raiseFindingFromItem(item)"
                           class="text-[10px] text-amber-400 hover:text-amber-300 px-2 py-1 rounded border border-amber-800/50 bg-amber-900/20"

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -181,7 +181,7 @@
             <tbody class="divide-y divide-slate-800">
               <tr v-for="sys in systemsList" :key="sys.id" class="hover:bg-slate-800/30 cursor-pointer" @click="router.push(orgPath('/systems'))">
                 <td class="px-4 py-2.5 text-sm text-slate-300">{{ sys.name }}</td>
-                <td class="px-4 py-2.5"><StatusBadge :status="sys.criticality" /></td>
+                <td class="px-4 py-2.5"><StatusBadge :status="sys.criticality" group="criticality" /></td>
                 <td class="px-4 py-2.5 text-sm text-slate-400">{{ sys.rpo_hours }}h</td>
                 <td class="px-4 py-2.5 text-sm text-slate-400">{{ sys.rto_hours }}h</td>
               </tr>
@@ -237,7 +237,7 @@
               <div class="text-sm font-medium text-slate-200">High &amp; critical risks</div>
               <div class="text-xs text-slate-500 mt-0.5">{{ highRiskCount }} risk{{ highRiskCount !== 1 ? 's' : '' }} requiring treatment or escalation</div>
             </div>
-            <StatusBadge status="critical" />
+            <StatusBadge status="critical" group="severity" />
             <span class="text-xs font-semibold bg-red-900/60 text-red-300 px-2.5 py-0.5 rounded-full tabular-nums">
               {{ highRiskCount }}
             </span>

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -156,7 +156,7 @@
               <td class="px-5 py-3.5">
                 <div class="text-sm font-medium text-slate-200">{{ sys.name }}</div>
               </td>
-              <td class="px-5 py-3.5"><StatusBadge :status="sys.classification" /></td>
+              <td class="px-5 py-3.5"><StatusBadge :status="sys.classification" group="classification" /></td>
               <td class="px-5 py-3.5">
                 <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(sys.criticality)">{{ sys.criticality }}</span>
               </td>
@@ -296,7 +296,7 @@
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Classification</div>
-                          <StatusBadge :status="selectedItem.classification" />
+                          <StatusBadge :status="selectedItem.classification" group="classification" />
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Criticality</div>

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -32,6 +32,10 @@ const GROUPS = {
   criticality: ['critical', 'high', 'medium', 'low'],
   classification: ['public', 'internal', 'confidential', 'restricted'],
   audit_result: ['not_assessed', 'conforming', 'minor_nc', 'major_nc', 'observation', 'opportunity'],
+  // corrective_actions.severity and audit_findings.finding_type share this value
+  // set. It is NOT `severity`: that group is the incident/priority scale, and
+  // two tables happen to have named their column `severity`.
+  finding_type: ['major_nc', 'minor_nc', 'observation', 'opportunity'],
   action: ['applied', 'rejected'],
   suggestion_type: ['create', 'update', 'reassess', 'link', 'review', 'reading'],
 }
@@ -83,6 +87,10 @@ test('labels are looked up per group, so one value can differ by family', async 
   // have told these apart.
   assert.equal(enumLabel('suggestion_type', 'review'), 'Review')
   assert.equal(enumLabel('status', 'in_review'), 'In review')
+  // A column name is not enough to pick a group: `severity` is the incident
+  // scale, while corrective_actions.severity holds the finding taxonomy.
+  assert.equal(enumLabel('severity', 'critical'), 'Critical')
+  assert.equal(enumLabel('finding_type', 'major_nc'), 'Major non-conformity')
 })
 
 test('a lagging locale falls back to the English label, not to de-slugging', () => {

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -1,0 +1,100 @@
+// The `common.enum.*` catalogue is the shared vocabulary: StatusBadge, the
+// `<option>` lists extracted per view, and the notification renderer all read
+// the same keys. These tests pin the parts of that contract a typo would
+// otherwise break silently — a missing key degrades to a de-slugged label,
+// which reads plausibly in English and is invisible in review.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { enumLabel } from '../src/composables/useEnumLabel.js'
+import { i18n } from '../src/i18n.js'
+import en from '../src/locales/en/index.js'
+import id from '../src/locales/id-ID/index.js'
+
+// Every status value any register can store, per the CHECK constraints in
+// migrations/ and the enum slices in internal/isms/db. One flat group, because
+// the values are distinct across registers and StatusBadge receives a bare
+// value with no family attached.
+const STATUS = [
+  'draft', 'open', 'in_review', 'approved', 'changes_requested', 'proposed_revision',
+  'merged', 'retired', 'pending', 'accepted', 'applied', 'rejected', 'withdrawn',
+  'resolved', 'closed', 'investigating', 'contained', 'todo', 'in_progress', 'done',
+  'cancelled', 'proposed', 'not_started', 'implemented', 'verified', 'planned',
+  'completed', 'active', 'at_risk', 'paused', 'complete', 'assessment',
+  'awaiting_approval', 'implementation', 'monitoring', 'under_review', 'suspended',
+  'terminated', 'decommissioned', 'archived',
+]
+
+// The translatable notification params (plan 82's closed set) and the groups the
+// four non-status StatusBadge call sites name explicitly.
+const GROUPS = {
+  status: STATUS,
+  severity: ['critical', 'high', 'medium', 'low'],
+  criticality: ['critical', 'high', 'medium', 'low'],
+  classification: ['public', 'internal', 'confidential', 'restricted'],
+  audit_result: ['not_assessed', 'conforming', 'minor_nc', 'major_nc', 'observation', 'opportunity'],
+  action: ['applied', 'rejected'],
+  suggestion_type: ['create', 'update', 'reassess', 'link', 'review', 'reading'],
+}
+
+// The suggestion `entity` param, resolved through common.entity.* rather than
+// common.enum.* — an entity name is a noun the whole app reuses, not an enum
+// member. Matches the entity_type CHECK on `suggestions`.
+const ENTITIES = [
+  'risk', 'supplier', 'incident', 'legal_requirement', 'change_request',
+  'corrective_action', 'objective', 'task', 'system', 'asset', 'audit',
+  'audit_finding', 'program', 'checkin', 'access_review',
+]
+
+test('every enum member a register can store has a label', () => {
+  for (const [group, values] of Object.entries(GROUPS)) {
+    for (const value of values) {
+      assert.ok(
+        en.common.enum[group]?.[value],
+        `common.enum.${group}.${value} is missing from locales/en`,
+      )
+    }
+  }
+})
+
+test('every suggestion entity type has an entity name', () => {
+  for (const e of ENTITIES) {
+    assert.ok(en.common.entity[e], `common.entity.${e} is missing from locales/en`)
+  }
+})
+
+test('id-ID mirrors the catalogue, so no user sees a de-slugged English value', () => {
+  for (const [group, values] of Object.entries(GROUPS)) {
+    for (const value of values) {
+      assert.ok(
+        id.common.enum[group]?.[value],
+        `common.enum.${group}.${value} is missing from locales/id-ID`,
+      )
+    }
+  }
+  for (const e of ENTITIES) {
+    assert.ok(id.common.entity[e], `common.entity.${e} is missing from locales/id-ID`)
+  }
+})
+
+test('labels are looked up per group, so one value can differ by family', async () => {
+  assert.equal(enumLabel('status', 'open'), 'Open')
+  assert.equal(enumLabel('audit_result', 'major_nc'), 'Major non-conformity')
+  // Same member, two families: the de-slugging this seam replaces could not
+  // have told these apart.
+  assert.equal(enumLabel('suggestion_type', 'review'), 'Review')
+  assert.equal(enumLabel('status', 'in_review'), 'In review')
+})
+
+test('a lagging locale falls back to the English label, not to de-slugging', () => {
+  // te() consults a single locale, so enumLabel probes the fallback catalogue.
+  // Registering a locale with an empty catalogue stands in for one that has not
+  // caught up with a newly added enum member.
+  i18n.global.setLocaleMessage('xx-XX', { common: { enum: {}, entity: {} } })
+  const previous = i18n.global.locale.value
+  i18n.global.locale.value = 'xx-XX'
+  try {
+    assert.equal(enumLabel('audit_result', 'major_nc'), 'Major non-conformity')
+  } finally {
+    i18n.global.locale.value = previous
+  }
+})

--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -12,7 +12,9 @@ test('enum labels come from the catalogue, and de-slug only as a fallback', () =
   })
   assert.equal(enumLabel('status', 'in_review'), 'In review')
   // A member the catalogue has not caught up with must not render a raw key.
-  assert.equal(enumLabel('status', 'changes_requested'), 'Changes requested')
+  // Use a value no register defines: every real status is catalogued now, so a
+  // real one would exercise the lookup rather than the fallback.
+  assert.equal(enumLabel('status', 'awaiting_signoff'), 'Awaiting signoff')
   assert.equal(enumLabel('status', null), '')
   assert.equal(enumLabel('status', ''), '')
 })


### PR DESCRIPTION
Part of #212 (i18n foundation + pt-BR localization).

## What this delivers

Status labels — the coloured chips shown next to every risk, incident, task,
system, supplier and corrective action — are now translatable, and are
translated into Indonesian.

Until now those labels were produced by reformatting the raw database value:
`awaiting_approval` became "awaiting approval" and was title-cased by the
stylesheet. That trick only works in English. There is no rearrangement of
`changes_requested` that produces Indonesian, and capitalisation rules differ by
language, so these labels could never have been translated while they were
derived that way. They now come from the translation files like every other
piece of text.

## Why it matters for the wider effort

This is the shared vocabulary layer. The same list of labels feeds three
different things:

1. the status chips in every register,
2. the ~437 dropdown options across the register screens, and
3. the notification inbox, whose titles were made translatable last week (#220)
   and which needs these labels to render.

Declaring them once, now, is what stops three separate pieces of work from
inventing three different names for the same thing. Renaming them afterwards
would invalidate any translation already in progress — the most expensive
avoidable mistake available to us on this issue, so it is worth the up-front
step.

## Scope

- 40 status values plus severity, criticality, classification, audit result and
  the entity names — every value the database can actually store, taken from the
  schema rather than from the screens, so nothing is missed and nothing dead is
  carried forward.
- English and Indonesian, complete in both.
- One behavioural fix: if a translation ever falls behind — a new status is added
  and a language has not caught up — the label now falls back to proper English
  instead of the raw-ish database value. Previously an Indonesian user would have
  seen "Major nc" where the correct fallback is "Major non-conformity".

Everything else on those screens (column headings, buttons, filter labels) is
still English. That is the next phase and is deliberately separate: one pull
request per screen, so each stays reviewable.

## Risk

Low, and contained to display text.

- No database, API or permissions changes. Nothing is stored differently.
- One shared component and five call sites changed; the rest of the app is
  untouched.
- Automated: 81 frontend tests pass, 5 of them new, and a check confirms the two
  languages have identical key sets so neither can drift.
- Manual: verified in a running app against seeded data in both languages — the
  chips render correctly, switching language applies immediately, and the
  fallback behaviour above was confirmed by deliberately removing a translation.

## Terminology was verified, not assumed

The Indonesian audit vocabulary was checked against an official adopted standard
rather than left for review. SNI ISO/IEC 27001:2022 is sold by BSN and was not
readable, but its clauses 4–10 are the shared management-system structure printed
verbatim in SNI ISO 9001:2015, which is published bilingually — so every term at
issue could be checked against an authoritative text.

Two of the terms were wrong, and neither would have been caught by proofreading:

- **"Peluang perbaikan" → "Peluang peningkatan"** (opportunity for improvement).
  The standard prints exactly this phrase against the English, and the word
  *perbaikan* appears nowhere in it: *perbaikan* is correction, *peningkatan* is
  improvement. The old wording blurred the distinction between an improvement
  opportunity and a nonconformity — the whole reason the category exists.
- **"Terbatas" → "Sangat Rahasia"** (restricted). Indonesia's national
  classification ladder runs Biasa → Terbatas → Rahasia → Sangat Rahasia by
  increasing sensitivity, so labelling our *most* sensitive level "Terbatas"
  placed it below "Rahasia" for an Indonesian reader while the badge beside it
  was red. A genuine hazard rather than a preference: it contradicted the
  hierarchy the interface communicates.

A third fix was internal jargon rather than translation: **"Bacaan" → "Nilai
ulang"** (reading). The underlying record is an assessment log, not something to
read, and the code runs "reading" and "reassess" through one handler, so the two
labels now agree.

**Still worth a maintainer eye, and cannot be settled from any standard:**
*ketidaksesuaian mayor / minor*. Standards do not grade nonconformities —
major/minor is certification-body practice — so this follows Indonesian industry
usage and is a judgement call.

## And a process change, so the next language is cheaper

The Indonesian bundle shipped in #218 with its terminology unreviewed, and this
catalogue nearly did the same. Fluent-but-wrong terminology is invisible to a
reviewer who does not speak the language, so the fix has to sit in the
contribution path rather than in a reviewer's attention:

- `web/src/locales/README.md` now carries the **procedure** (find your language's
  national adoption of the standard, take the terms from it), a **checklist** of
  the ten terms keyed to the clause of the standard that defines each — clause
  numbers are identical in every country's adoption, so a contributor copies the
  table and fills one column — and the **three traps** that recur across
  languages. Indonesian is the worked example under it.
- It is now a required step when adding a language (step 2 in `docs/i18n.md`,
  ahead of translating any value) and is called out in `CONTRIBUTING.md`.

This matters for #212 specifically: Portuguese has the identical trap in the
identical clause (*correção* is not *melhoria*), so the pt-BR translation
contributed on this issue would have hit it.

## What comes next on #212

1. Render the notification inbox from the keys stored in #220 — now unblocked by
   this change.
2. Route dates and numbers through the shared formatter (they currently use
   hardcoded English formats in ~40 places; one visible symptom is a raw
   timestamp on the Corrective Actions list).
3. Begin extracting the remaining screen text, one screen per pull request, then
   freeze the key set so the Portuguese translation can be written against
   something stable.
