### PR TITLE
feat(i18n): notifications render in the reader's language

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -340,7 +340,7 @@
             :class="n.read ? 'opacity-50' : ''"
           >
             <div class="text-sm text-slate-300 flex items-center gap-1.5">
-              <span class="flex-1">{{ n.message || n.title }}</span>
+              <span class="flex-1">{{ notificationTitle(n) }}</span>
               <svg v-if="n.link" class="w-3 h-3 text-slate-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
               </svg>
@@ -514,6 +514,7 @@ const confirmDialog = useConfirm()
 import GlobalSearch from './components/GlobalSearch.vue'
 import { useSession } from './composables/useSession'
 import { useNotifications } from './composables/useNotifications'
+import { notificationTitle } from './composables/useNotificationRender'
 import { useCurrentOrg, currentOrgPath, registerRouter, isSubdomainMode, subdomainRouting } from './composables/useCurrentOrg'
 
 const { toasts, dismiss: dismissToast } = useToast()

--- a/web/src/composables/useEnumLabel.js
+++ b/web/src/composables/useEnumLabel.js
@@ -29,9 +29,39 @@ export function enumLabel(group, value) {
   return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : humanize(value)
 }
 
+// Mid-sentence form of the same label.
+//
+// `common.enum.*` holds the standalone label — what a badge or an <option>
+// shows, capitalised because it starts its own line. Interpolated into a frame
+// it is wrong: "New Critical incident", "Incident Resolved: …". The inline form
+// is a separate authored string, not a transformation of the standalone one:
+// which words a language capitalises mid-sentence is a property of that
+// language (German capitalises every noun), so deriving one from the other is
+// the same locale-blind munging that `common.enum.*` exists to replace.
+//
+// Falls back to the standalone label, so a group with no inline forms authored
+// still renders — today's output, not a raw key.
+export function enumLabelInline(group, value) {
+  if (value === null || value === undefined || value === '') return ''
+  const key = `common.enum_inline.${group}.${value}`
+  return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : enumLabel(group, value)
+}
+
+// Entity names run through common.entity.* rather than common.enum.*, and need
+// the same two forms for the same reason.
+export function entityLabel(value, { inline = false } = {}) {
+  if (value === null || value === undefined || value === '') return ''
+  if (inline) {
+    const key = `common.entity_inline.${value}`
+    if (i18n.global.te(key, FALLBACK)) return i18n.global.t(key)
+  }
+  const key = `common.entity.${value}`
+  return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : value
+}
+
 // Component-facing form. Deliberately thin: the implementation lives in
 // enumLabel() so plain .js modules can use the same seam without a component
 // instance, exactly as `t` is exported from @/i18n for the same reason.
 export function useEnumLabel() {
-  return { enumLabel }
+  return { enumLabel, enumLabelInline, entityLabel }
 }

