### PR TITLE
fix(web): split list blocks keep their original numbering

### DIFF
--- a/web/src/utils/contentBlocks.js
+++ b/web/src/utils/contentBlocks.js
@@ -1,0 +1,82 @@
+// Splits rendered document HTML into paragraph-level "blocks" for the
+// document viewer: one block per heading/paragraph/pre/hr, one per list item,
+// one per table row, one per blockquote paragraph. Each block is what gets an
+// inline-comment "+" button and a stable #ph<hash> anchor.
+//
+// Extracted from Documents.vue's `contentBlocks` computed so this can be unit
+// tested directly — the logic runs against a DOM (document.createElement),
+// which node --test only has via jsdom in the test file, not via importing
+// the .vue component itself.
+import { parseMd } from '../composables/useRenderMd.js'
+
+export function buildContentBlocks(rawContent) {
+  if (!rawContent) return []
+  const html = parseMd(rawContent)
+  const div = document.createElement('div')
+  div.innerHTML = html
+  const blocks = []
+
+  function addBlock(html, tag, text) {
+    blocks.push({ index: blocks.length, html, tag, text })
+  }
+
+  for (const child of div.children) {
+    const tag = child.tagName.toLowerCase()
+
+    // Split lists — each bullet is commentable. Each <li> ends up alone in
+    // its own fresh <ol>, which resets an ordered list's visible number to 1
+    // for every item — so the wrapper carries a `start` tracking this item's
+    // real position in the original list, rather than a bare "<ol>" every
+    // time.
+    if ((tag === 'ul' || tag === 'ol') && child.children.length > 0) {
+      const start = tag === 'ol' ? (parseInt(child.getAttribute('start'), 10) || 1) : 1
+      let position = 0
+      for (const li of child.children) {
+        if (li.tagName.toLowerCase() === 'li') {
+          const openTag = tag === 'ol' ? `<ol start="${start + position}">` : '<ul>'
+          addBlock(openTag + li.outerHTML + '</' + tag + '>', 'li', li.textContent || '')
+          position++
+        }
+      }
+    }
+    // Tables — convert to grid-based rows so each gets a "+" button
+    else if (tag === 'table') {
+      const thead = child.querySelector('thead')
+      const tbody = child.querySelector('tbody')
+      const ths = thead ? Array.from(thead.querySelectorAll('th')) : []
+      const rows = tbody ? Array.from(tbody.querySelectorAll('tr')) : []
+      const colCount = ths.length || (rows[0] ? rows[0].children.length : 1)
+      const gridCols = 'grid-template-columns: ' + Array(colCount).fill('1fr').join(' ') + ';'
+
+      // Header as one block
+      if (ths.length > 0) {
+        const headerCells = ths.map(th => {
+          const styleAttr = th.getAttribute('style') || ''
+          return `<div class="tbl-hdr-cell" style="${styleAttr}">${th.innerHTML}</div>`
+        }).join('')
+        addBlock(`<div class="tbl-grid" style="${gridCols}">${headerCells}</div>`, 'thead', thead.textContent || '')
+      }
+
+      // Each body row as separate block — gets its own "+" button!
+      for (const tr of rows) {
+        const tds = Array.from(tr.querySelectorAll('td'))
+        const cells = tds.map(td => {
+          const styleAttr = td.getAttribute('style') || ''
+          return `<div class="tbl-cell" style="${styleAttr}">${td.innerHTML}</div>`
+        }).join('')
+        addBlock(`<div class="tbl-grid tbl-row" style="${gridCols}">${cells}</div>`, 'tr', tr.textContent || '')
+      }
+    }
+    // Split blockquotes — each paragraph inside is commentable
+    else if (tag === 'blockquote' && child.children.length > 1) {
+      for (const bqChild of child.children) {
+        addBlock('<blockquote>' + bqChild.outerHTML + '</blockquote>', 'blockquote-p', bqChild.textContent || '')
+      }
+    }
+    // Everything else — headings, paragraphs, pre, hr — one block each
+    else {
+      addBlock(child.outerHTML, tag, child.textContent || '')
+    }
+  }
+  return blocks
+}

