### PR TITLE
docs: fix the README build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,12 @@ See [Architecture](docs/architecture.md) for details on the core vs templates sp
 ### Build
 
 ```bash
-go build -o isms ./cmd/isms/
+just build
 ```
+
+This builds the Vue web UI and embeds it into the `isms` binary. `bin/isms` is the
+result. (A bare `go build ./cmd/isms/` will not work — the binary embeds the built
+web UI, so the frontend has to be built first.)
 
 ### Setup
 


### PR DESCRIPTION
Fixes #237.

The README's Build section said `go build -o isms ./cmd/isms/`. That fails: `cmd/isms/embed_web.go` embeds `cmd/isms/web/dist/`, gitignored build output that only exists after `just build-web` has run. Now says `just build`.