--- a/web/src/composables/useNotificationRender.js
+++ b/web/src/composables/useNotificationRender.js
@@ -1,0 +1,80 @@
+// The render seam for stored notifications.
+//
+// `notifications.title` / `body` are written pre-rendered in English and can
+// never be retranslated, so the backend also stores `title_key`, `body_key` and
+// a flat `params` object (plan 82 / PR #220). The stored English text stays the
+// fallback — for rows written before the keys existed, for agent-actionable
+// rows that are deliberately English, and for any key this bundle has no
+// message for.
+//
+// Wire keys are frozen: they are in DB rows already, so the catalogue bends to
+// them and not the other way round. A title wire key (`notifications.ca_resolved`)
+// is also the parent of its body wire key (`notifications.ca_resolved.body`),
+// which no JSON node can be at once — so the catalogue nests uniformly and the
+// wire key is mapped onto it here:
+//
+//   notifications.ca_resolved                     -> notifications.ca_resolved.title
+//   notifications.ca_resolved.body                -> unchanged
+//   notifications.review_forwarded.body_with_note -> unchanged
+import { FALLBACK, i18n } from '../i18n.js'
+import { enumLabel } from './useEnumLabel.js'
+
+// The closed set of params carrying an enum value, per plan 82. Each name is
+// also its `common.enum.*` group — that is why the groups were named after the
+// params in #229, so there is no second mapping to keep in sync.
+const ENUM_PARAMS = ['status', 'severity', 'action', 'suggestion_type']
+
+// `entity` is the one translatable param that is a noun the whole app reuses
+// rather than an enum member, so it resolves through common.entity.* instead.
+const ENTITY_PARAM = 'entity'
+
+// Body wire keys already name a leaf; title wire keys name the group.
+function catalogKey(wireKey) {
+  return /\.body(_with_note)?$/.test(wireKey) ? wireKey : `${wireKey}.title`
+}
+
+// Translate the params that are enum values and pass everything else through
+// untouched: actor, title, doc_id, version, round, id, note and reason are
+// proper nouns, numbers or the user's own words.
+function resolveParams(params) {
+  const out = {}
+  for (const [name, value] of Object.entries(params ?? {})) {
+    if (ENUM_PARAMS.includes(name)) {
+      out[name] = enumLabel(name, value)
+    } else if (name === ENTITY_PARAM) {
+      const key = `common.entity.${value}`
+      out[name] = i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : value
+    } else {
+      out[name] = value
+    }
+  }
+  return out
+}
+
+// Renders one field of a notification. `wireKey` is n.title_key or n.body_key;
+// `fallback` is the stored English n.title or n.body.
+//
+// te() is probed against FALLBACK rather than the active locale: the fallback
+// catalogue is complete by contract, so a locale that lags renders English
+// through fallbackLocale instead of dropping to the stored string — the same
+// reasoning as enumLabel().
+function render(wireKey, fallback, params) {
+  if (!wireKey) return fallback ?? ''
+  const key = catalogKey(wireKey)
+  if (!i18n.global.te(key, FALLBACK)) return fallback ?? ''
+  return i18n.global.t(key, resolveParams(params))
+}
+
+export function notificationTitle(n) {
+  if (!n) return ''
+  return render(n.title_key, n.title, n.params)
+}
+
+export function notificationBody(n) {
+  if (!n) return ''
+  return render(n.body_key, n.body, n.params)
+}
+
+export function useNotificationRender() {
+  return { notificationTitle, notificationBody }
+}

--- a/web/src/composables/useNotificationRender.js
+++ b/web/src/composables/useNotificationRender.js
@@ -17,7 +17,7 @@
 //   notifications.ca_resolved.body                -> unchanged
 //   notifications.review_forwarded.body_with_note -> unchanged
 import { FALLBACK, i18n } from '../i18n.js'
-import { enumLabel } from './useEnumLabel.js'
+import { enumLabelInline, entityLabel } from './useEnumLabel.js'
 
 // The closed set of params carrying an enum value, per plan 82. Each name is
 // also its `common.enum.*` group — that is why the groups were named after the
