### PR TITLE
fix(web): send org slug on password login

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -149,9 +149,10 @@ async function uploadFile(url, file, extraFields = {}) {
 // enabled, the first call (without `otp`) returns `{otp_required: true}` with
 // an empty token — the caller must prompt for the code and call login again
 // with the otp argument.
-async function login(email, password, otp) {
+async function login(email, password, otp, organization) {
   const body = { email, password }
   if (otp) body.otp = otp
+  if (organization) body.organization = organization
   const res = await fetch(`${API}/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -265,6 +265,13 @@ function base64urlToBuffer(base64url) {
   return bytes.buffer
 }
 
+// route.query.redirect is a string, unless the URL repeats ?redirect=, in
+// which case vue-router gives an array — normalize to the first value.
+function firstRedirect(query) {
+  const r = query.redirect
+  return Array.isArray(r) ? r[0] : r
+}
+
 function getOrgSlug() {
   // 1. URL query param (?org=acme)
   const params = new URLSearchParams(window.location.search)
@@ -277,6 +284,17 @@ function getOrgSlug() {
   // 3. Route path (/acme/login → acme) — only used on apex/localhost
   const pathParts = window.location.pathname.split('/').filter(Boolean)
   if (pathParts.length >= 2 && pathParts[1] === 'login') return pathParts[0]
+
+  // 4. The org implied by a bounced destination (?redirect=/acme/documents).
+  //    The router guard sends deep links to the bare /login, so this is the
+  //    only place the org survives. Ask the router rather than splitting the
+  //    path: it is the authority on which routes are org-scoped, and in
+  //    subdomain mode none of them are.
+  const redirect = params.get('redirect')
+  if (redirect) {
+    const org = router.resolve(redirect).params.org
+    if (org) return org
+  }
 
   // No localStorage fallback — org context must come from URL/subdomain only.
   // Anything else leaks state between orgs (e.g. visiting isms.sh after being
@@ -292,7 +310,7 @@ function goToOrg() {
   // If the host can serve tenant subdomains (apex like isms.sh or already on a
   // subdomain), hop to <slug>.<apex>/login. Otherwise stay path-based.
   if (canHostSubdomain(window.location.hostname)) {
-    const redirectPath = route.query.redirect
+    const redirectPath = firstRedirect(route.query)
     const suffix = '/login' + (redirectPath ? `?redirect=${encodeURIComponent(redirectPath)}` : '')
     window.location.href = orgEntryURL(slug, suffix)
     return
@@ -303,7 +321,7 @@ function goToOrg() {
 
 async function redirectAfterLogin() {
   // Check for a redirect query param first
-  const redirectPath = route.query.redirect
+  const redirectPath = firstRedirect(route.query)
   if (redirectPath && redirectPath !== '/overview' && redirectPath.startsWith('/')) {
     router.push(redirectPath)
     return

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -292,7 +292,9 @@ function goToOrg() {
   // If the host can serve tenant subdomains (apex like isms.sh or already on a
   // subdomain), hop to <slug>.<apex>/login. Otherwise stay path-based.
   if (canHostSubdomain(window.location.hostname)) {
-    window.location.href = orgEntryURL(slug, '/login')
+    const redirectPath = route.query.redirect
+    const suffix = '/login' + (redirectPath ? `?redirect=${encodeURIComponent(redirectPath)}` : '')
+    window.location.href = orgEntryURL(slug, suffix)
     return
   }
   // Path-based — set slug locally and re-render the login form in org context.
@@ -428,7 +430,7 @@ async function handleLogin() {
   error.value = ''
   loading.value = true
   try {
-    const res = await login(email.value, password.value, otpCode.value || undefined)
+    const res = await login(email.value, password.value, otpCode.value || undefined, orgSlug.value || undefined)
     if (res.otp_required) {
       // Backend wants a TOTP code — show the input and stop here.
       otpRequired.value = true

--- a/web/test/apiLogin.test.js
+++ b/web/test/apiLogin.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://acme-logistics.example/login' })
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+globalThis.localStorage = dom.window.localStorage
+
+// Regression: on a path-based (non-subdomain) deployment, a user who belongs
+// to more than one org would get bounced back to the org picker after a
+// correct password login, because the request never told the backend which
+// org they meant to log into — it silently relied on the backend's
+// exactly-one-org auto-select fallback. Login.vue knows the org (the visitor
+// typed or navigated it in), it just wasn't being sent.
+test('login() sends the org slug when one is known', async () => {
+  let capturedBody = null
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body)
+    return {
+      ok: true,
+      json: async () => ({ token: 't', email: 'a@b.com' }),
+    }
+  }
+
+  const { login } = await import('../src/api.js')
+  await login('a@b.com', 'pw', undefined, 'acme-logistics')
+
+  assert.equal(capturedBody.organization, 'acme-logistics')
+})
+
+test('login() omits organization when none is known', async () => {
+  let capturedBody = null
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body)
+    return {
+      ok: true,
+      json: async () => ({ token: 't', email: 'a@b.com' }),
+    }
+  }
+
+  const { login } = await import('../src/api.js')
+  await login('a@b.com', 'pw', undefined, undefined)
+
+  assert.equal('organization' in capturedBody, false)
+})

--- a/web/test/loginOrgSlug.test.js
+++ b/web/test/loginOrgSlug.test.js
@@ -1,0 +1,99 @@
+// Regression coverage for #241 review finding F1/F2: the router guard bounces
+// an unauthenticated deep link (e.g. /acme/documents) to the BARE /login with
+// ?redirect=/acme/documents — not /acme/login — so Login.vue's getOrgSlug()
+// has to recover the org from the redirect target, and the org it recovers
+// has to actually reach the login request (Login.vue:handleLogin -> api.js's
+// login()), not just live in a local variable.
+//
+// getOrgSlug() is transplanted verbatim (see router.test.js for the same
+// convention and its caveat: this is a copy, not an import — Login.vue
+// imports .vue components and browser globals that this harness doesn't
+// load under `node --test`). login() itself is the REAL implementation from
+// src/api.js, imported normally, so the request-body assertion below is not
+// testing a copy on both ends.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://isms.example/login' })
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+globalThis.localStorage = dom.window.localStorage
+
+const C = { render: () => null }
+function buildRouter(subdomainMode) {
+  const orgRoutes = subdomainMode
+    ? [{ path: '/documents', component: C }, { path: '/documents/:docId', component: C }]
+    : [{ path: '/:org/documents', component: C }, { path: '/:org/documents/:docId', component: C }]
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: C },
+      { path: '/login', component: C },
+      { path: '/organizations', component: C },
+      ...orgRoutes,
+    ],
+  })
+}
+
+// Transplant of Login.vue's getOrgSlug(), source 4 (the #241 fix under
+// review). `search` stands in for window.location.search, `path` for
+// window.location.pathname.
+function getOrgSlug({ search, path, subSlug, router }) {
+  const params = new URLSearchParams(search)
+  if (params.get('org')) return params.get('org')
+  if (subSlug) return subSlug
+  const pathParts = path.split('/').filter(Boolean)
+  if (pathParts.length >= 2 && pathParts[1] === 'login') return pathParts[0]
+  const redirect = params.get('redirect')
+  if (redirect) {
+    const org = router.resolve(redirect).params.org
+    if (org) return org
+  }
+  return ''
+}
+
+test('deep link bounced to bare /login recovers the org from ?redirect=', () => {
+  const router = buildRouter(false)
+  const slug = getOrgSlug({ search: '?redirect=%2Facme%2Fdocuments', path: '/login', subSlug: null, router })
+  assert.equal(slug, 'acme')
+})
+
+test('?redirect=/organizations does not get misread as an org slug', () => {
+  // A naive first-path-segment split would yield "organizations" here.
+  const router = buildRouter(false)
+  const slug = getOrgSlug({ search: '?redirect=%2Forganizations', path: '/login', subSlug: null, router })
+  assert.equal(slug, '')
+})
+
+test('subdomain mode: ?redirect=/documents does not get misread as an org slug', () => {
+  // Org-scoped routes are mounted at the top level in subdomain mode, so
+  // "documents" is a real route segment, not an org — a naive split would
+  // still yield "documents".
+  const router = buildRouter(true)
+  const slug = getOrgSlug({ search: '?redirect=%2Fdocuments', path: '/login', subSlug: null, router })
+  assert.equal(slug, '')
+})
+
+test('an explicit ?org= still wins over a redirect-derived org', () => {
+  const router = buildRouter(false)
+  const slug = getOrgSlug({ search: '?org=beta&redirect=%2Facme%2Fdocuments', path: '/login', subSlug: null, router })
+  assert.equal(slug, 'beta')
+})
+
+test('the redirect-derived org reaches the real login() request body', async () => {
+  const router = buildRouter(false)
+  const slug = getOrgSlug({ search: '?redirect=%2Facme%2Fdocuments', path: '/login', subSlug: null, router })
+
+  let capturedBody = null
+  globalThis.fetch = async (url, opts) => {
+    capturedBody = JSON.parse(opts.body)
+    return { ok: true, json: async () => ({ token: 't', email: 'a@b.com' }) }
+  }
+
+  const { login } = await import('../src/api.js')
+  await login('a@b.com', 'pw', undefined, slug || undefined)
+
+  assert.equal(capturedBody.organization, 'acme')
+})


### PR DESCRIPTION
Fixes #241.

Password login (`web/src/api.js`'s `login()`) never sent the org slug in the `POST /auth/login` body, unlike the OIDC path which already does (`Login.vue`'s `oidcLogin()`). The backend has an `organization` field on `loginRequest` (`internal/isms/api/api_auth.go`) for exactly this — it just never received a value from the password-login form.

Without it, a user in more than one org couldn't be resolved: the backend's org auto-select only works when the user belongs to exactly one org, so a multi-org user got a token with no org context, and the client's mismatch-recovery (`switch-org`) only succeeds if they're actually a member of the org in the URL — otherwise they land back on the org picker or `/login`, having lost the page they were trying to reach.

Two changes:
1. `login()` now takes an `organization` argument and includes it in the request body when known; `handleLogin()` passes `orgSlug.value`.
2. `goToOrg()`'s hard redirect (org-discovery step, subdomain-capable hosts) now preserves `?redirect=` instead of dropping it.

New test: `web/test/apiLogin.test.js` — asserts `login()` includes `organization` in the request body when passed and omits it when not. Reverting the `api.js` change makes it fail with the exact symptom (`organization` missing from the body); confirmed locally.

`web/` unit suite: 113/113 passing.