### PR TITLE
test(e2e): fix the flaky review-approval test that was randomly failing CI

### DIFF
--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -286,7 +286,10 @@ class TestReviewTwo:
             page.get_by_role("button", name="Approve").click()
             page.locator('button:has-text("Confirm Approve")').wait_for(state="visible", timeout=5000)
             page.locator('button:has-text("Confirm Approve")').click()
-            page.locator("text=/recorded|[Aa]pproved/").first.wait_for(state="visible", timeout=10000)
+            # Per-reviewer confirmation, rendered only once this user's own
+            # assignment status flips to approved. NOT the sidebar's static
+            # "Approved: n of m" label, which is on the page from first paint.
+            page.locator("text=You approved this round.").first.wait_for(state="visible", timeout=10000)
         finally:
             ctx.close()
 
@@ -300,7 +303,10 @@ class TestReviewTwo:
             page.get_by_role("button", name="Approve").click()
             page.locator('button:has-text("Confirm Approve")').wait_for(state="visible", timeout=5000)
             page.locator('button:has-text("Confirm Approve")').click()
-            page.locator("text=/recorded|[Aa]pproved/").first.wait_for(state="visible", timeout=10000)
+            # Per-reviewer confirmation, rendered only once this user's own
+            # assignment status flips to approved. NOT the sidebar's static
+            # "Approved: n of m" label, which is on the page from first paint.
+            page.locator("text=You approved this round.").first.wait_for(state="visible", timeout=10000)
         finally:
             ctx.close()
 

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -4,6 +4,7 @@ Requires: pip install playwright && playwright install chromium
 Run:      pytest tests/test_e2e_browser.py -v
 """
 import os, pytest, importlib
+import time
 import uuid
 import requests
 
@@ -69,6 +70,23 @@ def click_sidebar(page, label):
 
 def wait_for(page, text, timeout=8000):
     page.locator(f"text={text}").first.wait_for(state="visible", timeout=timeout)
+
+def wait_review_status(rid, token, status, timeout=15.0):
+    """Poll the API until a review reaches `status`.
+
+    Browser-driven approvals fire an async POST; a UI text assertion can pass
+    before the request lands (or while it is still in flight, in which case
+    closing the browser context cancels it server-side). Always gate a
+    follow-up API call on the real state, never on rendered copy.
+    """
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = api("get", f"/reviews/{rid}", token, expect_status=200).json().get("status")
+        if last == status:
+            return
+        time.sleep(0.25)
+    raise AssertionError(f"review {rid} never reached status {status!r} (last: {last!r})")
 
 # ── Fixtures ──
 
@@ -286,6 +304,10 @@ class TestReviewTwo:
         finally:
             ctx.close()
 
+        # Both approvals must have landed server-side before the merge step —
+        # closing the context above can cancel an approve POST still in flight.
+        wait_review_status(rid, t, "approved")
+
         # Merge — R2's approval may take a moment to propagate, so reload if needed
         ctx = pw_browser.new_context(viewport={"width": 1440, "height": 900})
         page = ctx.new_page()
@@ -380,12 +402,14 @@ class TestReviewRoundUX:
             page.get_by_role("button", name="Approve").click()
             page.locator('button:has-text("Confirm Approve")').wait_for(state="visible", timeout=5000)
             page.locator('button:has-text("Confirm Approve")').click()
-            # Feedback message should mention Round 2 or show approval confirmation
-            page.locator("text=/Round 2|approved|Approved|recorded/").first.wait_for(state="visible", timeout=10000)
+            # Approval feedback. NOT "Round 2" — that badge is already in the
+            # header from step 1, so matching it would make this wait a no-op.
+            page.locator("text=/Ready to merge|has been recorded/").first.wait_for(state="visible", timeout=10000)
         finally:
             ctx.close()
 
-        # Cleanup: merge via API
+        # Cleanup: merge via API — gate on real state, not on the rendered copy above.
+        wait_review_status(rid2, t, "approved")
         api("post", f"/reviews/{rid2}/merge", t, json={}, expect_status=200)
 
 # ── Suppliers (browser) ──

--- a/tests/test_e2e_browser.py
+++ b/tests/test_e2e_browser.py
@@ -303,10 +303,12 @@ class TestReviewTwo:
             page.get_by_role("button", name="Approve").click()
             page.locator('button:has-text("Confirm Approve")').wait_for(state="visible", timeout=5000)
             page.locator('button:has-text("Confirm Approve")').click()
-            # Per-reviewer confirmation, rendered only once this user's own
-            # assignment status flips to approved. NOT the sidebar's static
-            # "Approved: n of m" label, which is on the page from first paint.
-            page.locator("text=You approved this round.").first.wait_for(state="visible", timeout=10000)
+            # R2 is the last reviewer, so their approval flips the review to
+            # `approved` and the reviewer panel is replaced by the approved
+            # branch — "You approved this round." never renders for them.
+            # Every "Ready to merge" in Reviews.vue is gated on that status
+            # (lines 414, 1495), so it cannot appear before this POST lands.
+            page.locator("text=Ready to merge").first.wait_for(state="visible", timeout=10000)
         finally:
             ctx.close()
 


### PR DESCRIPTION
## What was going wrong

Our automated test suite has been failing at random on the `master` branch — the same test passing one run and failing the next, with no code change in between. Most recently it blocked the build with:

> `POST /reviews/11/merge: 400 review must be approved before merging`

That kind of intermittent red build is expensive: it makes people distrust CI, it prompts "just re-run it" as a reflex, and it hides the moment a *real* regression shows up.

**There is no bug in the product.** Reviews, approvals and merges all work correctly. The defect was in the tests themselves.

## Why it happened

The affected tests drive a real browser: a reviewer logs in, opens a document review, and clicks Approve. Each test was then supposed to wait for the on-screen confirmation before continuing.

They waited for the wrong thing. They watched for wording that is already on the page before anyone clicks anything — a "Round 2" badge in the header in one test, and a permanent "Approved: 1 of 2" counter in the review sidebar in the other. Those matched instantly, so the waits returned without actually waiting for the approval to finish.

Each test then closed the browser, which cut off the approval request mid-flight, and went on to merge a review that had never been approved. Hence the error.

Whether this failed came down to raw timing — on a fast CI machine the approval squeaked through, on a loaded one it did not. That is exactly why it looked random.

## What this changes

Three things, all confined to the test file — no product code is touched:

1. Each test now waits for wording that only appears *after* an approval genuinely succeeds: the "ready to merge" confirmation in one, and the reviewer's own "You approved this round" message in the other. Both are driven by the reviewer's real recorded decision, so neither can appear early.
2. Before merging, the tests now ask the server directly whether the review is approved, and wait until it is. Checking actual system state rather than what happens to be rendered on screen makes them immune to this whole class of timing failure.
3. Both affected tests get both protections, so neither can fail this way again.

The second change also future-proofs the suite: our in-flight internationalisation work is rewriting a lot of on-screen wording, and tests that hinge on exact English phrasing would start breaking as those translations land.

## Risk and validation

Low risk — test-only, no shipped behaviour changes. CI on this branch is the validation: the previously flaky tests should now pass consistently.