@@ -36,14 +36,17 @@ function catalogKey(wireKey) {
 // Translate the params that are enum values and pass everything else through
 // untouched: actor, title, doc_id, version, round, id, note and reason are
 // proper nouns, numbers or the user's own words.
+//
+// Every param here lands inside a sentence frame — that is what interpolation
+// means in this catalogue — so all of them take the inline form. There is no
+// notification key where an enum value stands on its own.
 function resolveParams(params) {
   const out = {}
   for (const [name, value] of Object.entries(params ?? {})) {
     if (ENUM_PARAMS.includes(name)) {
-      out[name] = enumLabel(name, value)
+      out[name] = enumLabelInline(name, value)
     } else if (name === ENTITY_PARAM) {
-      const key = `common.entity.${value}`
-      out[name] = i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : value
+      out[name] = entityLabel(value, { inline: true })
     } else {
       out[name] = value
     }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -39,6 +39,23 @@
     "checkin": "Check-in",
     "access_review": "Access review"
   },
+  "entity_inline": {
+    "risk": "risk",
+    "supplier": "supplier",
+    "incident": "incident",
+    "legal_requirement": "legal requirement",
+    "change_request": "change request",
+    "corrective_action": "corrective action",
+    "objective": "objective",
+    "task": "task",
+    "system": "system",
+    "asset": "asset",
+    "audit": "audit",
+    "audit_finding": "audit finding",
+    "program": "program",
+    "checkin": "check-in",
+    "access_review": "access review"
+  },
   "field": {},
   "enum": {
     "status": {
@@ -126,6 +143,34 @@
       "link": "Link",
       "review": "Review",
       "reading": "Reading"
+    }
+  },
+  "enum_inline": {
+    "severity": {
+      "critical": "critical",
+      "high": "high",
+      "medium": "medium",
+      "low": "low"
+    },
+    "status": {
+      "draft": "draft",
+      "open": "open",
+      "investigating": "investigating",
+      "contained": "contained",
+      "resolved": "resolved",
+      "closed": "closed"
+    },
+    "suggestion_type": {
+      "create": "create",
+      "update": "update",
+      "reassess": "reassess",
+      "link": "link",
+      "review": "review",
+      "reading": "reading"
+    },
+    "action": {
+      "applied": "applied",
+      "rejected": "rejected"
     }
   },
   "error": {},

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -12,7 +12,9 @@
 // modules, and understood by Vite/Rollup — the same file therefore loads both
 // in the bundler and under `node --test`.
 import common from './common.json' with { type: 'json' }
+import notifications from './notifications.json' with { type: 'json' }
 
 export default {
   common,
+  notifications,
 }

--- a/web/src/locales/en/notifications.json
+++ b/web/src/locales/en/notifications.json
@@ -1,0 +1,57 @@
+{
+  "mention_comment": {
+    "title": "{actor} mentioned you in a comment"
+  },
+  "mention_review_comment": {
+    "title": "{actor} mentioned you in a review comment"
+  },
+  "mention_change_request": {
+    "title": "{actor} mentioned you in a change request"
+  },
+  "review_forwarded": {
+    "title": "Review forwarded: {title}",
+    "body": "{actor} forwarded review of {doc_id} ({title} v{version}) to you",
+    "body_with_note": "{actor} forwarded review of {doc_id} ({title} v{version}) to you\n\nNote: {note}"
+  },
+  "review_requested": {
+    "title": "Review: {title} v{version}",
+    "body": "{actor} wants to publish {title} v{version} and requested your review",
+    "body_with_note": "{actor} wants to publish {title} v{version} and requested your review\n\nNote: {note}"
+  },
+  "review_resubmitted": {
+    "title": "Review resubmitted: {title}",
+    "body": "{actor} resubmitted {doc_id} ({title} v{version}) for review",
+    "body_with_note": "{actor} resubmitted {doc_id} ({title} v{version}) for review\n\nNote: {note}"
+  },
+  "ai_review_escalated": {
+    "title": "AI review escalated",
+    "body": "AI review of {doc_id} reached round {round} without agreement. Please review and decide."
+  },
+  "ca_assigned": {
+    "title": "Corrective action assigned: {title}"
+  },
+  "ca_resolved": {
+    "title": "Corrective action resolved: {title}",
+    "body": "Corrective action #{id} has been resolved by {actor}"
+  },
+  "suggestion_new": {
+    "title": "New suggestion",
+    "body": "{actor} suggested: {title} ({suggestion_type} {entity})"
+  },
+  "suggestion_resolved": {
+    "title": "Suggestion {action}"
+  },
+  "suggestion_applied": {
+    "body": "Your suggestion \"{title}\" was applied by {actor} → {entity} {id}"
+  },
+  "suggestion_rejected": {
+    "body": "Your suggestion \"{title}\" was rejected by {actor}: {reason}"
+  },
+  "incident_new": {
+    "title": "New {severity} incident: {title}"
+  },
+  "incident_status": {
+    "title": "Incident {status}: {title}",
+    "body": "Incident #{id} has been {status}"
+  }
+}

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -39,6 +39,23 @@
     "checkin": "Check-in",
     "access_review": "Tinjauan akses"
   },
+  "entity_inline": {
+    "risk": "risiko",
+    "supplier": "pemasok",
+    "incident": "insiden",
+    "legal_requirement": "persyaratan hukum",
+    "change_request": "permintaan perubahan",
+    "corrective_action": "tindakan korektif",
+    "objective": "sasaran",
+    "task": "tugas",
+    "system": "sistem",
+    "asset": "aset",
+    "audit": "audit",
+    "audit_finding": "temuan audit",
+    "program": "program",
+    "checkin": "check-in",
+    "access_review": "tinjauan akses"
+  },
   "field": {},
   "enum": {
     "status": {
@@ -126,6 +143,34 @@
       "link": "Tautkan",
       "review": "Tinjau",
       "reading": "Nilai ulang"
+    }
+  },
+  "enum_inline": {
+    "severity": {
+      "critical": "kritis",
+      "high": "tinggi",
+      "medium": "sedang",
+      "low": "rendah"
+    },
+    "status": {
+      "draft": "draf",
+      "open": "terbuka",
+      "investigating": "sedang diselidiki",
+      "contained": "terkendali",
+      "resolved": "selesai ditangani",
+      "closed": "ditutup"
+    },
+    "suggestion_type": {
+      "create": "buat",
+      "update": "perbarui",
+      "reassess": "nilai ulang",
+      "link": "tautkan",
+      "review": "tinjau",
+      "reading": "nilai ulang"
+    },
+    "action": {
+      "applied": "diterapkan",
+      "rejected": "ditolak"
     }
   },
   "error": {},

--- a/web/src/locales/id-ID/index.js
+++ b/web/src/locales/id-ID/index.js
@@ -12,7 +12,9 @@
 // modules, and understood by Vite/Rollup — the same file therefore loads both
 // in the bundler and under `node --test`.
 import common from './common.json' with { type: 'json' }
+import notifications from './notifications.json' with { type: 'json' }
 
 export default {
   common,
+  notifications,
 }

--- a/web/src/locales/id-ID/notifications.json
+++ b/web/src/locales/id-ID/notifications.json
@@ -1,0 +1,57 @@
+{
+  "mention_comment": {
+    "title": "{actor} menyebut Anda dalam sebuah komentar"
+  },
+  "mention_review_comment": {
+    "title": "{actor} menyebut Anda dalam komentar tinjauan"
+  },
+  "mention_change_request": {
+    "title": "{actor} menyebut Anda dalam permintaan perubahan"
+  },
+  "review_forwarded": {
+    "title": "Tinjauan diteruskan: {title}",
+    "body": "{actor} meneruskan tinjauan {doc_id} ({title} v{version}) kepada Anda",
+    "body_with_note": "{actor} meneruskan tinjauan {doc_id} ({title} v{version}) kepada Anda\n\nCatatan: {note}"
+  },
+  "review_requested": {
+    "title": "Tinjauan: {title} v{version}",
+    "body": "{actor} ingin menerbitkan {title} v{version} dan meminta tinjauan Anda",
+    "body_with_note": "{actor} ingin menerbitkan {title} v{version} dan meminta tinjauan Anda\n\nCatatan: {note}"
+  },
+  "review_resubmitted": {
+    "title": "Tinjauan diajukan ulang: {title}",
+    "body": "{actor} mengajukan ulang {doc_id} ({title} v{version}) untuk ditinjau",
+    "body_with_note": "{actor} mengajukan ulang {doc_id} ({title} v{version}) untuk ditinjau\n\nCatatan: {note}"
+  },
+  "ai_review_escalated": {
+    "title": "Tinjauan AI dieskalasi",
+    "body": "Tinjauan AI atas {doc_id} mencapai putaran {round} tanpa kesepakatan. Mohon tinjau dan putuskan."
+  },
+  "ca_assigned": {
+    "title": "Tindakan korektif ditugaskan: {title}"
+  },
+  "ca_resolved": {
+    "title": "Tindakan korektif diselesaikan: {title}",
+    "body": "Tindakan korektif #{id} telah diselesaikan oleh {actor}"
+  },
+  "suggestion_new": {
+    "title": "Saran baru",
+    "body": "{actor} menyarankan: {title} ({suggestion_type} {entity})"
+  },
+  "suggestion_resolved": {
+    "title": "Saran {action}"
+  },
+  "suggestion_applied": {
+    "body": "Saran Anda \"{title}\" diterapkan oleh {actor} → {entity} {id}"
+  },
+  "suggestion_rejected": {
+    "body": "Saran Anda \"{title}\" ditolak oleh {actor}: {reason}"
+  },
+  "incident_new": {
+    "title": "Insiden {severity} baru: {title}"
+  },
+  "incident_status": {
+    "title": "Insiden {status}: {title}",
+    "body": "Insiden #{id} telah {status}"
+  }
+}

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -5,7 +5,7 @@
 // which reads plausibly in English and is invisible in review.
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { enumLabel } from '../src/composables/useEnumLabel.js'
+import { enumLabel, enumLabelInline } from '../src/composables/useEnumLabel.js'
 import { i18n } from '../src/i18n.js'
 import en from '../src/locales/en/index.js'
 import id from '../src/locales/id-ID/index.js'
@@ -105,4 +105,70 @@ test('a lagging locale falls back to the English label, not to de-slugging', () 
   } finally {
     i18n.global.locale.value = previous
   }
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Inline forms. `common.enum.*` is the standalone label (badge, <option>);
+// a value interpolated into a sentence frame needs the mid-sentence form, or
+// notifications read "New Critical incident". The fallback in
+// enumLabelInline() is deliberately silent, so only a test can catch a new
+// enum member that reintroduces the bug.
+// ─────────────────────────────────────────────────────────────────────────
+
+// The closed set a notification param can actually carry. `status` is the six
+// incident values only: incident_status is the sole frame interpolating one.
+const INLINE_REQUIRED = {
+  severity: ['critical', 'high', 'medium', 'low'],
+  status: ['draft', 'open', 'investigating', 'contained', 'resolved', 'closed'],
+  suggestion_type: ['create', 'update', 'reassess', 'link', 'review', 'reading'],
+  action: ['applied', 'rejected'],
+}
+
+test('every notification-interpolated enum value has an inline form in en', () => {
+  for (const [group, values] of Object.entries(INLINE_REQUIRED)) {
+    for (const value of values) {
+      const inline = en.common.enum_inline?.[group]?.[value]
+      assert.equal(typeof inline, 'string', `common.enum_inline.${group}.${value} is missing in en`)
+      assert.ok(inline.length > 0, `common.enum_inline.${group}.${value} is empty in en`)
+    }
+  }
+})
+
+test('every entity name has an inline form in en', () => {
+  for (const name of Object.keys(en.common.entity)) {
+    const inline = en.common.entity_inline?.[name]
+    assert.equal(typeof inline, 'string', `common.entity_inline.${name} is missing in en`)
+  }
+})
+
+test('id-ID mirrors every inline form it needs', () => {
+  for (const [group, values] of Object.entries(INLINE_REQUIRED)) {
+    for (const value of values) {
+      assert.equal(typeof id.common.enum_inline?.[group]?.[value], 'string',
+        `common.enum_inline.${group}.${value} is missing in id-ID`)
+    }
+  }
+  for (const name of Object.keys(en.common.entity_inline)) {
+    assert.equal(typeof id.common.entity_inline?.[name], 'string',
+      `common.entity_inline.${name} is missing in id-ID`)
+  }
+})
+
+test('inline forms are used mid-sentence, so they do not lead with a capital', () => {
+  // en and id-ID both lowercase mid-sentence. A locale where that is false
+  // (German nouns) authors its own strings and this assertion moves with it.
+  for (const [group, values] of Object.entries(INLINE_REQUIRED)) {
+    for (const value of values) {
+      const inline = en.common.enum_inline[group][value]
+      assert.equal(inline, inline.toLowerCase(),
+        `en common.enum_inline.${group}.${value} should be lowercase mid-sentence`)
+    }
+  }
+})
+
+test('enumLabelInline falls back to the standalone label, not a raw key', () => {
+  // `criticality` has no inline group at all.
+  assert.equal(enumLabelInline('criticality', 'high'), enumLabel('criticality', 'high'))
+  // an unknown member still degrades through enumLabel's humanize()
+  assert.equal(enumLabelInline('severity', 'nonexistent'), 'Nonexistent')
 })

--- a/web/test/notificationRender.test.js
+++ b/web/test/notificationRender.test.js
@@ -75,14 +75,21 @@ test('every body key Go emits renders from the catalogue', () => {
   }
 })
 