--- a/web/src/utils/contentBlocks.js
+++ b/web/src/utils/contentBlocks.js
@@ -16,8 +16,15 @@ export function buildContentBlocks(rawContent) {
   div.innerHTML = html
   const blocks = []
 
-  function addBlock(html, tag, text) {
-    blocks.push({ index: blocks.length, html, tag, text })
+  function addBlock(html, tag, text, raw) {
+    const block = { index: blocks.length, html, tag, text }
+    // useDocumentComments.blockHash hashes `raw ?? html` to anchor inline
+    // comments; commentsForBlock hard-rejects on a hash mismatch, with no
+    // index fallback once a comment carries a hash. `raw` lets a block's
+    // rendered markup change (e.g. gaining `start=`) without re-hashing and
+    // silently detaching every comment already stored against it.
+    if (raw !== undefined) block.raw = raw
+    blocks.push(block)
   }
 
   for (const child of div.children) {
@@ -27,14 +34,17 @@ export function buildContentBlocks(rawContent) {
     // its own fresh <ol>, which resets an ordered list's visible number to 1
     // for every item — so the wrapper carries a `start` tracking this item's
     // real position in the original list, rather than a bare "<ol>" every
-    // time.
+    // time. `raw` keeps the hashed markup at the pre-`start` shape (see
+    // addBlock) so this doesn't detach comments already anchored to it.
     if ((tag === 'ul' || tag === 'ol') && child.children.length > 0) {
-      const start = tag === 'ol' ? (parseInt(child.getAttribute('start'), 10) || 1) : 1
+      const parsedStart = parseInt(child.getAttribute('start'), 10)
+      const start = tag === 'ol' && Number.isFinite(parsedStart) ? parsedStart : 1
       let position = 0
       for (const li of child.children) {
         if (li.tagName.toLowerCase() === 'li') {
           const openTag = tag === 'ol' ? `<ol start="${start + position}">` : '<ul>'
-          addBlock(openTag + li.outerHTML + '</' + tag + '>', 'li', li.textContent || '')
+          const rawWrapper = '<' + tag + '>' + li.outerHTML + '</' + tag + '>'
+          addBlock(openTag + li.outerHTML + '</' + tag + '>', 'li', li.textContent || '', rawWrapper)
           position++
         }
       }

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -1355,7 +1355,7 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, nextTick, onBeforeUnmount, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { parseMd } from '../composables/useRenderMd'
+import { buildContentBlocks } from '../utils/contentBlocks.js'
 import DOMPurify from 'dompurify'
 const sanitize = (html) => DOMPurify.sanitize(html, { ADD_ATTR: ['style', 'data-ref-type', 'data-ref-id'] })
 
@@ -2216,69 +2216,7 @@ async function removeTemplate(id) {
 }
 
 // --- Paragraph-level content blocks ---
-const contentBlocks = computed(() => {
-  if (!rawContent.value) return []
-  const html = parseMd(rawContent.value)
-  const div = document.createElement('div')
-  div.innerHTML = html
-  const blocks = []
-
-  function addBlock(html, tag, text) {
-    blocks.push({ index: blocks.length, html, tag, text })
-  }
-
-  for (const child of div.children) {
-    const tag = child.tagName.toLowerCase()
-
-    // Split lists — each bullet is commentable
-    if ((tag === 'ul' || tag === 'ol') && child.children.length > 0) {
-      for (const li of child.children) {
-        if (li.tagName.toLowerCase() === 'li') {
-          addBlock('<' + tag + '>' + li.outerHTML + '</' + tag + '>', 'li', li.textContent || '')
-        }
-      }
-    }
-    // Tables — convert to grid-based rows so each gets a "+" button
-    else if (tag === 'table') {
-      const thead = child.querySelector('thead')
-      const tbody = child.querySelector('tbody')
-      const ths = thead ? Array.from(thead.querySelectorAll('th')) : []
-      const rows = tbody ? Array.from(tbody.querySelectorAll('tr')) : []
-      const colCount = ths.length || (rows[0] ? rows[0].children.length : 1)
-      const gridCols = 'grid-template-columns: ' + Array(colCount).fill('1fr').join(' ') + ';'
-
-      // Header as one block
-      if (ths.length > 0) {
-        const headerCells = ths.map(th => {
-          const styleAttr = th.getAttribute('style') || ''
-          return `<div class="tbl-hdr-cell" style="${styleAttr}">${th.innerHTML}</div>`
-        }).join('')
-        addBlock(`<div class="tbl-grid" style="${gridCols}">${headerCells}</div>`, 'thead', thead.textContent || '')
-      }
-
-      // Each body row as separate block — gets its own "+" button!
-      for (const tr of rows) {
-        const tds = Array.from(tr.querySelectorAll('td'))
-        const cells = tds.map(td => {
-          const styleAttr = td.getAttribute('style') || ''
-          return `<div class="tbl-cell" style="${styleAttr}">${td.innerHTML}</div>`
-        }).join('')
-        addBlock(`<div class="tbl-grid tbl-row" style="${gridCols}">${cells}</div>`, 'tr', tr.textContent || '')
-      }
-    }
-    // Split blockquotes — each paragraph inside is commentable
-    else if (tag === 'blockquote' && child.children.length > 1) {
-      for (const bqChild of child.children) {
-        addBlock('<blockquote>' + bqChild.outerHTML + '</blockquote>', 'blockquote-p', bqChild.textContent || '')
-      }
-    }
-    // Everything else — headings, paragraphs, pre, hr — one block each
-    else {
-      addBlock(child.outerHTML, tag, child.textContent || '')
-    }
-  }
-  return blocks
-})
+const contentBlocks = computed(() => buildContentBlocks(rawContent.value))
 
 async function selectItem(folder, id, listItem) {
   activeId.value = id

--- a/web/test/contentBlocks.test.js
+++ b/web/test/contentBlocks.test.js
@@ -79,3 +79,46 @@ test('empty content produces no blocks', () => {
   assert.deepEqual(buildContentBlocks(''), [])
   assert.deepEqual(buildContentBlocks(null), [])
 })
+
+// The block's markup is not only rendered — useDocumentComments.blockHash
+// hashes it to anchor inline comments, and commentsForBlock hard-rejects on a
+// hash mismatch. So adding `start` to the wrapper must not change what gets
+// hashed, or every inline comment already stored against an ordered-list item
+// silently detaches. `raw` is what keeps the hashed string stable.
+test('ordered-list blocks hash the same as before start was threaded', () => {
+  // verbatim from web/src/composables/useDocumentComments.js:35-44
+  const blockHash = (block) => {
+    const text = block.raw || block.html || ''
+    let h = 5381
+    for (let i = 0; i < text.length; i++) h = ((h << 5) + h + text.charCodeAt(i)) & 0xffffffff
+    return h.toString(36)
+  }
+  const md = Array.from({ length: 14 }, (_, i) => `${i + 1}. Item ${i + 1}`).join('\n')
+  for (const b of buildContentBlocks(md)) {
+    // the pre-`start` wrapper shape, which is what the hash must still see
+    assert.match(b.raw, /^<ol><li>/)
+    assert.doesNotMatch(b.raw, /start=/)
+    assert.match(b.html, /^<ol start="\d+">/)
+    assert.equal(blockHash(b), blockHash({ html: b.raw }))
+  }
+})
+
+test('unordered-list blocks also carry a stable raw, unchanged from html', () => {
+  // ul's rendered html never gains `start`, so raw is redundant there — but
+  // still set (addBlock applies it uniformly), and it must equal html.
+  const md = '- First\n- Second\n'
+  for (const b of buildContentBlocks(md)) {
+    assert.equal(b.raw, b.html)
+  }
+})
+
+test('a list starting at 0 keeps 0 as its base, not 1', () => {
+  // parseInt('0', 10) is 0, which is falsy — a naive `|| 1` fallback would
+  // treat a deliberate "0." start the same as no start attribute at all.
+  const md = '0. Zeroth\n1. First\n2. Second\n'
+  const blocks = buildContentBlocks(md)
+  assert.deepEqual(
+    blocks.map((b) => b.html.match(/start="(\d+)"/)[1]),
+    ['0', '1', '2'],
+  )
+})

--- a/web/test/contentBlocks.test.js
+++ b/web/test/contentBlocks.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>')
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+globalThis.Node = dom.window.Node
+globalThis.Element = dom.window.Element
+globalThis.HTMLElement = dom.window.HTMLElement
+
+const { buildContentBlocks } = await import('../src/utils/contentBlocks.js')
+
+// Regression: splitting a list into one commentable block per <li> left each
+// item alone in a fresh <ol>, which resets an ordered list's visible number
+// to 1 for every item — a real production document rendered every item as
+// "1." instead of counting up. The fix threads a `start` attribute through
+// each split so the browser still shows the item's real position.
+test('split ordered-list blocks keep their original numbering', () => {
+  const md = Array.from({ length: 14 }, (_, i) => `${i + 1}. Item ${i + 1}`).join('\n')
+  const blocks = buildContentBlocks(md)
+  assert.equal(blocks.length, 14)
+  blocks.forEach((b, i) => {
+    assert.equal(b.tag, 'li')
+    assert.match(b.html, new RegExp(`^<ol start="${i + 1}">`))
+    assert.match(b.html, new RegExp(`Item ${i + 1}`))
+  })
+})
+
+test('a blank line between list items does not reset numbering', () => {
+  // The exact shape that surfaced this: marked keeps a blank-line-separated
+  // ordered list as ONE list (just "loose", each item wrapped in <p>), so the
+  // split still has to count every item's true position, not restart at the
+  // blank line.
+  const md = '1. First\n2. Second\n\n3. Third\n4. Fourth\n'
+  const blocks = buildContentBlocks(md)
+  assert.equal(blocks.length, 4)
+  assert.deepEqual(
+    blocks.map((b) => b.html.match(/start="(\d+)"/)[1]),
+    ['1', '2', '3', '4'],
+  )
+})
+
+test('an ordered list starting above 1 keeps its real start number', () => {
+  // marked emits a `start` attribute on the <ol> itself when the source's
+  // first item names a number other than 1. The split must carry that
+  // forward as the base, not always assume 1.
+  const md = '5. Fifth\n6. Sixth\n7. Seventh\n'
+  const blocks = buildContentBlocks(md)
+  assert.deepEqual(
+    blocks.map((b) => b.html.match(/start="(\d+)"/)[1]),
+    ['5', '6', '7'],
+  )
+})
+
+test('unordered list items are not given a start attribute', () => {
+  const md = '- First\n- Second\n- Third\n'
+  const blocks = buildContentBlocks(md)
+  assert.equal(blocks.length, 3)
+  for (const b of blocks) {
+    assert.match(b.html, /^<ul>/)
+    assert.doesNotMatch(b.html, /start=/)
+  }
+})
+
+test('non-list content is not split — one block per element', () => {
+  const md = '# Heading\n\nA paragraph.\n\nAnother paragraph.\n'
+  const blocks = buildContentBlocks(md)
+  assert.deepEqual(blocks.map((b) => b.tag), ['h1', 'p', 'p'])
+})
+
+test('table rows split into one block per row, header separate', () => {
+  const md = '| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n'
+  const blocks = buildContentBlocks(md)
+  assert.deepEqual(blocks.map((b) => b.tag), ['thead', 'tr', 'tr'])
+})
+
+test('empty content produces no blocks', () => {
+  assert.deepEqual(buildContentBlocks(''), [])
+  assert.deepEqual(buildContentBlocks(null), [])
+})


### PR DESCRIPTION
Fixes https://github.com/unidoc/isms/issues/230.

Documents.vue's read view splits every list item into its own commentable block. Each `<li>` ends up alone in a brand-new `<ol>` with no `start` attribute, so the browser renders every item as "1." regardless of its real position — confirmed against a real customer document (a 14-item list, every item showing "1." in the read view).

Traced it precisely rather than guessing: fed the exact markdown to `marked` directly (same instance `useRenderMd.js` uses) and it correctly parses a single `<ol>` with all 14 `<li>` in order — including across a blank line between two items, which CommonMark keeps as one "loose" list rather than splitting it. The bug is entirely in `contentBlocks`' per-item split that runs on the already-correct HTML, not in markdown parsing.

This also explains why edit and read view disagreed (the second part of the report): the editor (tiptap) renders the whole list as one WYSIWYG list and never splits it, so only the read view was affected.

**Fix:** each split `<li>` now carries `start="N"` on its wrapper `<ol>`, computed from the original list's own `start` (default 1, but respects a source list that legitimately starts elsewhere) plus the item's position within it.

**Also:** extracted the split logic out of the `.vue` file into `web/src/utils/contentBlocks.js` — it runs against `document.createElement`, so it had no real test coverage before (would have needed transplanting into a test file by hand, the way `router.test.js` documents having to do for router.js). New `web/test/contentBlocks.test.js` covers: numbering across a blank-line-separated loose list, a list with a non-1 `start`, unordered lists staying unaffected, and the other block types (tables, headings/paragraphs) unaffected by the change.

**Verified:** mutation-checked — reverted just the `start`-threading and confirmed exactly the 3 numbering-related tests fail, nothing else. `just build-web` clean, full `npm test` 83/83 (76 existing + 7 new).