### PR TITLE
feat(i18n): every date and relative time renders through useFormat (#212)

### DIFF
--- a/web/src/components/CommentSidebar.vue
+++ b/web/src/components/CommentSidebar.vue
@@ -132,6 +132,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import DOMPurify from 'dompurify'
+import { formatRecent } from '../composables/useFormat.js'
 const sanitize = (html) => DOMPurify.sanitize(html, { ADD_ATTR: ['style'] })
 import { api, getCurrentUser } from '../api'
 import MentionTextarea from './MentionTextarea.vue'
@@ -220,16 +221,8 @@ async function submitReply() {
   }
 }
 
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const date = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  const now = new Date()
-  const diff = now - date
-  if (diff < 60000) return 'just now'
-  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago'
-  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago'
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
-}
+// A comment thread pins to a date after a day, not a week.
+const formatDate = (d) => formatRecent(d, { within: 24 * 60 * 60 * 1000, style: 'dayMonth' })
 
 function renderBody(body) {
   if (!body) return ''

--- a/web/src/components/CommentsPanel.vue
+++ b/web/src/components/CommentsPanel.vue
@@ -34,6 +34,7 @@ import { useMembers } from '../composables/useMembers'
 import { renderMention } from '../composables/useMention'
 import { useSession } from '../composables/useSession'
 import { useToast } from '../composables/useToast'
+import { formatDate } from '../composables/useFormat.js'
 
 const { show: showError } = useToast()
 
@@ -53,12 +54,6 @@ const props = defineProps({
 const comments = ref([])
 const loading = ref(false)
 const newComment = ref('')
-
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-}
 
 async function loadComments() {
   loading.value = true

--- a/web/src/components/DocumentViewer.vue
+++ b/web/src/components/DocumentViewer.vue
@@ -235,6 +235,7 @@ import { api, getCurrentUser } from '../api'
 import MentionTextarea from './MentionTextarea.vue'
 import { useMembers } from '../composables/useMembers'
 import { parseMd } from '../composables/useRenderMd'
+import { formatRecent } from '../composables/useFormat.js'
 
 const { members } = useMembers()
 
@@ -618,21 +619,7 @@ function toggleReviewBlock(index) {
 }
 
 // --- Format helpers ---
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  try {
-    const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-    const now = new Date()
-    const diff = now - d
-    if (diff < 60000) return 'just now'
-    if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
-    if (diff < 604800000) return `${Math.floor(diff / 86400000)}d ago`
-    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-  } catch {
-    return dateStr
-  }
-}
+const formatDate = (dateStr) => formatRecent(dateStr)
 
 // --- Lifecycle ---
 watch(() => props.documentId, (newId) => {

--- a/web/src/components/HistoryPanel.vue
+++ b/web/src/components/HistoryPanel.vue
@@ -36,6 +36,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { api } from '../api'
+import { formatDate as formatDateValue } from '../composables/useFormat.js'
 
 const props = defineProps({
   entityType: { type: String, required: true },
@@ -92,11 +93,7 @@ function groupTooltip(g) {
   return t
 }
 
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })
-}
+const formatDate = (d) => formatDateValue(d, 'dayMonthTime')
 
 function toEpoch(d) {
   return typeof d === 'number' ? d : new Date(d).getTime() / 1000

--- a/web/src/components/ReadingsPanel.vue
+++ b/web/src/components/ReadingsPanel.vue
@@ -202,6 +202,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { api } from '../api'
+import { formatRecent } from '../composables/useFormat.js'
 
 // Auto-recompute next_review when severity changes, unless user has manually edited it
 
@@ -371,14 +372,7 @@ function scoreColor(v) {
   return 'bg-emerald-900/40 text-emerald-300'
 }
 
-function relativeTime(ts) {
-  if (!ts) return ''
-  const d = new Date(typeof ts === 'number' ? ts * 1000 : ts)
-  const diff = Math.floor((Date.now() - d.getTime()) / 60000)
-  if (diff < 60) return `${diff}m ago`
-  if (diff < 1440) return `${Math.floor(diff / 60)}h ago`
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-}
+const relativeTime = (ts) => formatRecent(ts, { within: 24 * 60 * 60 * 1000 })
 
 function shortEmail(e) { return e ? e.split('@')[0] : '-' }
 

--- a/web/src/components/SideBySideReview.vue
+++ b/web/src/components/SideBySideReview.vue
@@ -139,6 +139,7 @@ import DOMPurify from 'dompurify'
 import DiffView from './DiffView.vue'
 import { parseMd } from '../composables/useRenderMd'
 import { diffTables, isTableBlock } from '../composables/useTableDiff'
+import { formatDate } from '../composables/useFormat.js'
 
 const props = defineProps({
   oldBody: { type: String, default: '' },
@@ -177,11 +178,7 @@ const expandedBlock = ref(null)
 
 watch(expandedBlock, () => { commentBody.value = '' })
 
-function formatTime(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })
-}
+const formatTime = (d) => formatDate(d, 'dayMonthTime')
 
 const showOutdated = ref({})
 

--- a/web/src/components/SuggestionPanel.vue
+++ b/web/src/components/SuggestionPanel.vue
@@ -86,6 +86,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { api } from '../api'
 import { useConfirm } from '../composables/useConfirm'
 import { useToast } from '../composables/useToast'
+import { formatDate as formatDateValue } from '../composables/useFormat.js'
 
 const { show: showError, success: showSuccess } = useToast()
 
@@ -231,11 +232,7 @@ function statusLabel(s) {
   }[s] || s.replace(/_/g, ' ')
 }
 
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
-}
+const formatDate = (d) => formatDateValue(d, 'dayMonth')
 
 onMounted(load)
 watch(() => props.entityId, load)

--- a/web/src/components/SupplierReviewPanel.vue
+++ b/web/src/components/SupplierReviewPanel.vue
@@ -81,6 +81,7 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
 import { api } from '../api'
+import { formatRecent } from '../composables/useFormat.js'
 
 const props = defineProps({
   supplierId: { type: Number, required: true },
@@ -125,14 +126,7 @@ async function submit() {
   }
 }
 
-function formatTime(ts) {
-  if (!ts) return ''
-  const d = new Date(typeof ts === 'number' ? ts * 1000 : ts)
-  const diff = Math.floor((Date.now() - d.getTime()) / 60000)
-  if (diff < 60) return `${diff}m ago`
-  if (diff < 1440) return `${Math.floor(diff / 60)}h ago`
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-}
+const formatTime = (ts) => formatRecent(ts, { within: 24 * 60 * 60 * 1000 })
 
 onMounted(load)
 watch(() => props.supplierId, load)

--- a/web/src/components/TrackChanges.vue
+++ b/web/src/components/TrackChanges.vue
@@ -126,6 +126,7 @@ import { tokenize, diffTokens, diffLines, escapeHtml } from '../composables/useW
 import { diffTables } from '../composables/useTableDiff'
 import DiffView from './DiffView.vue'
 import api from '../api'
+import { formatDate, formatRecent } from '../composables/useFormat.js'
 
 const emit = defineEmits(['comment'])
 
@@ -157,15 +158,7 @@ function outdatedCommentsForParagraph(idx) {
 const activeCommentCount = computed(() => props.comments.filter(c => !c.is_outdated).length)
 
 function formatTime(ts) {
-  if (!ts) return ''
-  try {
-    const d = new Date(typeof ts === 'number' ? ts * 1000 : ts)
-    const diff = Math.floor((Date.now() - d.getTime()) / 60000)
-    if (diff < 1) return 'just now'
-    if (diff < 60) return `${diff}m ago`
-    if (diff < 1440) return `${Math.floor(diff / 60)}h ago`
-    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
-  } catch { return '' }
+  return formatRecent(ts, { within: 24 * 60 * 60 * 1000, style: 'dayMonth' })
 }
 
 function submitComment(paragraphIndex) {
@@ -262,23 +255,10 @@ watch([() => props.documentId, () => props.blameRef], async ([id]) => {
 
 function relTime(dateStr) {
   if (!dateStr) return ''
-  try {
-    const d = new Date(dateStr)
-    const diffH = Math.floor((new Date() - d) / 3600000)
-    if (diffH < 1) return 'just now'
-    if (diffH < 24) return `${diffH}h ago`
-    const diffD = Math.floor(diffH / 24)
-    if (diffD < 30) return `${diffD}d ago`
-    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
-  } catch { return '' }
+  return formatRecent(dateStr, { within: 30 * 24 * 60 * 60 * 1000, style: 'dayMonth' })
 }
 
-function fullDate(dateStr) {
-  if (!dateStr) return ''
-  try {
-    return new Date(dateStr).toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-  } catch { return '' }
-}
+const fullDate = (dateStr) => formatDate(dateStr, 'datetime')
 
 function shortName(email) {
   if (!email) return ''

--- a/web/src/composables/useFormat.js
+++ b/web/src/composables/useFormat.js
@@ -99,6 +99,16 @@ export function formatRelative(value, now = Date.now()) {
   return rtf.format(Math.round(diff / 1000), 'second')
 }
 
+// Six components carried the same ladder by hand: relative wording for a recent
+// timestamp, an absolute date once it is old enough to be worth pinning down.
+// The threshold is a per-surface choice (a comment thread pins after a day, a
+// document list after a week), so it stays a parameter; the wording does not.
+export function formatRecent(value, { within = 7 * 24 * 60 * 60 * 1000, style = 'short' } = {}) {
+  const d = toDate(value)
+  if (!d) return ''
+  return Math.abs(Date.now() - d.getTime()) < within ? formatRelative(d) : formatDate(d, style)
+}
+
 export function useFormat() {
-  return { date: formatDate, number: formatNumber, relative: formatRelative }
+  return { date: formatDate, number: formatNumber, relative: formatRelative, recent: formatRecent }
 }

--- a/web/src/composables/useFormat.js
+++ b/web/src/composables/useFormat.js
@@ -69,6 +69,20 @@ export function formatDate(value, style = 'short') {
   return formatter(Intl.DateTimeFormat, 'date', activeLocale(), options).format(d)
 }
 
+// A calendar date, not an instant. Postgres DATE columns (a due date, a next
+// review) come over the wire as epoch seconds at midnight UTC, so rendering
+// them in the viewer's zone moves the day backwards for everyone west of UTC —
+// a 5 Aug due date reads 4 Aug in Sao Paulo. Pinning the formatter to UTC keeps
+// the day the one that was entered, which is the only meaning a DATE has.
+// Use this for a DATE column and formatDate() for a timestamp; the wire format
+// is identical, so the distinction cannot be recovered from the value.
+export function formatDay(value, style = 'short') {
+  const d = toDate(value)
+  if (!d) return ''
+  const options = DATE_STYLES[style] ?? DATE_STYLES.short
+  return formatter(Intl.DateTimeFormat, 'date', activeLocale(), { ...options, timeZone: 'UTC' }).format(d)
+}
+
 export function formatNumber(value, options = {}) {
   if (typeof value !== 'number' || !Number.isFinite(value)) return ''
   return formatter(Intl.NumberFormat, 'number', activeLocale(), options).format(value)
@@ -110,5 +124,5 @@ export function formatRecent(value, { within = 7 * 24 * 60 * 60 * 1000, style = 
 }
 
 export function useFormat() {
-  return { date: formatDate, number: formatNumber, relative: formatRelative, recent: formatRecent }
+  return { date: formatDate, day: formatDay, number: formatNumber, relative: formatRelative, recent: formatRecent }
 }

--- a/web/src/composables/useFormat.js
+++ b/web/src/composables/useFormat.js
@@ -20,23 +20,46 @@ function formatter(Ctor, kind, locale, options) {
   return f
 }
 
+// The app's English is British — every call site this seam replaces was
+// hardcoded to `en-GB`, and bare `en` resolves to US ordering ("Aug 24, 2026"
+// against "24 Aug 2026"). The message bundle is tagged `en` and stays that way;
+// only the Intl formatting tag is widened, so adopting the seam changes no
+// English user's date shape.
+const FORMAT_LOCALE = { en: 'en-GB' }
+
 function activeLocale() {
-  return i18n.global.locale.value
+  const tag = i18n.global.locale.value
+  return FORMAT_LOCALE[tag] ?? tag
 }
 
-// Accepts a Date, an epoch number, or an ISO string (the API's wire format).
-// Returns null for anything unparseable so callers render an em dash rather
-// than "Invalid Date".
+// Anything below this is read as epoch seconds, anything above as epoch
+// milliseconds. The API writes seconds (`created_at: 1756...`) while
+// `Date.now()` arithmetic produces milliseconds, and both reach these helpers.
+// 1e11 separates them with no ambiguity in practice: as milliseconds it is
+// 1973, as seconds it is the year 5138.
+const SECONDS_CEILING = 1e11
+
+// Accepts a Date, an epoch number (seconds or milliseconds, per above), or an
+// ISO string (the API's other wire format). Returns null for anything
+// unparseable so callers render an em dash rather than "Invalid Date".
 function toDate(value) {
   if (value === null || value === undefined || value === '') return null
-  const d = value instanceof Date ? value : new Date(value)
+  let d
+  if (value instanceof Date) d = value
+  else if (typeof value === 'number') d = new Date(Math.abs(value) < SECONDS_CEILING ? value * 1000 : value)
+  else d = new Date(value)
   return Number.isNaN(d.getTime()) ? null : d
 }
 
+// `dateStyle` cannot drop the year, so the two year-less shapes the UI uses
+// (comment timelines, audit date ranges) are spelled out as component bags.
+// Component order is still the locale's, not the bag's.
 const DATE_STYLES = {
   short: { dateStyle: 'medium' }, // "24 Aug 2026" — the table default
   long: { dateStyle: 'long' },
   datetime: { dateStyle: 'medium', timeStyle: 'short' },
+  dayMonth: { day: 'numeric', month: 'short' }, // "24 Aug"
+  dayMonthTime: { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' },
 }
 
 export function formatDate(value, style = 'short') {

--- a/web/src/composables/useNotifications.js
+++ b/web/src/composables/useNotifications.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { api } from '../api'
 import { isSubdomainMode } from './useCurrentOrg'
+import { formatDate } from './useFormat.js'
 
 const notifications = ref([])
 const unreadCount = ref(0)
@@ -49,11 +50,7 @@ export function useNotifications() {
     } catch { /* ignore */ }
   }
 
-  function formatNotifDate(dateStr) {
-    if (!dateStr && dateStr !== 0) return ''
-    const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })
-  }
+  const formatNotifDate = (dateStr) => formatDate(dateStr, 'dayMonthTime')
 
   // Listen for external notification changes (e.g. Inbox page marking all read)
   if (typeof window !== 'undefined') {

--- a/web/src/views/Admin.vue
+++ b/web/src/views/Admin.vue
@@ -704,6 +704,7 @@ import api from '../api.js'
 import { useSession } from '../composables/useSession'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { useLocale } from '../composables/useLocale'
+import { formatDate } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -861,12 +862,6 @@ const showPoweredByToggle = computed({
 function switchTab(key) {
   activeTab.value = key
   router.replace(orgPath(`/admin/${key}`))
-}
-
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
 function providerIconClass(name) {

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -423,6 +423,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -547,12 +548,6 @@ function ciaColorText(v) {
 
 function formatLabel(s) {
   return (s || '').replace(/_/g, ' ')
-}
-
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
 function isOverdue(dateStr) {

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -266,7 +266,7 @@
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Next Review</div>
                           <div class="text-sm" :class="isOverdue(selectedItem.next_review) ? 'text-red-400' : 'text-slate-300'">
-                            {{ formatDate(selectedItem.next_review) || '—' }}
+                            {{ formatDay(selectedItem.next_review) || '—' }}
                           </div>
                         </div>
                         <div v-if="selectedItem.created_at">
@@ -290,7 +290,7 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDate(selectedItem.next_review) }}
+                    Review overdue since {{ formatDay(selectedItem.next_review) }}
                   </div>
 
                   <!-- CIA scores -->
@@ -316,8 +316,8 @@
                   </div>
 
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDate(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDate(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
                   </div>
 
                   <!-- Readings -->
@@ -423,7 +423,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -1153,6 +1153,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -1376,25 +1377,13 @@ function stripMd(text) {
   return String(text).replace(/[#*_`>\[\]]/g, '').replace(/\s+/g, ' ').trim().slice(0, 200)
 }
 
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-}
-
-function formatDateTime(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleString('en-GB', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
+const formatDateTime = (d) => formatDate(d, 'datetime')
 
 function formatDateRange(planned, end) {
-  const sd = planned ? (typeof planned === 'number' ? new Date(planned * 1000) : new Date(planned)) : null
-  const ed = end ? (typeof end === 'number' ? new Date(end * 1000) : new Date(end)) : null
-  const s = sd ? sd.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }) : ''
-  const e = ed ? ed.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }) : ''
+  const s = formatDate(planned, 'dayMonth')
+  const e = formatDate(end, 'dayMonth')
   if (s && e) return `${s} – ${e}`
-  return s || ''
+  return s
 }
 
 function isOverdue(dateStr) {

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -303,7 +303,7 @@
                 </td>
                 <td class="px-5 py-3.5 text-sm text-slate-500 truncate max-w-[160px]">{{ resolveUserName(f.owner) }}</td>
                 <td class="px-5 py-3.5 text-sm" :class="isOverdue(f.due_date) && f.status === 'open' ? 'text-red-400 font-medium' : 'text-slate-500'">
-                  {{ f.due_date ? formatDate(f.due_date) : '-' }}
+                  {{ f.due_date ? formatDay(f.due_date) : '-' }}
                 </td>
                 <td class="px-5 py-3.5"><StatusBadge :status="f.status" /></td>
               </tr>
@@ -882,7 +882,7 @@
                         <span class="text-sm font-medium text-slate-200 flex-1 truncate min-w-0">{{ f.title }}</span>
                         <span v-if="f.audit_item_id" class="text-[10px] text-slate-500 font-mono">item #{{ f.audit_item_id }}</span>
                         <span v-if="isOverdue(f.due_date) && f.status === 'open'" class="text-[10px] px-1.5 py-0.5 rounded bg-red-900/60 text-red-300 font-semibold tracking-wider uppercase">Overdue</span>
-                        <span v-if="f.due_date" class="text-xs text-slate-500">{{ formatDate(f.due_date) }}</span>
+                        <span v-if="f.due_date" class="text-xs text-slate-500">{{ formatDay(f.due_date) }}</span>
                         <StatusBadge :status="f.status" />
                       </div>
                     </div>
@@ -1058,7 +1058,7 @@
                       <div>
                         <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Due date</div>
                         <div class="text-sm" :class="isOverdue(selectedFinding.due_date) && selectedFinding.status === 'open' ? 'text-red-400 font-medium' : 'text-slate-300'">
-                          {{ selectedFinding.due_date ? formatDate(selectedFinding.due_date) : '—' }}
+                          {{ selectedFinding.due_date ? formatDay(selectedFinding.due_date) : '—' }}
                         </div>
                       </div>
                       <div v-if="selectedFinding.created_at">
@@ -1153,7 +1153,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -1380,8 +1380,8 @@ function stripMd(text) {
 const formatDateTime = (d) => formatDate(d, 'datetime')
 
 function formatDateRange(planned, end) {
-  const s = formatDate(planned, 'dayMonth')
-  const e = formatDate(end, 'dayMonth')
+  const s = formatDay(planned, 'dayMonth')
+  const e = formatDay(end, 'dayMonth')
   if (s && e) return `${s} – ${e}`
   return s
 }

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -425,6 +425,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 
@@ -516,12 +517,6 @@ function priorityClass(p) {
     case 'low': return 'bg-slate-500/15 text-slate-400'
     default: return 'bg-slate-500/15 text-slate-400'
   }
-}
-
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
 async function selectChange(cr) {

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -161,7 +161,7 @@
             <span v-if="ca.assignee" class="text-xs text-slate-500 truncate max-w-[160px]">{{ resolveUserName(ca.assignee) }}</span>
             <!-- Due date -->
             <span v-if="ca.due_date" class="text-xs" :class="isOverdue(ca.due_date) && ca.status !== 'resolved' ? 'text-red-400' : 'text-slate-600'">
-              {{ ca.due_date }}
+              {{ formatDate(ca.due_date) }}
             </span>
             <!-- ID -->
             <span class="text-xs text-slate-600 font-mono">{{ ca.identifier }}</span>
@@ -421,6 +421,7 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { renderMarkdown } from '../composables/useRenderMd.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 
@@ -894,15 +895,5 @@ function severityClass(sev) {
   }
 }
 
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
-}
-
-function formatDateTime(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleString('en-GB', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
+const formatDateTime = (d) => formatDate(d, 'datetime')
 </script>

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -161,7 +161,7 @@
             <span v-if="ca.assignee" class="text-xs text-slate-500 truncate max-w-[160px]">{{ resolveUserName(ca.assignee) }}</span>
             <!-- Due date -->
             <span v-if="ca.due_date" class="text-xs" :class="isOverdue(ca.due_date) && ca.status !== 'resolved' ? 'text-red-400' : 'text-slate-600'">
-              {{ formatDate(ca.due_date) }}
+              {{ formatDay(ca.due_date) }}
             </span>
             <!-- ID -->
             <span class="text-xs text-slate-600 font-mono">{{ ca.identifier }}</span>
@@ -285,7 +285,7 @@
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Due date</div>
-                          <div class="text-sm" :class="selectedCA.due_date && isOverdue(selectedCA.due_date) && selectedCA.status !== 'resolved' ? 'text-red-400' : 'text-slate-300'">{{ selectedCA.due_date ? formatDate(selectedCA.due_date) : '—' }}</div>
+                          <div class="text-sm" :class="selectedCA.due_date && isOverdue(selectedCA.due_date) && selectedCA.status !== 'resolved' ? 'text-red-400' : 'text-slate-300'">{{ selectedCA.due_date ? formatDay(selectedCA.due_date) : '—' }}</div>
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
@@ -421,7 +421,7 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { renderMarkdown } from '../composables/useRenderMd.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -536,6 +536,7 @@ import StatusBadge from '../components/StatusBadge.vue'
 import HeatMap from '../components/HeatMap.vue'
 import OverdueItems from '../components/OverdueItems.vue'
 import { useCurrentOrg, orgEntryURL, isSubdomainMode } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -763,16 +764,6 @@ function typeStats(t) {
 }
 
 // --- Utilities ---
-
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  })
-}
 
 // --- Data fetch ---
 

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -463,7 +463,7 @@
               <span v-if="activeDoc.status">{{ activeDoc.status }}</span>
               <span v-if="activeDoc.author"> &mdash; Author: {{ resolveUserName(activeDoc.author) || activeDoc.author }}</span>
               <span> &mdash; {{ activeId }}</span>
-              <span> &mdash; Printed {{ new Date().toLocaleDateString() }}</span>
+              <span> &mdash; Printed {{ formatDateValue(Date.now()) }}</span>
             </div>
           </div>
 
@@ -1357,6 +1357,7 @@ import { ref, reactive, computed, watch, onMounted, nextTick, onBeforeUnmount, d
 import { useRoute, useRouter } from 'vue-router'
 import { buildContentBlocks } from '../utils/contentBlocks.js'
 import DOMPurify from 'dompurify'
+import { formatDate as formatDateValue, formatRecent } from '../composables/useFormat.js'
 const sanitize = (html) => DOMPurify.sanitize(html, { ADD_ATTR: ['style', 'data-ref-type', 'data-ref-id'] })
 
 // Render [[TYPE:ID|Title]] reference links as styled pills
@@ -1681,7 +1682,7 @@ const docNextReview = computed(() => {
   if (isNaN(approved.getTime())) return null
   const next = new Date(approved)
   next.setMonth(next.getMonth() + cycle)
-  return next.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  return formatDateValue(next)
 })
 
 const docReviewOverdue = computed(() => {
@@ -2510,21 +2511,7 @@ async function resolveComment(id) {
   }
 }
 
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  try {
-    const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-    const now = new Date()
-    const diff = now - d
-    if (diff < 60000) return 'just now'
-    if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
-    if (diff < 604800000) return `${Math.floor(diff / 86400000)}d ago`
-    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
-  } catch {
-    return dateStr
-  }
-}
+const formatDate = (dateStr) => formatRecent(dateStr)
 
 // Reload review progress when content blocks change (new doc loaded)
 watch(() => [activeId.value, contentBlocks.value.length], () => {

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -355,7 +355,7 @@
               class="text-xs flex-shrink-0 w-24 text-right"
               :class="isOverdue(task) ? 'text-red-400 font-medium' : 'text-slate-500'"
             >
-              {{ formatDate(task.due_date) }}
+              {{ formatDay(task.due_date) }}
               <span v-if="isOverdue(task)" class="block text-[10px] text-red-500">OVERDUE</span>
             </span>
 
@@ -419,7 +419,7 @@
             <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 flex-shrink-0">{{ (ca.severity || '').replace(/_/g, ' ') }}</span>
             <span class="text-xs text-slate-500 flex-shrink-0 capitalize w-32 truncate text-right">{{ (ca.source || '').replace(/_/g, ' ') }}</span>
             <span v-if="ca.due_date" class="text-xs flex-shrink-0 w-24 text-right" :class="isOverdue(ca) ? 'text-red-400 font-medium' : 'text-slate-500'">
-              {{ formatDate(ca.due_date) }}
+              {{ formatDay(ca.due_date) }}
               <span v-if="isOverdue(ca)" class="block text-[10px] text-red-500">OVERDUE</span>
             </span>
             <StatusBadge :status="ca.status" class="flex-shrink-0" />
@@ -725,7 +725,7 @@ import { useConfirm } from '../composables/useConfirm'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate as formatDateValue } from '../composables/useFormat.js'
+import { formatDate as formatDateValue, formatDay as formatDayValue } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -905,6 +905,10 @@ function resolveUserName(email) {
 // an empty string; only that choice stays local.
 function formatDate(dateStr) {
   return formatDateValue(dateStr) || '-'
+}
+
+function formatDay(dateStr) {
+  return formatDayValue(dateStr) || '-'
 }
 
 function isOverdue(task) {

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -725,6 +725,7 @@ import { useConfirm } from '../composables/useConfirm'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate as formatDateValue } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -900,10 +901,10 @@ function resolveUserName(email) {
 }
 
 // ---------- Helpers ----------
+// The table renders a dash for a missing date, where the shared seam returns
+// an empty string; only that choice stays local.
 function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return '-'
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  return formatDateValue(dateStr) || '-'
 }
 
 function isOverdue(task) {

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -539,6 +539,7 @@ import { useToast } from '../composables/useToast.js'
 import { useConfirm } from '../composables/useConfirm.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -886,15 +887,5 @@ function typeClass(type_) {
   }
 }
 
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
-}
-
-function formatDateTime(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleString('en-GB', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
+const formatDateTime = (d) => formatDate(d, 'datetime')
 </script>

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -505,6 +505,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -630,12 +631,6 @@ function scoreColor(score) {
 }
 
 function formatLabel(s) { return (s || '').replace(/_/g, ' ') }
-
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
-}
 
 function isOverdue(dateStr) {
   if (!dateStr) return false

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -386,7 +386,7 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDate(selectedItem.next_review) }}
+                    Review overdue since {{ formatDay(selectedItem.next_review) }}
                   </div>
                   <div class="flex items-center gap-4">
                     <div class="flex gap-3 flex-1">
@@ -398,8 +398,8 @@
                     </div>
                   </div>
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDate(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDate(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
                   </div>
                   <div class="border-t border-slate-800 pt-4">
                     <ReadingsPanel entityType="legal_requirement" :entityId="selectedItem.id" :identifier="selectedItem.identifier || ('LEGAL-' + selectedItem.id)" :canWrite="canWrite"
@@ -505,7 +505,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -510,6 +510,7 @@ import StatusBadge from '../components/StatusBadge.vue'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -605,17 +606,7 @@ function opSymbol(op) {
   return map[op] || op
 }
 
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
-}
-
-function formatDateTime(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleString('en-GB', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
+const formatDateTime = (d) => formatDate(d, 'datetime')
 
 function formatBytes(bytes) {
   if (!bytes) return ''

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -274,6 +274,7 @@ import HistoryPanel from '../components/HistoryPanel.vue'
 import Pagination from '../components/Pagination.vue'
 import ListSkeleton from '../components/ListSkeleton.vue'
 import RefreshButton from '../components/RefreshButton.vue'
+import { formatDate } from '../composables/useFormat.js'
 
 const route = useRoute()
 const router = useRouter()
@@ -340,12 +341,6 @@ const paged = computed(() => {
 })
 
 watch([searchQuery, pageSize], () => { page.value = 1 })
-
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
-}
 
 async function loadAll() {
   loading.value = true

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -853,6 +853,7 @@ import ListSkeleton from '../components/ListSkeleton.vue'
 import RefreshButton from '../components/RefreshButton.vue'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatRelative } from '../composables/useFormat.js'
 const DocumentEditor = defineAsyncComponent(() => import('../components/DocumentEditor.vue'))
 
 const route = useRoute()
@@ -1239,21 +1240,7 @@ function initial(email) {
   return email.charAt(0).toUpperCase()
 }
 
-function timeAgo(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  const now = new Date()
-  const seconds = Math.floor((now - d) / 1000)
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
-  const months = Math.floor(days / 30)
-  return `${months}mo ago`
-}
+const timeAgo = (dateStr) => formatRelative(dateStr)
 
 // Navigation
 function goToList() {

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -588,7 +588,7 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDate(selectedRisk.next_review) }}
+                    Review overdue since {{ formatDay(selectedRisk.next_review) }}
                   </div>
 
                   <!-- Score summary -->
@@ -612,8 +612,8 @@
                     </div>
                   </div>
                   <div class="flex gap-4 text-[10px] text-slate-500">
-                    <span v-if="selectedRisk.last_review">Last review: {{ formatDate(selectedRisk.last_review) }}</span>
-                    <span v-if="selectedRisk.next_review && !isOverdue(selectedRisk.next_review)">Next review: {{ formatDate(selectedRisk.next_review) }}</span>
+                    <span v-if="selectedRisk.last_review">Last review: {{ formatDay(selectedRisk.last_review) }}</span>
+                    <span v-if="selectedRisk.next_review && !isOverdue(selectedRisk.next_review)">Next review: {{ formatDay(selectedRisk.next_review) }}</span>
                   </div>
 
                   <!-- Readings panel -->
@@ -729,7 +729,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate as formatDateValue } from '../composables/useFormat.js'
+import { formatDate as formatDateValue, formatDay as formatDayValue } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -964,6 +964,10 @@ function formatOrigin(o) {
 // an empty string; only that choice stays local.
 function formatDate(dateStr) {
   return formatDateValue(dateStr) || '-'
+}
+
+function formatDay(dateStr) {
+  return formatDayValue(dateStr) || '-'
 }
 
 const ciaLabel = (v) => ['Not Assessed','Insignificant','Minor','Moderate','Major','Severe'][v] || 'N/A'

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -729,6 +729,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate as formatDateValue } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -959,10 +960,10 @@ function formatOrigin(o) {
   return o ? o.charAt(0).toUpperCase() + o.slice(1) : ''
 }
 
+// The table renders a dash for a missing date, where the shared seam returns
+// an empty string; only that choice stays local.
 function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return '-'
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+  return formatDateValue(dateStr) || '-'
 }
 
 const ciaLabel = (v) => ['Not Assessed','Insignificant','Minor','Moderate','Major','Severe'][v] || 'N/A'

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -231,8 +231,8 @@
               <span v-if="t.revoked_at" class="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">revoked</span>
             </div>
             <div class="text-xs text-slate-500 mt-0.5">
-              Created {{ t.created_at ? (typeof t.created_at === 'number' ? new Date(t.created_at * 1000) : new Date(t.created_at)).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : 'Unknown' }}
-              <span v-if="t.last_used_at" class="ml-2">Last used {{ (typeof t.last_used_at === 'number' ? new Date(t.last_used_at * 1000) : new Date(t.last_used_at)).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) }}</span>
+              Created {{ t.created_at ? formatDate(t.created_at) : 'Unknown' }}
+              <span v-if="t.last_used_at" class="ml-2">Last used {{ formatDate(t.last_used_at) }}</span>
               <span v-else class="ml-2">Never used</span>
             </div>
           </div>
@@ -279,8 +279,8 @@
                 </button>
               </div>
               <div class="text-xs text-slate-500 mt-0.5">
-                Added {{ pk.created_at ? (typeof pk.created_at === 'number' ? new Date(pk.created_at * 1000) : new Date(pk.created_at)).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : 'Unknown' }}
-                <span v-if="pk.last_used_at" class="ml-2">Last used {{ (typeof pk.last_used_at === 'number' ? new Date(pk.last_used_at * 1000) : new Date(pk.last_used_at)).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) }}</span>
+                Added {{ pk.created_at ? formatDate(pk.created_at) : 'Unknown' }}
+                <span v-if="pk.last_used_at" class="ml-2">Last used {{ formatDate(pk.last_used_at) }}</span>
               </div>
             </template>
           </div>
@@ -311,6 +311,7 @@ import { ref, nextTick, onMounted, computed } from 'vue'
 import QRCode from 'qrcode'
 import api from '../api.js'
 import LocalePicker from '../components/LocalePicker.vue'
+import { formatDate } from '../composables/useFormat.js'
 
 const user = ref(null)
 

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -169,7 +169,7 @@
               </td>
               <td class="px-5 py-3.5 text-sm text-slate-400">{{ resolveUserName(supplier.owner) }}</td>
               <td class="px-5 py-3.5 text-sm" :class="isOverdue(supplier.next_review) ? 'text-amber-400 font-medium' : 'text-slate-500'">
-                {{ formatDate(supplier.next_review) || '-' }}
+                {{ formatDay(supplier.next_review) || '-' }}
               </td>
             </tr>
           </tbody>
@@ -302,7 +302,7 @@
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Contract Expiry</div>
-                          <div class="text-sm text-slate-300">{{ formatDate(selectedItem.contract_expiry) || '—' }}</div>
+                          <div class="text-sm text-slate-300">{{ formatDay(selectedItem.contract_expiry) || '—' }}</div>
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Data Access</div>
@@ -344,7 +344,7 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDate(selectedItem.next_review) }}
+                    Review overdue since {{ formatDay(selectedItem.next_review) }}
                   </div>
 
                   <!-- CIA scores -->
@@ -370,8 +370,8 @@
                   </div>
 
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDate(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDate(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
                   </div>
 
                   <!-- Readings -->
@@ -485,7 +485,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -485,6 +485,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -641,12 +642,6 @@ function criticalityChipColor(c) {
 
 function formatLabel(s) {
   return (s || '').replace(/_/g, ' ')
-}
-
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
 function isOverdue(dateStr) {

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -531,6 +531,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
@@ -690,12 +691,6 @@ function rtoColor(hours) {
   if (hours <= 12) return 'text-amber-400'
   if (hours <= 48) return 'text-blue-400'
   return 'text-slate-400'
-}
-
-function formatDate(dateStr) {
-  if (!dateStr && dateStr !== 0) return ''
-  const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
-  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
 function isOverdue(dateStr) {

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -175,7 +175,7 @@
               </td>
               <td class="px-5 py-3.5 text-sm text-slate-400">{{ resolveUserName(sys.owner) }}</td>
               <td class="px-5 py-3.5 text-sm" :class="isOverdue(sys.next_review) ? 'text-amber-400 font-medium' : 'text-slate-500'">
-                {{ formatDate(sys.next_review) || '-' }}
+                {{ formatDay(sys.next_review) || '-' }}
               </td>
             </tr>
           </tbody>
@@ -347,7 +347,7 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDate(selectedItem.next_review) }}
+                    Review overdue since {{ formatDay(selectedItem.next_review) }}
                   </div>
 
                   <!-- CIA scores -->
@@ -373,8 +373,8 @@
                   </div>
 
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDate(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDate(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
                   </div>
 
                   <!-- Readings -->
@@ -531,7 +531,7 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -147,7 +147,7 @@
               <div class="text-xs text-slate-500 mt-1">
                 <span v-if="task.assignee">{{ resolveUserName(task.assignee) }}</span>
                 <span v-if="task.due_date" class="ml-2" :class="isOverdue(task) ? 'text-red-400' : ''">
-                  Due {{ formatDate(task.due_date) }}
+                  Due {{ formatDay(task.due_date) }}
                   <span v-if="isOverdue(task)" class="text-red-400 font-semibold ml-1">OVERDUE</span>
                 </span>
                 <span v-if="task.created_by" class="ml-2 text-slate-600">by {{ resolveUserName(task.created_by) }}</span>
@@ -277,7 +277,7 @@
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Due date</div>
-                          <div class="text-sm" :class="isOverdue(selectedTask) ? 'text-red-400' : 'text-slate-300'">{{ selectedTask.due_date ? formatDate(selectedTask.due_date) : '—' }}</div>
+                          <div class="text-sm" :class="isOverdue(selectedTask) ? 'text-red-400' : 'text-slate-300'">{{ selectedTask.due_date ? formatDay(selectedTask.due_date) : '—' }}</div>
                         </div>
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
@@ -418,7 +418,7 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { renderMarkdown } from '../composables/useRenderMd.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatDay } from '../composables/useFormat.js'
 
 const { ask, confirm: confirmDialog } = useConfirm()
 const { success: showSaved, error: showError } = useToast()

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -418,6 +418,7 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { renderMarkdown } from '../composables/useRenderMd.js'
+import { formatDate } from '../composables/useFormat.js'
 
 const { ask, confirm: confirmDialog } = useConfirm()
 const { success: showSaved, error: showError } = useToast()
@@ -516,12 +517,6 @@ function isOverdue(task) {
   if (!task.due_date || task.status === 'done' || task.status === 'cancelled') return false
   const d = typeof task.due_date === 'number' ? new Date(task.due_date * 1000) : new Date(task.due_date)
   return d < new Date()
-}
-
-function formatDate(d) {
-  if (!d && d !== 0) return ''
-  const dt = typeof d === 'number' ? new Date(d * 1000) : new Date(d)
-  return dt.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
 function epochToDateStr(d) {

--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -3,7 +3,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { enumLabel } from '../src/composables/useEnumLabel.js'
-import { formatDate, formatNumber, formatRecent, formatRelative, useFormat } from '../src/composables/useFormat.js'
+import { formatDate, formatDay, formatNumber, formatRecent, formatRelative, useFormat } from '../src/composables/useFormat.js'
 import { i18n } from '../src/i18n.js'
 
 test('enum labels come from the catalogue, and de-slug only as a fallback', () => {
@@ -41,8 +41,9 @@ test('epoch numbers are read as seconds or milliseconds by magnitude', () => {
   assert.equal(formatDate(ms / 1000, 'datetime'), formatDate(ms, 'datetime'))
   assert.equal(formatDate(ms / 1000), formatDate(iso))
   // 0 is the epoch, not "no value" — the callers this replaced all special-cased
-  // it back in with `!d && d !== 0`.
-  assert.match(formatDate(0), /1970/)
+  // it back in with `!d && d !== 0`. Asserted through formatDay so the
+  // expectation does not depend on the machine's timezone.
+  assert.equal(formatDay(0), '1 Jan 1970')
 })
 
 test('English formats British, so adopting the seam keeps the shape the UI had', () => {
@@ -71,10 +72,49 @@ test('recent timestamps read as relative, older ones pin to a date', () => {
   assert.equal(formatRecent(null), '')
 })
 
+test('a DATE column keeps its calendar day in every timezone', () => {
+  // Postgres DATE arrives as epoch seconds at midnight UTC. Formatted in a
+  // zone west of UTC that instant is still the previous evening, so the plain
+  // date formatter moves a 5 Aug due date to 4 Aug for the whole of the
+  // Americas — which is where this project's pt-BR users are.
+  const midnightUTC = Date.UTC(2026, 7, 5) / 1000
+  const westOfUTC = new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeZone: 'America/Sao_Paulo',
+  }).format(new Date(midnightUTC * 1000))
+  assert.equal(westOfUTC, '4 Aug 2026') // the shift this guards against
+  assert.equal(formatDay(midnightUTC), '5 Aug 2026')
+  assert.equal(formatDay(midnightUTC, 'dayMonth'), '5 Aug')
+  assert.equal(formatDay(null), '')
+})
+
+test('the active locale drives every shape, not just the English fallback', async () => {
+  // The point of the whole seam: switching locale must change the output. An
+  // English-only assertion would still pass if the locale stopped being read.
+  const previous = i18n.global.locale.value
+  // Intl needs the tag, not the message bundle, so no loader is involved here.
+  i18n.global.locale.value = 'id-ID'
+  try {
+    assert.equal(formatDate('2026-08-05T14:30:00Z'), '5 Agu 2026')
+    // Indonesian separates hours from minutes with a dot.
+    assert.match(formatDate('2026-08-05T14:30:00Z', 'datetime'), /5 Agu 2026, \d{2}\.\d{2}/)
+    assert.equal(formatDay(Date.UTC(2026, 7, 5) / 1000), '5 Agu 2026')
+    const now = Date.parse('2026-08-24T12:00:00Z')
+    assert.equal(formatRelative(new Date(now - 5 * 60 * 1000), now), '5 menit yang lalu')
+    assert.equal(formatRelative(new Date(now - 24 * 60 * 60 * 1000), now), 'kemarin')
+    assert.equal(formatNumber(1234.5, { maximumFractionDigits: 1 }), '1.234,5')
+  } finally {
+    i18n.global.locale.value = previous
+  }
+  // …and the switch is not sticky.
+  assert.equal(formatDate('2026-08-05T14:30:00Z'), '5 Aug 2026')
+})
+
 test('useFormat exposes the seam under the names the contract documents', () => {
-  const { date, number, relative, recent } = useFormat()
+  const { date, day, number, relative, recent } = useFormat()
   assert.equal(typeof date, 'function')
   assert.equal(typeof number, 'function')
   assert.equal(typeof relative, 'function')
+  assert.equal(typeof day, 'function')
   assert.equal(typeof recent, 'function')
 })

--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -3,7 +3,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { enumLabel } from '../src/composables/useEnumLabel.js'
-import { formatDate, formatNumber, formatRelative, useFormat } from '../src/composables/useFormat.js'
+import { formatDate, formatNumber, formatRecent, formatRelative, useFormat } from '../src/composables/useFormat.js'
 import { i18n } from '../src/i18n.js'
 
 test('enum labels come from the catalogue, and de-slug only as a fallback', () => {
@@ -61,9 +61,20 @@ test('relative time picks the largest fitting unit in both directions', () => {
   assert.equal(formatRelative(null), '')
 })
 
+test('recent timestamps read as relative, older ones pin to a date', () => {
+  const DAY = 24 * 60 * 60 * 1000
+  assert.equal(formatRecent(Date.now() - 2 * 60 * 60 * 1000), '2 hours ago')
+  // Past the surface's threshold the wording gives way to an absolute date, so
+  // a year-old item does not read "12 months ago".
+  assert.equal(formatRecent('2020-08-24T10:30:00Z'), '24 Aug 2020')
+  assert.equal(formatRecent(Date.now() - 2 * DAY, { within: DAY }), formatDate(Date.now() - 2 * DAY))
+  assert.equal(formatRecent(null), '')
+})
+
 test('useFormat exposes the seam under the names the contract documents', () => {
-  const { date, number, relative } = useFormat()
+  const { date, number, relative, recent } = useFormat()
   assert.equal(typeof date, 'function')
   assert.equal(typeof number, 'function')
   assert.equal(typeof relative, 'function')
+  assert.equal(typeof recent, 'function')
 })

--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -33,6 +33,25 @@ test('dates and numbers format through Intl, and reject unusable input', () => {
   assert.equal(formatNumber('12'), '')
 })
 
+test('epoch numbers are read as seconds or milliseconds by magnitude', () => {
+  const iso = '2026-08-24T10:30:00Z'
+  const ms = Date.parse(iso)
+  // The API writes seconds; Date.now() arithmetic produces milliseconds. Both
+  // reach these helpers and must land on the same instant.
+  assert.equal(formatDate(ms / 1000, 'datetime'), formatDate(ms, 'datetime'))
+  assert.equal(formatDate(ms / 1000), formatDate(iso))
+  // 0 is the epoch, not "no value" — the callers this replaced all special-cased
+  // it back in with `!d && d !== 0`.
+  assert.match(formatDate(0), /1970/)
+})
+
+test('English formats British, so adopting the seam keeps the shape the UI had', () => {
+  // The message bundle is tagged `en`; bare `en` would order dates US-style.
+  assert.equal(formatDate('2026-08-24T10:30:00Z'), '24 Aug 2026')
+  assert.equal(formatDate('2026-08-24T10:30:00Z', 'dayMonth'), '24 Aug')
+  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonthTime'), /^24 Aug, \d{2}:\d{2}$/)
+})
+
 test('relative time picks the largest fitting unit in both directions', () => {
   const now = Date.parse('2026-08-24T12:00:00Z')
   const at = (ms) => formatRelative(new Date(now + ms), now)


### PR DESCRIPTION
Part of the web i18n foundation for #212. Until now, choosing a non-English locale translated the interface but left **every date in English** — a Brazilian or Indonesian user saw `24 Aug 2026` on every table, timeline and audit plan. This closes that gap.

## Before and after

Same instant throughout: 5 August 2026, 14:30 UTC. "Before" is what the app printed for *every* user, in every language, because the format was hardcoded.

| Where it appears | Before (all languages) | After — English | After — Indonesian |
|---|---|---|---|
| Table and detail dates | `05 Aug 2026` | `5 Aug 2026` | `5 Agu 2026` |
| Date with time | `05 Aug 2026, 14:30` | `5 Aug 2026, 14:30` | `5 Agu 2026, 14.30` |
| Comment timelines, audit ranges | `5 Aug` | `5 Aug` | `5 Agu` |
| A few minutes ago | `5m ago` | `5 minutes ago` | `5 menit yang lalu` |
| A few hours ago | `3h ago` | `3 hours ago` | `3 jam yang lalu` |
| Yesterday | `1d ago` | `yesterday` | `kemarin` |

Note the Indonesian time separator (`14.30`, not `14:30`) — that is the Indonesian convention, and it comes for free from formatting in the user's language rather than being something anyone has to translate. The same applies to any language added later: Portuguese would print `5 de ago. de 2026` and `há 5 minutos` with no extra work.

## What changes for users

- Dates and times follow the user's chosen language, including the ordering and punctuation conventions each language expects.
- Relative timestamps are translated too. They previously could not be: the app built those phrases by gluing English fragments together, so no translation file could reach them.
- Two bugs fixed on the way. The Corrective Actions list showed a raw number instead of a due date. And every calendar date — due dates, next reviews, audit plan dates — displayed **one day early for anyone west of UTC**, Brazil included: a 5 August due date read 4 August in São Paulo. That one predates this PR, but it lives in the code this PR replaces, so it is fixed here.

## Why it was a larger change than "translate the dates"

There was already a shared date-formatting helper, added in an earlier PR — but nothing used it. Twenty-seven screens each carried their own copy of the formatting logic, every one of them pinned to British English, and six screens carried their own hand-written "5m ago" logic on top. This PR deletes all of those and routes every screen through the one shared helper, which reads the active language.

That is the durable part: adding the third and fourth languages now costs a translation file, not another sweep through twenty-seven screens.

**Net effect: 30 files, 243 lines removed, 85 added.**

## Two visible changes worth knowing about

Both are intended, and neither is a defect — they are the two rows in the table where the English column differs from "before":

- Relative times read `5 minutes ago` rather than `5m ago`. The abbreviated form was the untranslatable one. Text is slightly longer.
- Single-digit days lose their leading zero: `5 Aug 2026` rather than `05 Aug 2026`.

One deliberate restraint: an old item still shows an absolute date rather than "3 months ago". Recent items read relative, older ones pin to a date — the existing behaviour, preserved. Changing that would be a product decision, not a translation one.

## Verification

- Automated test suite: 109 tests pass, 5 of them new, covering the date shapes above and the two timestamp formats the API sends.
- Production build: clean.
- Repository-wide search confirms no screen formats a date on its own any more, and every date call in the 27 changed screens resolves correctly — a check worth calling out because the build alone would not catch a broken one; it would only fail when a user opened that page.

## Not included

Three smaller items in the same foundation remain open and are deliberately kept to separate PRs: country names (which needs a check for stored data first, and possibly a data migration), the confirm-dialog button labels, and a CI guard against new hardcoded English text.