+// vue-i18n falls back to `en` for a missing id-ID message, so "not the stored
+// English" is not enough here — an untranslated key would render the English
+// frame and pass. Comparing against the en render is what actually catches it.
 test('the same keys all render in id-ID', () => {
-  withLocale('id-ID', () => {
-    for (const [key, params] of Object.entries(ROWS)) {
-      const out = notificationTitle({ title_key: key, title: STORED, params })
-      assert.notEqual(out, STORED, `${key} has no id-ID message`)
-      assert.ok(!out.includes('{'), `${key} left a placeholder in id-ID: ${out}`)
-    }
-  })
+  const cases = [
+    ...Object.entries(ROWS).map(([key, params]) => [key, params, (p) => notificationTitle({ title_key: key, title: STORED, params: p })]),
+    ...Object.entries(BODY_ROWS).map(([key, params]) => [key, params, (p) => notificationBody({ body_key: key, body: STORED, params: p })]),
+  ]
+  for (const [key, params, render] of cases) {
+    const english = render(params)
+    const out = withLocale('id-ID', () => render(params))
+    assert.notEqual(out, STORED, `${key} has no id-ID message`)
+    assert.notEqual(out, english, `${key} rendered the English frame in id-ID — the message is missing`)
+    assert.ok(!out.includes('{'), `${key} left a placeholder in id-ID: ${out}`)
+  }
 })
 
 // The half-translated trap plan 82 was written to avoid: an enum param spliced

--- a/web/test/notificationRender.test.js
+++ b/web/test/notificationRender.test.js
@@ -1,0 +1,143 @@
+// Step 6 of plan 82: the stored key+params become translated text.
+//
+// The contract these pin is split across two repos' worth of code — Go writes
+// the wire keys, the locale files carry the frames — and a mismatch is silent:
+// an unmapped key falls back to the stored English, which looks correct in
+// review and never translates. So every key Go can emit is rendered here.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { notificationTitle, notificationBody } from '../src/composables/useNotificationRender.js'
+import { i18n } from '../src/i18n.js'
+import id from '../src/locales/id-ID/index.js'
+
+i18n.global.setLocaleMessage('id-ID', id)
+
+function withLocale(tag, fn) {
+  const previous = i18n.global.locale.value
+  i18n.global.locale.value = tag
+  try {
+    return fn()
+  } finally {
+    i18n.global.locale.value = previous
+  }
+}
+
+// One sample row per title key Go emits, with the params that site actually
+// passes. Mirrors the call sites in api_collab.go, api_corrective.go,
+// api_incidents.go and api_suggestions.go.
+const ROWS = {
+  'notifications.mention_comment': { actor: 'ana@x.io' },
+  'notifications.mention_review_comment': { actor: 'ana@x.io' },
+  'notifications.mention_change_request': { actor: 'ana@x.io' },
+  'notifications.review_forwarded': { actor: 'ana@x.io', doc_id: 'iso27001-4-1', title: 'Context', version: '2' },
+  'notifications.review_requested': { actor: 'ana@x.io', title: 'Context', version: '2' },
+  'notifications.review_resubmitted': { actor: 'ana@x.io', doc_id: 'iso27001-4-1', title: 'Context', version: '2' },
+  'notifications.ai_review_escalated': { doc_id: 'iso27001-4-1', round: 3 },
+  'notifications.ca_assigned': { title: 'Patch the gateway' },
+  'notifications.ca_resolved': { title: 'Patch the gateway', id: 12, actor: 'ana@x.io' },
+  'notifications.suggestion_new': { actor: 'ana@x.io', title: 'Raise the score', suggestion_type: 'update', entity: 'risk' },
+  'notifications.suggestion_resolved': { action: 'applied' },
+  'notifications.incident_new': { severity: 'critical', title: 'Phishing wave' },
+  'notifications.incident_status': { status: 'resolved', title: 'Phishing wave', id: 7 },
+}
+
+const BODY_ROWS = {
+  'notifications.review_forwarded.body': ROWS['notifications.review_forwarded'],
+  'notifications.review_forwarded.body_with_note': { ...ROWS['notifications.review_forwarded'], note: 'please look' },
+  'notifications.review_requested.body': ROWS['notifications.review_requested'],
+  'notifications.review_requested.body_with_note': { ...ROWS['notifications.review_requested'], note: 'please look' },
+  'notifications.review_resubmitted.body': ROWS['notifications.review_resubmitted'],
+  'notifications.review_resubmitted.body_with_note': { ...ROWS['notifications.review_resubmitted'], note: 'please look' },
+  'notifications.ai_review_escalated.body': ROWS['notifications.ai_review_escalated'],
+  'notifications.ca_resolved.body': ROWS['notifications.ca_resolved'],
+  'notifications.suggestion_new.body': ROWS['notifications.suggestion_new'],
+  'notifications.suggestion_applied.body': { title: 'Raise the score', actor: 'ana@x.io', entity: 'risk', id: 'R-4' },
+  'notifications.suggestion_rejected.body': { title: 'Raise the score', actor: 'ana@x.io', reason: 'out of scope' },
+  'notifications.incident_status.body': ROWS['notifications.incident_status'],
+}
+
+const STORED = 'STORED ENGLISH'
+
+test('every title key Go emits renders from the catalogue', () => {
+  for (const [key, params] of Object.entries(ROWS)) {
+    const out = notificationTitle({ title_key: key, title: STORED, params })
+    assert.notEqual(out, STORED, `${key} fell back to the stored title — no message for it`)
+    assert.ok(out.length > 0, `${key} rendered empty`)
+    assert.ok(!out.includes('{'), `${key} left an uninterpolated placeholder: ${out}`)
+  }
+})
+
+test('every body key Go emits renders from the catalogue', () => {
+  for (const [key, params] of Object.entries(BODY_ROWS)) {
+    const out = notificationBody({ body_key: key, body: STORED, params })
+    assert.notEqual(out, STORED, `${key} fell back to the stored body — no message for it`)
+    assert.ok(!out.includes('{'), `${key} left an uninterpolated placeholder: ${out}`)
+  }
+})
+
+test('the same keys all render in id-ID', () => {
+  withLocale('id-ID', () => {
+    for (const [key, params] of Object.entries(ROWS)) {
+      const out = notificationTitle({ title_key: key, title: STORED, params })
+      assert.notEqual(out, STORED, `${key} has no id-ID message`)
+      assert.ok(!out.includes('{'), `${key} left a placeholder in id-ID: ${out}`)
+    }
+  })
+})
+
+// The half-translated trap plan 82 was written to avoid: an enum param spliced
+// in raw yields "Insiden resolved: …".
+test('enum params are translated before interpolation, not spliced raw', () => {
+  const row = { title_key: 'notifications.incident_status', title: STORED, params: ROWS['notifications.incident_status'] }
+  assert.equal(notificationTitle(row), 'Incident Resolved: Phishing wave')
+  withLocale('id-ID', () => {
+    const out = notificationTitle(row)
+    assert.ok(!out.includes('resolved'), `raw enum value survived into id-ID: ${out}`)
+    assert.ok(out.includes('Selesai'), `expected the id-ID status label, got: ${out}`)
+  })
+})
+
+test('the entity param resolves through common.entity.*', () => {
+  withLocale('id-ID', () => {
+    const out = notificationBody({
+      body_key: 'notifications.suggestion_applied.body',
+      body: STORED,
+      params: BODY_ROWS['notifications.suggestion_applied.body'],
+    })
+    assert.ok(out.includes('Risiko'), `entity was not translated: ${out}`)
+    assert.ok(!out.includes('risk'), `raw entity value survived: ${out}`)
+  })
+})
+
+test('verbatim params pass through untouched', () => {
+  const note = 'don’t ship — "as-is" per §4'
+  const out = notificationBody({
+    body_key: 'notifications.review_forwarded.body_with_note',
+    body: STORED,
+    params: { ...ROWS['notifications.review_forwarded'], note },
+  })
+  assert.ok(out.includes(note), `user text was altered: ${out}`)
+})
+
+test('a row with no key renders the stored English', () => {
+  assert.equal(notificationTitle({ title: 'AI review escalated' }), 'AI review escalated')
+  assert.equal(notificationBody({ body: 'raw description' }), 'raw description')
+})
+
+test('an unmapped key renders the stored English rather than the key', () => {
+  const out = notificationTitle({ title_key: 'notifications.invented_later', title: STORED, params: {} })
+  assert.equal(out, STORED)
+})
+
+test('a body that is org content keeps its stored text', () => {
+  // api_incidents.go passes inc.Description with no BodyKey, on purpose.
+  const out = notificationBody({ title_key: 'notifications.incident_new', body: 'attacker mailed staff', params: {} })
+  assert.equal(out, 'attacker mailed staff')
+})
+
+test('missing params and null rows degrade instead of throwing', () => {
+  assert.equal(notificationTitle(null), '')
+  assert.equal(notificationBody(undefined), '')
+  const out = notificationTitle({ title_key: 'notifications.ca_assigned', title: STORED })
+  assert.ok(typeof out === 'string')
+})

--- a/web/test/notificationRender.test.js
+++ b/web/test/notificationRender.test.js
@@ -89,11 +89,11 @@ test('the same keys all render in id-ID', () => {
 // in raw yields "Insiden resolved: …".
 test('enum params are translated before interpolation, not spliced raw', () => {
   const row = { title_key: 'notifications.incident_status', title: STORED, params: ROWS['notifications.incident_status'] }
-  assert.equal(notificationTitle(row), 'Incident Resolved: Phishing wave')
+  assert.equal(notificationTitle(row), 'Incident resolved: Phishing wave')
   withLocale('id-ID', () => {
     const out = notificationTitle(row)
     assert.ok(!out.includes('resolved'), `raw enum value survived into id-ID: ${out}`)
-    assert.ok(out.includes('Selesai'), `expected the id-ID status label, got: ${out}`)
+    assert.ok(out.includes('selesai ditangani'), `expected the id-ID status label, got: ${out}`)
   })
 })
 
@@ -104,7 +104,7 @@ test('the entity param resolves through common.entity.*', () => {
       body: STORED,
       params: BODY_ROWS['notifications.suggestion_applied.body'],
     })
-    assert.ok(out.includes('Risiko'), `entity was not translated: ${out}`)
+    assert.ok(out.includes('risiko'), `entity was not translated: ${out}`)
     assert.ok(!out.includes('risk'), `raw entity value survived: ${out}`)
   })
 })


### PR DESCRIPTION
Closes the last gap that made the Indonesian UI only half-translated: notifications.

## The problem this solves

When a user switched the app to Bahasa Indonesia, the interface translated but their
notification inbox stayed in English — permanently. Notifications are written to the
database as finished English sentences ("New critical incident: Phishing wave"), so once
a row exists there is nothing left to translate. Every notification a user received was
frozen in the language it was written in.

Groundwork shipped earlier this week: since 25 Aug the server has also been storing a
**key** plus the **values** for each notification ("this is an incident-created
notification, severity = critical, title = Phishing wave") alongside the English text.
Nothing read those keys yet, so nothing changed on screen. This PR makes the app read
them and build the sentence in the reader's own language.

## What changes for users

- A notification now displays in whatever language the reader has selected, regardless of
  the language it was written in. Switching language re-renders the inbox immediately.
- This applies to all 13 notification types the product sends — review requests and
  forwards, mentions, corrective actions, incidents, and suggestions.
- Notifications written before 25 Aug, and notifications aimed at AI agents rather than
  people, keep showing their original English. That is intended: older rows have no key
  to rebuild from, and agent-facing text is a machine interface, not user copy.

## What is improved beyond the fix

The sentences are assembled from the shared vocabulary the rest of the app already uses,
so a status or severity reads the same in a notification as it does on a badge or in a
dropdown. One translation, one place to maintain it.

While building this we found and fixed a related quality problem. Words like "Critical"
or "Resolved" are capitalised when they stand alone on a badge, but dropping that same
word into a sentence produced "New **C**ritical incident" and "Insiden **S**elesai
ditangani". The vocabulary now carries both a standalone and a mid-sentence form, and the
app picks the right one by context. This will matter well beyond notifications — the same
choice comes up on every screen as we translate the rest of the interface.

## Considerations for review and release

**Translation quality — the one item needing a second pair of eyes.** This PR adds 58 new
Indonesian strings. Every ISO and domain term in them is reused from the vocabulary that
was checked against the Indonesian national adoption of the standard last week, so the
terminology itself is on solid ground. But the connecting sentences around those terms are
newly written and have **not** had a native-speaker review. Our contribution guide makes
that review a required step precisely because wrong-but-fluent wording is invisible to a
reviewer who does not speak the language. Recommend a native speaker reads the 25 sentence
templates before this goes out to Indonesian users.

**No database or API changes.** Purely a display-layer change, so there is nothing to
migrate and no deployment ordering to coordinate. The English text stays in the database
untouched and is still what the app falls back to.

**Low blast radius, but it is on a shared screen.** The notification bell is visible on
every page. If a key were ever missing, the affected notification quietly shows its
original English rather than breaking — the design fails soft by intent.

**One follow-up is deliberately not in this PR.** There is no automated check yet that a
newly added notification type has matching translations. Without it, a future notification
would silently appear in English for non-English users and no reviewer would notice. That
guard is the next piece of work and is tracked under #212; it is a small, self-contained
task.

## Verification

- Automated tests: 96 passing, 15 added. Every notification type the server can send is
  rendered in both languages, plus the fallback cases (pre-existing rows, agent
  notifications, unknown types) and passthrough of user-written text such as a reviewer's
  rejection reason.
- Manual: ran a real server against a clean database, generated genuine notifications
  through the API, and confirmed in the browser that the inbox renders correctly in both
  English and Indonesian, switches language without a reload, and still shows older
  keyless notifications in English.
- Production build clean.

Part of #212.
