### PR TITLE
feat(i18n): guard notification keys against the locale catalogues (#212)

### DIFF
--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -163,7 +163,7 @@ func (s *Server) notifyMentions(ctx context.Context, orgID int, actor, body, tit
 func (s *Server) notifyReviewMentions(ctx context.Context, orgID, reviewID int, actor, body string) {
 	s.notifyMentions(ctx, orgID, actor, body,
 		fmt.Sprintf("%s mentioned you in a review comment", actor),
-		"notifications.mention_review_comment",
+		NotifyKeyMentionReviewComment,
 		fmt.Sprintf("/reviews/%d", reviewID))
 }
 
@@ -513,7 +513,7 @@ func (s *Server) handleForwardReview(c echo.Context) error {
 		// frame that always carries it renders a dangling label when there is no
 		// note. `note` itself is the requester's own words and interpolates
 		// verbatim; it is passed only to the variant that has a slot for it.
-		bodyKey := "notifications.review_forwarded.body"
+		bodyKey := NotifyKeyReviewForwardedBody
 		params := map[string]any{
 			"actor":   actor,
 			"doc_id":  review.DocumentID,
@@ -522,12 +522,12 @@ func (s *Server) handleForwardReview(c echo.Context) error {
 		}
 		if req.Message != "" {
 			notifBody += "\n\nNote: " + req.Message
-			bodyKey += "_with_note"
+			bodyKey = NotifyKeyReviewForwardedBodyWithNote
 			params["note"] = req.Message
 		}
 		s.db.CreateNotificationContentByEmail(ctx, orgID, reviewer, db.NotificationContent{
 			Title:    fmt.Sprintf("Review forwarded: %s", review.Title),
-			TitleKey: "notifications.review_forwarded",
+			TitleKey: NotifyKeyReviewForwarded,
 			Body:     notifBody,
 			BodyKey:  bodyKey,
 			Params:   params,
@@ -1202,9 +1202,9 @@ func (s *Server) handleReviewApprove(c echo.Context) error {
 					if doc, loadErr := st.LoadDocument(filePath); loadErr == nil && doc != nil && doc.Frontmatter.Owner != "" {
 						_ = s.db.CreateNotificationContentByEmail(ctx, orgID, doc.Frontmatter.Owner, db.NotificationContent{
 							Title:    "AI review escalated",
-							TitleKey: "notifications.ai_review_escalated",
+							TitleKey: NotifyKeyAIReviewEscalated,
 							Body:     fmt.Sprintf("AI review of %s reached round %d without agreement. Please review and decide.", review.DocumentID, review.Round),
-							BodyKey:  "notifications.ai_review_escalated.body",
+							BodyKey:  NotifyKeyAIReviewEscalatedBody,
 							Params:   map[string]any{"doc_id": review.DocumentID, "round": review.Round},
 							Link:     fmt.Sprintf("/reviews/%d", id),
 						})
@@ -2706,7 +2706,7 @@ func (s *Server) handleCreateChange(c echo.Context) error {
 	s.notifyMentions(ctx, orgID, cr.RequestedBy,
 		strings.Join([]string{cr.Description, cr.Justification, cr.Notes, cr.RollbackPlan}, "\n"),
 		fmt.Sprintf("%s mentioned you in a change request", cr.RequestedBy),
-		"notifications.mention_change_request",
+		NotifyKeyMentionChangeRequest,
 		entityLink("change_request", strconv.Itoa(cr.ID)))
 
 	return c.JSON(http.StatusCreated, cr)
@@ -3953,7 +3953,7 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 				notifBody := fmt.Sprintf("%s resubmitted %s (%s v%s) for review", actor, docID, title, version)
 				// Separate with-note frame — see handleForwardReview for why the
 				// label cannot be an optional interpolation.
-				bodyKey := "notifications.review_resubmitted.body"
+				bodyKey := NotifyKeyReviewResubmittedBody
 				params := map[string]any{
 					"actor":   actor,
 					"doc_id":  docID,
@@ -3962,12 +3962,12 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 				}
 				if req.Message != "" {
 					notifBody += "\n\nNote: " + req.Message
-					bodyKey += "_with_note"
+					bodyKey = NotifyKeyReviewResubmittedBodyWithNote
 					params["note"] = req.Message
 				}
 				s.db.CreateNotificationContentByEmail(ctx, orgID, a.Reviewer, db.NotificationContent{
 					Title:    fmt.Sprintf("Review resubmitted: %s", title),
-					TitleKey: "notifications.review_resubmitted",
+					TitleKey: NotifyKeyReviewResubmitted,
 					Body:     notifBody,
 					BodyKey:  bodyKey,
 					Params:   params,
@@ -4011,7 +4011,7 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 			// so they share one key rather than duplicating a translation. That
 			// includes the with-note split: both sites pick the variant the same
 			// way, or the shared key stops being shared.
-			bodyKey := "notifications.review_requested.body"
+			bodyKey := NotifyKeyReviewRequestedBody
 			params := map[string]any{
 				"actor":   actor,
 				"title":   title,
@@ -4019,12 +4019,12 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 			}
 			if req.Message != "" {
 				notifBody += "\n\nNote: " + req.Message
-				bodyKey += "_with_note"
+				bodyKey = NotifyKeyReviewRequestedBodyWithNote
 				params["note"] = req.Message
 			}
 			s.db.CreateNotificationContentByEmail(ctx, orgID, reviewer, db.NotificationContent{
 				Title:    fmt.Sprintf("Review: %s v%s", title, version),
-				TitleKey: "notifications.review_requested",
+				TitleKey: NotifyKeyReviewRequested,
 				Body:     notifBody,
 				BodyKey:  bodyKey,
 				Params:   params,
@@ -4089,7 +4089,7 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 	for _, reviewer := range req.Reviewers {
 		notifBody := fmt.Sprintf("%s wants to publish %s v%s and requested your review", actor, title, version)
 		// Same frame and same with-note split as the reviewers-added site above.
-		bodyKey := "notifications.review_requested.body"
+		bodyKey := NotifyKeyReviewRequestedBody
 		params := map[string]any{
 			"actor":   actor,
 			"title":   title,
@@ -4097,12 +4097,12 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 		}
 		if req.Message != "" {
 			notifBody += "\n\nNote: " + req.Message
-			bodyKey += "_with_note"
+			bodyKey = NotifyKeyReviewRequestedBodyWithNote
 			params["note"] = req.Message
 		}
 		s.db.CreateNotificationContentByEmail(ctx, orgID, reviewer, db.NotificationContent{
 			Title:    fmt.Sprintf("Review: %s v%s", title, version),
-			TitleKey: "notifications.review_requested",
+			TitleKey: NotifyKeyReviewRequested,
 			Body:     notifBody,
 			BodyKey:  bodyKey,
 			Params:   params,

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -154,7 +154,7 @@ func (s *Server) handleCreateCorrectiveAction(c echo.Context) error {
 		// content rather than product copy, and must never be translated.
 		s.db.CreateNotificationContentByEmail(ctx, orgID, ca.Assignee, db.NotificationContent{
 			Title:    fmt.Sprintf("Corrective action assigned: %s", ca.Title),
-			TitleKey: "notifications.ca_assigned",
+			TitleKey: NotifyKeyCAAssigned,
 			Body:     ca.Description,
 			Params:   map[string]any{"title": ca.Title},
 			Link:     "/corrective-actions",
@@ -358,9 +358,9 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 		if err == nil {
 			s.db.CreateNotificationContentByEmail(ctx, orgID, ca.CreatedBy, db.NotificationContent{
 				Title:    fmt.Sprintf("Corrective action resolved: %s", ca.Title),
-				TitleKey: "notifications.ca_resolved",
+				TitleKey: NotifyKeyCAResolved,
 				Body:     fmt.Sprintf("Corrective action #%d has been resolved by %s", id, actor),
-				BodyKey:  "notifications.ca_resolved.body",
+				BodyKey:  NotifyKeyCAResolvedBody,
 				Params:   map[string]any{"title": ca.Title, "id": id, "actor": actor},
 				Link:     "/corrective-actions",
 			})

--- a/internal/isms/api/api_entity_comments.go
+++ b/internal/isms/api/api_entity_comments.go
@@ -76,7 +76,7 @@ func (s *Server) handleCreateEntityComment(c echo.Context) error {
 	// so change-request comments (and every other register) pull members in.
 	s.notifyMentions(ctx, orgID, actor, req.Body,
 		fmt.Sprintf("%s mentioned you in a comment", actor),
-		"notifications.mention_comment",
+		NotifyKeyMentionComment,
 		entityLink(req.EntityType, req.EntityID))
 
 	return c.JSON(http.StatusCreated, comment)

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -236,7 +236,7 @@ func (s *Server) handleCreateIncident(c echo.Context) error {
 			s.db.CreateNotification(ctx, orgID, &db.Notification{
 				RecipientID: m.ID,
 				Title:       fmt.Sprintf("New %s incident: %s", inc.Severity, inc.Title),
-				TitleKey:    "notifications.incident_new",
+				TitleKey:    NotifyKeyIncidentNew,
 				Body:        inc.Description,
 				Params:      map[string]any{"severity": inc.Severity, "title": inc.Title},
 				Link:        "/incidents",
@@ -529,9 +529,9 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 			for _, r := range recipients {
 				s.db.CreateNotificationContentByEmail(ctx, orgID, r, db.NotificationContent{
 					Title:    fmt.Sprintf("Incident %s: %s", req.Status, inc.Title),
-					TitleKey: "notifications.incident_status",
+					TitleKey: NotifyKeyIncidentStatus,
 					Body:     fmt.Sprintf("Incident #%d has been %s", id, req.Status),
-					BodyKey:  "notifications.incident_status.body",
+					BodyKey:  NotifyKeyIncidentStatusBody,
 					Params:   map[string]any{"status": req.Status, "title": inc.Title, "id": id},
 					Link:     "/incidents",
 				})

--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -530,7 +530,7 @@ func (s *Server) handleApplyEntitySuggestion(c echo.Context) error {
 	})
 	s.notifySuggestionResolved(ctx, orgID, sg, "applied",
 		fmt.Sprintf("Your suggestion \"%s\" was applied by %s → %s %s", sg.Title, actor, sg.EntityType, appliedEntityID),
-		"notifications.suggestion_applied.body",
+		NotifyKeySuggestionAppliedBody,
 		map[string]any{"title": sg.Title, "actor": actor, "entity": sg.EntityType, "id": appliedEntityID})
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
@@ -581,7 +581,7 @@ func (s *Server) handleRejectEntitySuggestion(c echo.Context) error {
 		// `reason` is the reviewer's own words — verbatim, like a review note.
 		s.notifySuggestionResolved(ctx, orgID, sg, "rejected",
 			fmt.Sprintf("Your suggestion \"%s\" was rejected by %s: %s", sg.Title, actor, body.Reason),
-			"notifications.suggestion_rejected.body",
+			NotifyKeySuggestionRejectedBody,
 			map[string]any{"title": sg.Title, "actor": actor, "reason": body.Reason})
 	}
 
@@ -646,9 +646,9 @@ func (s *Server) notifySuggestionCreated(ctx context.Context, orgID int, sg *db.
 		if (u.Role == "admin" || u.Role == "manager") && u.Email != sg.SuggestedBy {
 			_ = s.db.CreateNotificationContentByEmail(ctx, orgID, u.Email, db.NotificationContent{
 				Title:    "New suggestion",
-				TitleKey: "notifications.suggestion_new",
+				TitleKey: NotifyKeySuggestionNew,
 				Body:     body,
-				BodyKey:  "notifications.suggestion_new.body",
+				BodyKey:  NotifyKeySuggestionNewBody,
 				Params:   params,
 				Link:     link,
 			})
@@ -671,7 +671,7 @@ func (s *Server) notifySuggestionResolved(ctx context.Context, orgID int, sg *db
 	}
 	_ = s.db.CreateNotificationContentByEmail(ctx, orgID, sg.SuggestedBy, db.NotificationContent{
 		Title:    title,
-		TitleKey: "notifications.suggestion_resolved",
+		TitleKey: NotifyKeySuggestionResolved,
 		Body:     detail,
 		BodyKey:  bodyKey,
 		Params:   params,

--- a/internal/isms/api/notification_keys.go
+++ b/internal/isms/api/notification_keys.go
@@ -1,0 +1,122 @@
+package api
+
+// Wire keys for stored notifications, declared once.
+//
+// Every keyed notification write in this package MUST use a constant from this
+// file rather than a string literal. That is not style — it is what makes the
+// key set enumerable, which is what NotificationKeys and its test need to
+// exist at all.
+//
+// Why enumerable matters here (plan 82 step 7): useNotificationRender.js falls
+// back to the stored English title when the catalogue has no message for a
+// key. That fallback is what keeps legacy rows, agent rows and a lagging
+// locale safe, and it is also what makes a MISSING translation look exactly
+// like correct behaviour — no error, no warning, and a diff that reads fine to
+// an English-speaking reviewer. It is wrong only for a non-English user,
+// silently, in production. So the invariant "every key Go emits has a frame in
+// web/src/locales/en/notifications.json" has to be checked mechanically.
+//
+// The alternative was grepping the Go source for `"notifications.…"` literals.
+// That undercounts: the three `_with_note` variants used to be built by
+// `bodyKey += "_with_note"` at four call sites, so a regex over quoted strings
+// returned 22 of 25 keys and reported a clean bill of health while three body
+// frames went untranslated. Declaring them removes the extraction problem
+// instead of solving it, and turns "add a notification" into "add a constant"
+// — which the test picks up with no further work.
+//
+// These strings are FROZEN. They are in `notifications.title_key` /
+// `body_key` on rows already written, so a rename orphans those rows to the
+// English fallback forever. Rename the catalogue nesting if you must; never a
+// wire key.
+//
+// Note a title wire key is also the parent of its body wire keys
+// (`notifications.ca_resolved` and `notifications.ca_resolved.body`), which no
+// single JSON node can be. The catalogue therefore nests uniformly and the
+// client maps wire key onto catalogue key; see catalogKey in
+// useNotificationRender.js and its twin in notification_keys_test.go.
+const (
+	// Mentions — title only. The body is the comment snippet, org-authored
+	// text that must never be translated, so these have no body key.
+	NotifyKeyMentionComment       = "notifications.mention_comment"
+	NotifyKeyMentionReviewComment = "notifications.mention_review_comment"
+	NotifyKeyMentionChangeRequest = "notifications.mention_change_request"
+
+	// Review lifecycle. Each body has a with-note variant: the "Note:" label
+	// is product copy the frame owns, so an optional `note` param in one frame
+	// would either dangle the label or lose its translation. `note` appears in
+	// params only for the _with_note variant.
+	NotifyKeyReviewForwarded             = "notifications.review_forwarded"
+	NotifyKeyReviewForwardedBody         = "notifications.review_forwarded.body"
+	NotifyKeyReviewForwardedBodyWithNote = "notifications.review_forwarded.body_with_note"
+
+	NotifyKeyReviewRequested             = "notifications.review_requested"
+	NotifyKeyReviewRequestedBody         = "notifications.review_requested.body"
+	NotifyKeyReviewRequestedBodyWithNote = "notifications.review_requested.body_with_note"
+
+	NotifyKeyReviewResubmitted             = "notifications.review_resubmitted"
+	NotifyKeyReviewResubmittedBody         = "notifications.review_resubmitted.body"
+	NotifyKeyReviewResubmittedBodyWithNote = "notifications.review_resubmitted.body_with_note"
+
+	NotifyKeyAIReviewEscalated     = "notifications.ai_review_escalated"
+	NotifyKeyAIReviewEscalatedBody = "notifications.ai_review_escalated.body"
+
+	// Corrective actions. ca_assigned has no body key: the body is the
+	// action's own description, org-authored.
+	NotifyKeyCAAssigned     = "notifications.ca_assigned"
+	NotifyKeyCAResolved     = "notifications.ca_resolved"
+	NotifyKeyCAResolvedBody = "notifications.ca_resolved.body"
+
+	// Suggestions. suggestion_resolved is one shared title frame with `action`
+	// as a translatable param, while applied and rejected say genuinely
+	// different things and so carry their own body frames — hence a title with
+	// no body and two bodies with no title.
+	NotifyKeySuggestionNew          = "notifications.suggestion_new"
+	NotifyKeySuggestionNewBody      = "notifications.suggestion_new.body"
+	NotifyKeySuggestionResolved     = "notifications.suggestion_resolved"
+	NotifyKeySuggestionAppliedBody  = "notifications.suggestion_applied.body"
+	NotifyKeySuggestionRejectedBody = "notifications.suggestion_rejected.body"
+
+	// Incidents. incident_new has no body key: the body is the reporter's own
+	// description.
+	NotifyKeyIncidentNew        = "notifications.incident_new"
+	NotifyKeyIncidentStatus     = "notifications.incident_status"
+	NotifyKeyIncidentStatusBody = "notifications.incident_status.body"
+)
+
+// NotificationKeys is every wire key this build can write. Adding a constant
+// above without adding it here makes TestNotificationKeysIsExhaustive fail,
+// so the slice cannot silently fall behind the constants it indexes.
+var NotificationKeys = []string{
+	NotifyKeyMentionComment,
+	NotifyKeyMentionReviewComment,
+	NotifyKeyMentionChangeRequest,
+
+	NotifyKeyReviewForwarded,
+	NotifyKeyReviewForwardedBody,
+	NotifyKeyReviewForwardedBodyWithNote,
+
+	NotifyKeyReviewRequested,
+	NotifyKeyReviewRequestedBody,
+	NotifyKeyReviewRequestedBodyWithNote,
+
+	NotifyKeyReviewResubmitted,
+	NotifyKeyReviewResubmittedBody,
+	NotifyKeyReviewResubmittedBodyWithNote,
+
+	NotifyKeyAIReviewEscalated,
+	NotifyKeyAIReviewEscalatedBody,
+
+	NotifyKeyCAAssigned,
+	NotifyKeyCAResolved,
+	NotifyKeyCAResolvedBody,
+
+	NotifyKeySuggestionNew,
+	NotifyKeySuggestionNewBody,
+	NotifyKeySuggestionResolved,
+	NotifyKeySuggestionAppliedBody,
+	NotifyKeySuggestionRejectedBody,
+
+	NotifyKeyIncidentNew,
+	NotifyKeyIncidentStatus,
+	NotifyKeyIncidentStatusBody,
+}

--- a/internal/isms/api/notification_keys.go
+++ b/internal/isms/api/notification_keys.go
@@ -120,3 +120,67 @@ var NotificationKeys = []string{
 	NotifyKeyIncidentStatus,
 	NotifyKeyIncidentStatusBody,
 }
+
+// NotificationKeyParams is the set of param names each wire key's call sites
+// can send, declared per key rather than package-wide.
+//
+// The closed set in internal/isms/db is a vocabulary, not a contract: it says
+// `reason` is a name the backend knows, not that the incident_status frame is
+// ever handed one. Checking frames against the vocabulary alone lets a
+// translator (or a copy edit) add {reason} to incident_status in every locale
+// and pass every test, while the call site sends only status, title and id —
+// so the slot renders empty and the sentence quietly loses a clause. Checking
+// against this table instead asks the question that matters: is this slot
+// filled *for this notification*?
+//
+// A title and its body share one params map at the write site, so both are
+// listed from that same map. Where a key is written from several sites, the
+// entry is the union of what those sites can send — the with-note bodies get
+// `note` and the plain ones do not, because the call sites pick the variant by
+// whether a note exists.
+//
+// Hand-maintained, and deliberately so: params are inline map literals built
+// conditionally at each call site (`if req.Message != "" { params["note"] = … }`),
+// which no static extraction can enumerate. What keeps the table honest is
+// TestNotificationKeyParamsIsExhaustive — its key set is pinned to
+// NotificationKeys, so a new notification cannot ship without an entry. The
+// remaining risk is an entry that names more than its call site sends, which
+// is the direction that fails safe: it only widens what a frame may ask for.
+// The call-site half stays a runtime concern (see keyedColumns in
+// internal/isms/db/notifications.go, which logs an out-of-set param).
+var NotificationKeyParams = map[string][]string{
+	NotifyKeyMentionComment:       {"actor"},
+	NotifyKeyMentionReviewComment: {"actor"},
+	NotifyKeyMentionChangeRequest: {"actor"},
+
+	NotifyKeyReviewForwarded:             {"actor", "doc_id", "title", "version", "note"},
+	NotifyKeyReviewForwardedBody:         {"actor", "doc_id", "title", "version"},
+	NotifyKeyReviewForwardedBodyWithNote: {"actor", "doc_id", "title", "version", "note"},
+
+	NotifyKeyReviewRequested:             {"actor", "title", "version", "note"},
+	NotifyKeyReviewRequestedBody:         {"actor", "title", "version"},
+	NotifyKeyReviewRequestedBodyWithNote: {"actor", "title", "version", "note"},
+
+	NotifyKeyReviewResubmitted:             {"actor", "doc_id", "title", "version", "note"},
+	NotifyKeyReviewResubmittedBody:         {"actor", "doc_id", "title", "version"},
+	NotifyKeyReviewResubmittedBodyWithNote: {"actor", "doc_id", "title", "version", "note"},
+
+	NotifyKeyAIReviewEscalated:     {"doc_id", "round"},
+	NotifyKeyAIReviewEscalatedBody: {"doc_id", "round"},
+
+	NotifyKeyCAAssigned:     {"title"},
+	NotifyKeyCAResolved:     {"title", "id", "actor"},
+	NotifyKeyCAResolvedBody: {"title", "id", "actor"},
+
+	// suggestion_resolved is one title frame shared by the applied and
+	// rejected sites, so its entry is the union of both param maps.
+	NotifyKeySuggestionNew:          {"actor", "title", "suggestion_type", "entity"},
+	NotifyKeySuggestionNewBody:      {"actor", "title", "suggestion_type", "entity"},
+	NotifyKeySuggestionResolved:     {"action", "title", "actor", "entity", "id", "reason"},
+	NotifyKeySuggestionAppliedBody:  {"action", "title", "actor", "entity", "id"},
+	NotifyKeySuggestionRejectedBody: {"action", "title", "actor", "reason"},
+
+	NotifyKeyIncidentNew:        {"severity", "title"},
+	NotifyKeyIncidentStatus:     {"status", "title", "id"},
+	NotifyKeyIncidentStatusBody: {"status", "title", "id"},
+}

--- a/internal/isms/api/notification_keys_test.go
+++ b/internal/isms/api/notification_keys_test.go
@@ -1,0 +1,316 @@
+package api
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"isms.sh/internal/isms/db"
+)
+
+// The guard for plan 82 step 7: the keys this package emits and the frames
+// web/src/locales/en/notifications.json provides must be the same set, in both
+// directions, and every placeholder in those frames must be a param name the
+// backend is allowed to send.
+//
+// This lives in the go-unit job rather than under `npm test` because the Go
+// side owns the key set. It reads the locale file across the module boundary,
+// which is unusual and deliberate: the invariant is a coupling between two
+// languages, so the test has to sit on one side and look at the other. The
+// alternative — asserting a hand-typed list, as web/test/notificationRender.test.js
+// does — is what let the set drift in the first place: add a notification type
+// and every existing check stays green.
+//
+// If the locale files move, fix this path. Do NOT make a missing file skip:
+// no catalogue is the failure this test exists to report.
+const localesDir = "../../../web/src/locales"
+
+// fallbackLocale is the catalogue the key set is checked against. It is the
+// one locale guaranteed complete by contract — useNotificationRender.js probes
+// te() against it rather than the active locale, so a lagging locale renders
+// English through fallbackLocale instead of dropping to the stored string.
+const fallbackLocale = "en"
+
+func notificationsPath(locale string) string {
+	return filepath.Join(localesDir, locale, "notifications.json")
+}
+
+// localesWithNotifications lists every locale directory shipping a
+// notifications catalogue.
+//
+// Checking only `en` would aim the guard away from the person it exists to
+// protect: `en` is the locale that renders correctly no matter what, and the
+// stated victim of every failure here is the non-English reader. A translator
+// localising a placeholder name — {actor} to {pelaku}, a plausible-looking
+// "fix" — is invisible to every other check in the tree: localeKeyset.test.js
+// compares key sets and not frame contents, and notificationRender.test.js
+// cannot see it because vue-i18n renders an unknown slot as the empty string
+// rather than leaving a literal {…} behind, so its `!includes("{")` assertion
+// passes on a sentence with the actor silently missing.
+func localesWithNotifications(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(localesDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", localesDir, err)
+	}
+	var locales []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(notificationsPath(e.Name())); err == nil {
+			locales = append(locales, e.Name())
+		}
+	}
+	if len(locales) == 0 {
+		t.Fatalf("no locale under %s ships notifications.json", localesDir)
+	}
+	return locales
+}
+
+// catalogKey maps a wire key onto the catalogue key that holds its frame.
+//
+// A title wire key (notifications.ca_resolved) is also the parent of its body
+// wire key (notifications.ca_resolved.body), and no single JSON node can be a
+// leaf and a group at once — so the catalogue nests uniformly and titles get
+// ".title" appended. Body keys already name a leaf and pass through.
+//
+// This is a deliberate twin of catalogKey in
+// web/src/composables/useNotificationRender.js:33. The same rule in two
+// languages is a coupling worth naming: if that one changes, this one is wrong
+// and the test will report keys as missing that render perfectly in the app.
+func catalogKey(wireKey string) string {
+	if strings.HasSuffix(wireKey, ".body") || strings.HasSuffix(wireKey, ".body_with_note") {
+		return wireKey
+	}
+	return wireKey + ".title"
+}
+
+// loadENNotificationLeaves returns every leaf in the catalogue, keyed as a full
+// dotted path with the "notifications." prefix restored, so leaves and
+// catalogKey output are directly comparable.
+func loadNotificationLeaves(t *testing.T, locale string) map[string]string {
+	t.Helper()
+	path := notificationsPath(locale)
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("reading the %s notification catalogue: %v\n"+
+			"This test compares the keys Go emits against that file; it cannot pass without it.", locale, err)
+	}
+	// The file is one level of groups holding string leaves, but decode
+	// generically so a future nesting change fails loudly here rather than
+	// silently dropping frames from the comparison.
+	var tree map[string]map[string]any
+	if err := json.Unmarshal(raw, &tree); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	leaves := map[string]string{}
+	for group, node := range tree {
+		for leaf, v := range node {
+			s, ok := v.(string)
+			if !ok {
+				t.Fatalf("catalogue node notifications.%s.%s in %s is %T, want a string frame; "+
+					"the catalogue is expected to be groups of string leaves", group, leaf, locale, v)
+			}
+			leaves["notifications."+group+"."+leaf] = s
+		}
+	}
+	return leaves
+}
+
+// TestNotificationKeysHaveENFrames is the forward direction: nothing Go can
+// write is untranslatable.
+//
+// This is the assertion that matters most, because its failure mode in
+// production is invisible. useNotificationRender.js falls back to the stored
+// English title when a key has no frame, so a missing translation looks exactly
+// like correct behaviour to everyone except a non-English user.
+func TestNotificationKeysHaveENFrames(t *testing.T) {
+	leaves := loadNotificationLeaves(t, fallbackLocale)
+	for _, wireKey := range NotificationKeys {
+		if _, ok := leaves[catalogKey(wireKey)]; !ok {
+			t.Errorf("wire key %q has no frame at %q in %s\n"+
+				"Add it to the en catalogue (and to every other locale, or localeKeyset.test.js fails).",
+				wireKey, catalogKey(wireKey), notificationsPath(fallbackLocale))
+		}
+	}
+}
+
+// TestENNotificationFramesAreEmitted is the reverse direction: no stale frames.
+//
+// A renamed or removed notification leaves a frame behind that every locale
+// then keeps translating forever, because localeKeyset.test.js only compares
+// locales to each other and would see nothing wrong with all of them carrying
+// the same dead key.
+func TestENNotificationFramesAreEmitted(t *testing.T) {
+	emitted := map[string]bool{}
+	for _, wireKey := range NotificationKeys {
+		emitted[catalogKey(wireKey)] = true
+	}
+	for key := range loadNotificationLeaves(t, fallbackLocale) {
+		if !emitted[key] {
+			t.Errorf("catalogue frame %q is not emitted by any key in NotificationKeys\n"+
+				"Either a notification was renamed/removed and this frame is stale, or a new "+
+				"call site is missing its constant in notification_keys.go.", key)
+		}
+	}
+}
+
+// Digits are included deliberately. vue-i18n also accepts positional slots
+// ({0}, {1}), which no call site here sends — so a frame acquiring one renders
+// it empty, and a name-only pattern would not even see it to complain.
+var placeholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+
+func placeholdersIn(frame string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range placeholderRe.FindAllStringSubmatch(frame, -1) {
+		out[m[1]] = true
+	}
+	return out
+}
+
+// TestNotificationPlaceholdersAreInClosedSet checks the catalogue half of the
+// param guard: every slot a frame asks to be filled is a name the backend is
+// allowed to send.
+//
+// The write-side half is NotificationContent.Validate plus the log on its
+// degrade path (both exercised in internal/isms/db). The two halves catch
+// opposite mistakes — a frame asking for a param nobody sends renders an
+// unfilled slot; a call site sending a param no frame reads is dead weight or
+// a rename done on one side. Neither is visible in English.
+func TestNotificationPlaceholdersAreInClosedSet(t *testing.T) {
+	allowed := map[string]bool{db.NotificationEntityParam: true}
+	for _, n := range db.NotificationEnumParams {
+		allowed[n] = true
+	}
+	for _, n := range db.NotificationVerbatimParams {
+		allowed[n] = true
+	}
+	for _, locale := range localesWithNotifications(t) {
+		for key, frame := range loadNotificationLeaves(t, locale) {
+			for name := range placeholdersIn(frame) {
+				if !allowed[name] {
+					t.Errorf("[%s] frame %q interpolates {%s}, which is not in the closed param set\n"+
+						"Either the call site sends a name the schema does not document, or this is "+
+						"a typo that will render as an empty slot. See "+
+						"the Notification*Params vars in internal/isms/db/notifications.go.", locale, key, name)
+				}
+			}
+		}
+	}
+}
+
+// TestTranslatedFramesReuseTheFallbackPlaceholders catches the localised
+// placeholder: a translator renaming {actor} to {pelaku} because every other
+// word in the sentence was translated.
+//
+// Nothing else in the tree catches it. localeKeyset.test.js compares key sets,
+// not frame contents. notificationRender.test.js asserts the rendered string
+// contains no "{", which holds — vue-i18n drops an unknown slot to the empty
+// string rather than leaving the literal behind, so the actor simply vanishes
+// from the sentence and the test passes.
+//
+// Subset, not equality: a translation may legitimately drop a slot its grammar
+// makes redundant, and forcing every frame to spend every param would be a
+// claim about other languages this test has no standing to make. Introducing a
+// name the fallback does not have is the unambiguous error, and it is the one
+// that silently loses information.
+func TestTranslatedFramesReuseTheFallbackPlaceholders(t *testing.T) {
+	fallback := loadNotificationLeaves(t, fallbackLocale)
+	for _, locale := range localesWithNotifications(t) {
+		if locale == fallbackLocale {
+			continue
+		}
+		for key, frame := range loadNotificationLeaves(t, locale) {
+			base, ok := fallback[key]
+			if !ok {
+				continue // localeKeyset.test.js owns key-set drift
+			}
+			baseNames := placeholdersIn(base)
+			for name := range placeholdersIn(frame) {
+				if !baseNames[name] {
+					t.Errorf("[%s] frame %q interpolates {%s}, which the %s frame does not have\n"+
+						"  %s: %q\n  %s: %q\n"+
+						"Placeholder names are param names sent by the backend and are never "+
+						"translated; this slot will render empty.",
+						locale, key, name, fallbackLocale, fallbackLocale, base, locale, frame)
+				}
+			}
+		}
+	}
+}
+
+// TestNotificationKeysIsExhaustive holds NotificationKeys to the constants
+// declared beside it. The slice is what every check above walks, so a constant
+// added to the const block but forgotten here would be exempt from all of them
+// — a guard with a hole in exactly the place a new notification lands.
+//
+// Enumerating the const block means reading the source: Go has no reflection
+// over package-level constants. It is parsed with go/ast rather than matched
+// with a regex, because a regex over declarations is exactly the fragility
+// this file exists to remove. An earlier version anchored on the closing quote
+// at end of line and accepted no digits in the key, so a constant carrying
+// this repo's usual trailing issue reference —
+//
+//	NotifyKeyRiskReviewDue = "notifications.risk_review_due" // #241
+//
+// — or one naming a standard (notifications.iso27001_review_due) was invisible
+// to it. Both stayed invisible while gofmt reported the file clean, and a
+// constant missing from the slice AND from the scan matches on both sides: the
+// test passes, and the key ships with no frame at all.
+func TestNotificationKeysIsExhaustive(t *testing.T) {
+	const src = "notification_keys.go"
+	file, err := parser.ParseFile(token.NewFileSet(), src, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", src, err)
+	}
+	var declared []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !strings.HasPrefix(name.Name, "NotifyKey") || i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					t.Errorf("%s is not a string literal; every NotifyKey* constant must be one, "+
+						"or it cannot be compared against the catalogue", name.Name)
+					continue
+				}
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquoting %s: %v", name.Name, err)
+				}
+				declared = append(declared, value)
+			}
+		}
+	}
+	if len(declared) == 0 {
+		t.Fatal("found no NotifyKey* constants — the declaration shape changed and this test is now vacuous")
+	}
+	inSlice := append([]string(nil), NotificationKeys...)
+	sort.Strings(declared)
+	sort.Strings(inSlice)
+	if !reflect.DeepEqual(declared, inSlice) {
+		t.Errorf("NotificationKeys does not match the declared constants\n slice: %v\nconsts: %v\n"+
+			"Add the new constant to NotificationKeys, or it is exempt from every check in this file.",
+			inSlice, declared)
+	}
+}

--- a/internal/isms/api/notification_keys_test.go
+++ b/internal/isms/api/notification_keys_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -165,15 +166,40 @@ func TestENNotificationFramesAreEmitted(t *testing.T) {
 	}
 }
 
-// Digits are included deliberately. vue-i18n also accepts positional slots
-// ({0}, {1}), which no call site here sends — so a frame acquiring one renders
-// it empty, and a name-only pattern would not even see it to complain.
-var placeholderRe = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+// Anything between braces counts, rather than a pattern that tries to describe
+// a valid slot.
+//
+// vue-i18n's own grammar is wider than it looks: @intlify/message-compiler
+// starts a named identifier on [a-zA-Z_] but continues it over [a-zA-Z0-9_$-],
+// and readNamedIdentifier skips surrounding spaces — so {actor-name}, {a$b} and
+// { actor } are all live slots that render, and it also accepts positional
+// slots ({0}, {1}) that no call site here sends. A pattern matching only
+// [a-zA-Z0-9_] misses every one of those, and missing them is not a false
+// negative in isolation: the slot is invisible to the closed-set check AND to
+// the fallback-placeholder check below, so a localised {pelaku-nama} renders
+// empty with the whole file green.
+//
+// Mirroring the compiler's character classes here would just be a third twin to
+// keep in sync. Capturing everything instead pushes the verdict onto the
+// closed-set check, where {actor-name}, {a$b} and {0} all come out as "not a
+// param the backend sends" — which is the right answer for each of them.
+var placeholderRe = regexp.MustCompile(`\{([^{}]*)\}`)
 
 func placeholdersIn(frame string) map[string]bool {
 	out := map[string]bool{}
 	for _, m := range placeholderRe.FindAllStringSubmatch(frame, -1) {
-		out[m[1]] = true
+		out[strings.TrimSpace(m[1])] = true
+	}
+	return out
+}
+
+// wireKeyForCatalogKey inverts catalogKey so a frame can be checked against the
+// params of the notification that writes it.
+func wireKeyForCatalogKey(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, wireKey := range NotificationKeys {
+		out[catalogKey(wireKey)] = wireKey
 	}
 	return out
 }
@@ -188,13 +214,7 @@ func placeholdersIn(frame string) map[string]bool {
 // unfilled slot; a call site sending a param no frame reads is dead weight or
 // a rename done on one side. Neither is visible in English.
 func TestNotificationPlaceholdersAreInClosedSet(t *testing.T) {
-	allowed := map[string]bool{db.NotificationEntityParam: true}
-	for _, n := range db.NotificationEnumParams {
-		allowed[n] = true
-	}
-	for _, n := range db.NotificationVerbatimParams {
-		allowed[n] = true
-	}
+	allowed := allowedParamNames()
 	for _, locale := range localesWithNotifications(t) {
 		for key, frame := range loadNotificationLeaves(t, locale) {
 			for name := range placeholdersIn(frame) {
@@ -312,5 +332,205 @@ func TestNotificationKeysIsExhaustive(t *testing.T) {
 		t.Errorf("NotificationKeys does not match the declared constants\n slice: %v\nconsts: %v\n"+
 			"Add the new constant to NotificationKeys, or it is exempt from every check in this file.",
 			inSlice, declared)
+	}
+}
+
+// TestNotificationKeyParamsIsExhaustive pins the per-key param table to the key
+// set, so a new notification cannot ship without declaring what it sends. A key
+// missing from the table would be exempt from the frame check below — the same
+// hole TestNotificationKeysIsExhaustive closes for the slice.
+func TestNotificationKeyParamsIsExhaustive(t *testing.T) {
+	declared := map[string]bool{}
+	for key := range NotificationKeyParams {
+		declared[key] = true
+	}
+	for _, wireKey := range NotificationKeys {
+		if !declared[wireKey] {
+			t.Errorf("wire key %q has no entry in NotificationKeyParams\n"+
+				"List the params its call sites send, or its frames are checked against nothing.", wireKey)
+		}
+		delete(declared, wireKey)
+	}
+	for key := range declared {
+		t.Errorf("NotificationKeyParams has an entry for %q, which is not in NotificationKeys\n"+
+			"The notification was renamed or removed and this entry is stale.", key)
+	}
+	allowed := allowedParamNames()
+	for key, names := range NotificationKeyParams {
+		for _, name := range names {
+			if !allowed[name] {
+				t.Errorf("NotificationKeyParams[%q] declares %q, which is not in the closed param set\n"+
+					"See the Notification*Params vars in internal/isms/db/notifications.go.", key, name)
+			}
+		}
+	}
+}
+
+// allowedParamNames is the package-wide vocabulary: every name the backend is
+// permitted to send, regardless of which notification sends it.
+func allowedParamNames() map[string]bool {
+	allowed := map[string]bool{db.NotificationEntityParam: true}
+	for _, n := range db.NotificationEnumParams {
+		allowed[n] = true
+	}
+	for _, n := range db.NotificationVerbatimParams {
+		allowed[n] = true
+	}
+	return allowed
+}
+
+// TestFramesOnlyUseTheirOwnKeysParams is the per-key half of the param guard.
+//
+// The closed-set check above asks whether a slot names a param the backend
+// knows; this asks whether it names one THIS notification sends. The difference
+// is the whole failure: {reason} added to the incident_status frame in every
+// locale is a name the vocabulary contains and a name that call site never
+// sends, so the closed-set check passes and the sentence renders with the
+// clause silently missing — in English too, which is the one thing that makes
+// this variant catchable at all, and only by someone who happens to look.
+//
+// Subset, not equality: a frame is free to spend fewer params than the call
+// site offers (the shared suggestion_resolved title uses only {action} out of
+// six), and a grammar may make a slot redundant in one language and not
+// another. Asking for a param nobody sends is the unambiguous error.
+func TestFramesOnlyUseTheirOwnKeysParams(t *testing.T) {
+	wireKeys := wireKeyForCatalogKey(t)
+	for _, locale := range localesWithNotifications(t) {
+		for key, frame := range loadNotificationLeaves(t, locale) {
+			wireKey, ok := wireKeys[key]
+			if !ok {
+				continue // stale frame; TestENNotificationFramesAreEmitted owns it
+			}
+			sent := map[string]bool{}
+			for _, name := range NotificationKeyParams[wireKey] {
+				sent[name] = true
+			}
+			for name := range placeholdersIn(frame) {
+				if !sent[name] {
+					t.Errorf("[%s] frame %q interpolates {%s}, which %q does not send\n"+
+						"  frame: %q\n  sends: %v\n"+
+						"The slot renders empty. Either the frame is wrong, or the call site "+
+						"gained a param and NotificationKeyParams was not updated.",
+						locale, key, name, wireKey, frame, NotificationKeyParams[wireKey])
+				}
+			}
+		}
+	}
+}
+
+// TestKeyedWritesUseDeclaredConstants closes the gap the exhaustiveness tests
+// cannot see: they prove the declared constants are all indexed and translated,
+// never that a notification write uses a declared constant at all.
+//
+// A call site can still write TitleKey: "notifications.foo" directly, or pass
+// that literal into notifyMentions or notifySuggestionResolved, which take the
+// key as a plain string parameter. Every check in this file stays green while
+// the notification ships with no frame in any language — which is precisely the
+// invisible failure the file exists to prevent, arriving through the one door
+// left open.
+//
+// So: no "notifications." string literal anywhere in the server source except
+// notification_keys.go, where the constants live. Scanning the whole of
+// internal/ and cmd/ rather than this package alone, because the next write site
+// need not land here — the MCP server writes notifications too.
+func TestKeyedWritesUseDeclaredConstants(t *testing.T) {
+	const declSite = "notification_keys.go"
+	scanned := 0
+	for _, root := range []string{"../../../internal", "../../../cmd"} {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			base := filepath.Base(path)
+			// Tests may name keys freely — they assert against them, and a
+			// literal in a test cannot reach a user's inbox.
+			if strings.HasSuffix(base, "_test.go") || base == declSite {
+				return nil
+			}
+			file, perr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+			if perr != nil {
+				return fmt.Errorf("parsing %s: %w", path, perr)
+			}
+			scanned++
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				value, uerr := strconv.Unquote(lit.Value)
+				if uerr != nil || !strings.HasPrefix(value, "notifications.") {
+					return true
+				}
+				t.Errorf("%s contains the literal %q\n"+
+					"Notification wire keys must come from a NotifyKey* constant in %s. A literal "+
+					"is invisible to every check in this file, so the key ships untranslated.",
+					path, value, declSite)
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no Go files — the source layout changed and this test is now vacuous")
+	}
+}
+
+// Anchored on the exact declarations in useNotificationRender.js. A regex over
+// declarations is the fragility this file otherwise avoids, and it is the only
+// option here — there is no JS parser in the Go toolchain. The not-found path is
+// therefore fatal rather than a skip: a rename that moves these declarations out
+// of reach must fail loudly, not quietly stop checking.
+var (
+	jsEnumParamsRe = regexp.MustCompile(`(?m)^const ENUM_PARAMS = \[([^\]]*)\]`)
+	jsEntityRe     = regexp.MustCompile(`(?m)^const ENTITY_PARAM = '([^']*)'`)
+	jsStringRe     = regexp.MustCompile(`'([^']*)'`)
+)
+
+// TestClientParamClassificationMatchesGo keeps the two halves of the
+// translated/verbatim split in step.
+//
+// db.NotificationEnumParams decides which names the catalogue may translate;
+// ENUM_PARAMS in useNotificationRender.js decides which ones the client
+// actually resolves through common.enum.*. Nothing connected them. Adding an
+// enum param on the Go side alone passes every catalogue check here and then
+// splices the raw English value ("in_progress") into a translated sentence —
+// the half-translated output the split exists to prevent. Dropping one on the
+// client side alone does the same. Both are invisible in English.
+func TestClientParamClassificationMatchesGo(t *testing.T) {
+	const src = "../../../web/src/composables/useNotificationRender.js"
+	raw, err := os.ReadFile(filepath.Clean(src))
+	if err != nil {
+		t.Fatalf("reading %s: %v\nThis test compares the Go param split against that file; "+
+			"it cannot pass without it.", src, err)
+	}
+	m := jsEnumParamsRe.FindSubmatch(raw)
+	if m == nil {
+		t.Fatalf("no `const ENUM_PARAMS = [...]` declaration in %s\n"+
+			"It was renamed or reshaped; update this test rather than leaving the two lists unchecked.", src)
+	}
+	var jsEnum []string
+	for _, s := range jsStringRe.FindAllSubmatch(m[1], -1) {
+		jsEnum = append(jsEnum, string(s[1]))
+	}
+	goEnum := append([]string(nil), db.NotificationEnumParams...)
+	sort.Strings(jsEnum)
+	sort.Strings(goEnum)
+	if !reflect.DeepEqual(jsEnum, goEnum) {
+		t.Errorf("ENUM_PARAMS in %s does not match db.NotificationEnumParams\n    js: %v\n    go: %v\n"+
+			"A name in one list only is either an enum spliced in untranslated or a value "+
+			"translated with no group behind it.", src, jsEnum, goEnum)
+	}
+	e := jsEntityRe.FindSubmatch(raw)
+	if e == nil {
+		t.Fatalf("no `const ENTITY_PARAM = '...'` declaration in %s", src)
+	}
+	if got := string(e[1]); got != db.NotificationEntityParam {
+		t.Errorf("ENTITY_PARAM in %s is %q, db.NotificationEntityParam is %q", src, got, db.NotificationEntityParam)
 	}
 }

--- a/internal/isms/db/notifications.go
+++ b/internal/isms/db/notifications.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 )
 
 // Notification represents an inbox item for a user.
@@ -52,6 +53,72 @@ type NotificationContent struct {
 	Link   string
 }
 
+// The closed set of interpolation param names, split by how the client must
+// treat each one before it reaches a translated frame.
+// Mirrors the `params` column comment on
+// migrations/20260824000000_v0.8.0.sql — that comment is the normative
+// statement of the split; this is its executable form.
+//
+// The split is load-bearing, not cosmetic: splicing an untranslated enum value
+// into a translated sentence yields half-translated output, so the translatable
+// names resolve through common.enum.* / common.entity.* BEFORE interpolation
+// (see resolveParams in web/src/composables/useNotificationRender.js, which
+// keys off these same names) while the verbatim ones are proper nouns, numbers
+// or the user's own words and pass through untouched.
+var (
+	// NotificationEnumParams resolve through common.enum.<param>.<value>. Each
+	// name IS its enum group — the groups were named after the params in #229
+	// precisely so there is no second mapping to keep in sync.
+	NotificationEnumParams = []string{"status", "severity", "action", "suggestion_type"}
+
+	// NotificationEntityParam is the one translatable param that is a noun the
+	// whole app reuses rather than an enum member, so it resolves through
+	// common.entity.* instead.
+	NotificationEntityParam = "entity"
+
+	// NotificationVerbatimParams interpolate as-is.
+	NotificationVerbatimParams = []string{"actor", "title", "doc_id", "version", "round", "id", "note", "reason"}
+)
+
+// notificationParamAllowed reports whether name is in the closed set.
+func notificationParamAllowed(name string) bool {
+	if name == NotificationEntityParam {
+		return true
+	}
+	for _, n := range NotificationEnumParams {
+		if n == name {
+			return true
+		}
+	}
+	for _, n := range NotificationVerbatimParams {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate reports an unknown param name.
+//
+// An unlisted name means one of two things, and both are silent in production:
+// an enum spliced into a frame with no group to translate it through, or a
+// param no frame interpolates at all (a typo, or a rename on one side only).
+// Neither produces an error, a warning, or a diff that reads wrong to an
+// English-speaking reviewer — the frame simply renders with the placeholder
+// unfilled or the value untranslated, and only for a non-English user.
+//
+// Note the closed set here is NOT the one plan 81 §1 defines for API errors
+// (entity/field/status/count). Different surface, different set; they are easy
+// to conflate.
+func (c NotificationContent) Validate() error {
+	for name := range c.Params {
+		if !notificationParamAllowed(name) {
+			return fmt.Errorf("notification param %q is not in the closed set (see the Notification*Params vars)", name)
+		}
+	}
+	return nil
+}
+
 // paramsJSON marshals Params for the JSONB column, returning nil (SQL NULL) for
 // an empty map. ok is false only when a non-empty map failed to marshal — the
 // caller must then store the row English-only (see keyedColumns): the params a
@@ -73,7 +140,30 @@ func (c NotificationContent) paramsJSON() (b []byte, ok bool) {
 // keys are dropped too, so the row is unambiguously English-only and the client
 // takes the Title/Body fallback instead of rendering a half-filled frame. A
 // lost translation beats a lost inbox item; a broken translation beats neither.
+//
+// A param outside the closed set degrades the same way, for the same reason.
+// Plan 82 step 7 proposed failing the write on an unknown name, to make the
+// guard a runtime guarantee as well as a test-time one — but a failed write
+// here IS a lost inbox item, which the line above already decided against, and
+// a param that fails validation is by definition one no frame renders
+// correctly anyway. So the row goes in English-only.
+//
+// But degrading quietly would make a call-site typo LESS visible than it was
+// before this check existed: an unknown param used to be stored, and the frame
+// then rendered with an unfilled slot that every user saw, English included.
+// Dropping the keys renders the English title perfectly and hides the bug from
+// exactly the reviewer most likely to catch it. So this branch logs, and that
+// log is the call-site half of the guarantee — the Go tests can only check the
+// catalogue side, because params are inline map literals at each call site and
+// no amount of constant-declaring makes them statically enumerable.
+//
+// The marshal branch below stays silent by contrast: a map[string]any failing
+// to marshal is not a realistic programmer error, while a param typo is.
 func (c NotificationContent) keyedColumns() (titleKey, bodyKey *string, params []byte) {
+	if err := c.Validate(); err != nil {
+		log.Printf("notification %q: %v (storing English-only)", c.TitleKey, err)
+		return nil, nil, nil
+	}
 	params, ok := c.paramsJSON()
 	if !ok {
 		return nil, nil, nil

--- a/internal/isms/db/notifications_test.go
+++ b/internal/isms/db/notifications_test.go
@@ -1,7 +1,11 @@
 package db
 
 import (
+	"bytes"
 	"encoding/json"
+	"log"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -144,5 +148,104 @@ func TestNotificationJSONOmitsKeysWhenAbsent(t *testing.T) {
 	// The English original stays alongside the key — it is the fallback.
 	if m["title"] != "New critical incident: Outage" {
 		t.Errorf("title = %v, want the English original preserved", m["title"])
+	}
+}
+
+func TestNotificationContentValidate(t *testing.T) {
+	t.Run("the closed set is accepted", func(t *testing.T) {
+		// Every name the schema documents, in one map — so a name dropped from
+		// the Notification*Params vars fails here rather than at a call site.
+		params := map[string]any{}
+		for _, n := range NotificationEnumParams {
+			params[n] = "x"
+		}
+		params[NotificationEntityParam] = "risk"
+		for _, n := range NotificationVerbatimParams {
+			params[n] = "x"
+		}
+		c := NotificationContent{TitleKey: "notifications.incident_status", Params: params}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("the documented closed set must validate: %v", err)
+		}
+	})
+
+	t.Run("no params validates", func(t *testing.T) {
+		// Agent rows and legacy call sites carry none.
+		if err := (NotificationContent{Title: "x"}).Validate(); err != nil {
+			t.Fatalf("empty params: %v", err)
+		}
+	})
+
+	t.Run("an unknown name is rejected and named", func(t *testing.T) {
+		// `severity_label` is the realistic mistake: a plausible-looking name
+		// that no frame interpolates, so the slot it was meant to fill renders
+		// empty and nothing else complains.
+		err := NotificationContent{Params: map[string]any{
+			"actor":          "alice@example.com",
+			"severity_label": "critical",
+		}}.Validate()
+		if err == nil {
+			t.Fatal("want an error for a param outside the closed set")
+		}
+		if !strings.Contains(err.Error(), "severity_label") {
+			t.Errorf("the error must name the offending param, got: %v", err)
+		}
+	})
+
+	t.Run("an API-error param name is rejected", func(t *testing.T) {
+		// `field` belongs to plan 81 §1's closed set for API errors, not this
+		// one. The two sets are easy to conflate, so pin the boundary.
+		if err := (NotificationContent{Params: map[string]any{"field": "title"}}).Validate(); err == nil {
+			t.Error("`field` is the API-error set, not the notification set — want an error")
+		}
+	})
+}
+
+func TestNotificationKeyedColumnsDropsKeysOnBadParam(t *testing.T) {
+	// Same degradation as an unmarshallable param map: keys and params travel
+	// together, so the row is unambiguously English-only and the client takes
+	// the Title fallback instead of rendering a frame with an empty slot.
+	// Deliberately NOT a failed write — a lost inbox item is worse than a lost
+	// translation.
+	titleKey, bodyKey, params := NotificationContent{
+		Title:    "Incident resolved: Laptop theft",
+		TitleKey: "notifications.incident_status",
+		BodyKey:  "notifications.incident_status.body",
+		Params:   map[string]any{"status": "resolved", "not_a_param": 1},
+	}.keyedColumns()
+	if titleKey != nil || bodyKey != nil || params != nil {
+		t.Errorf("want all three columns nil, got titleKey=%v bodyKey=%v params=%q", titleKey, bodyKey, params)
+	}
+}
+
+func TestNotificationKeyedColumnsLogsABadParam(t *testing.T) {
+	// The log is the call-site half of the param guard. The Go tests in
+	// internal/isms/api can only check the catalogue side — params are inline
+	// map literals at each call site, so nothing makes them statically
+	// enumerable — and the degrade branch renders a perfect English title,
+	// which hides the bug from exactly the reviewer most likely to catch it.
+	// Without this output there is no signal at all, which is why it is pinned
+	// rather than left as incidental logging.
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	NotificationContent{
+		TitleKey: "notifications.incident_new",
+		Params:   map[string]any{"severity_label": "critical"},
+	}.keyedColumns()
+	if got := buf.String(); !strings.Contains(got, "severity_label") || !strings.Contains(got, "English-only") {
+		t.Errorf("want a log naming the offending param and the degradation, got %q", got)
+	}
+
+	// And silent on the happy path — a log on every keyed write would train
+	// readers to ignore it.
+	buf.Reset()
+	NotificationContent{
+		TitleKey: "notifications.incident_new",
+		Params:   map[string]any{"severity": "critical", "title": "Laptop theft"},
+	}.keyedColumns()
+	if buf.Len() != 0 {
+		t.Errorf("valid params must not log, got %q", buf.String())
 	}
 }


### PR DESCRIPTION
Closes the last open item of the notification-keying work started in #220 and continued in #234. Part of #212, which stays open through the pt-BR contribution.

## What problem this solves

Notifications are stored in the database as pre-rendered English text. Since #220 we also store a *key* alongside them, and since #234 the app renders that key in the reader's language. So a notification written today reaches an Indonesian user in Indonesian.

That only works if every notification type has a translation. When one is missing, the app quietly falls back to the stored English — no error, no warning, nothing in the logs. That fallback is deliberate and load-bearing: it is what keeps old notifications, agent notifications and a half-finished translation from breaking the inbox.

The catch is that **the safety net also hides its own gaps.** A developer adding a new notification type and forgetting the translation sees a notification that works perfectly. So does the reviewer, because both are reading it in English. The only person who sees the bug is the non-English user, in production, and nothing tells them anything is wrong — the notification just arrives in the wrong language, forever.

Nothing checked for this. The existing test asserted a list of 25 keys typed by hand into the test file, with no connection to what the application actually sends: add a 14th notification type and every existing check stays green.

## What this adds

An automated check, running on every pull request, that fails the build if a notification can reach a user untranslated. It is not a new feature and changes nothing users see.

Five things are now enforced:

1. Every notification the backend can send has an English translation.
2. Every translation still corresponds to a notification that exists (so renaming one doesn't leave a dead entry every future translator keeps translating).
3. Every value a translated sentence expects to have filled in — a name, a document title, a severity — is one the backend actually sends **for that particular notification**, **in every language, not just English**.
4. A translated sentence cannot invent a slot the English one doesn't have.
5. Every notification is written through a declared name, so none can slip past checks 1–4 by naming itself inline.
6. The two places that decide which values get translated before they land in a sentence — one in Go, one in the frontend — cannot disagree.
7. A new notification type cannot accidentally opt itself out of checks 1–6.

## Cost and risk

Low. No database change, no API change, no frontend change, nothing users see. The check runs in the existing fast test job that needs no database, and adds about a second.

The one thing a reviewer should weigh in on is a **judgment call about what happens when a notification is malformed**. The obvious answer is to refuse to save it. This does the opposite: it saves the notification in English and writes the problem to the server log.

The reasoning is that refusing to save means the user never receives the notification at all — someone loses a real inbox item to protect a translation, which is the wrong way round. The existing code already settled this exact trade for a related case, in as many words: *"a lost translation beats a lost inbox item; a broken translation beats neither"* (`internal/isms/db/notifications.go:141`). Logging keeps the mistake visible to us without charging it to the user.

## Verification

Rather than trust that the checks work, each one was deliberately broken and confirmed to fail — an untranslated notification, a stale translation, a mistyped value, a translation with an invented slot, and a new notification type sneaking past — then restored.

Backend tests, frontend tests (111), formatting and build all pass.

Two rounds of review found gaps **in the checks themselves**, each demonstrated before fixing.

First round:

- The check that stops a new notification type opting out could be fooled by a trailing code comment — the style used throughout this repo — or by a digit in the name (`iso27001_…`). Both were invisible to it, and invisibility cancelled out: the check passed while the notification shipped untranslated.
- The value check only looked at English, the one language that renders correctly no matter what, leaving Indonesian — the language of the person this protects — unchecked. Renaming a slot in the Indonesian file passed every test in the repository while silently deleting the person's name from the sentence.
- A second slot format the translation library accepts was not recognised at all.

Second round, from automated review, four more:

- The value check compared a slot against the *vocabulary* of names the backend knows rather than the names that particular notification sends. Adding a `reason` slot to the incident-status sentence in every language passed, while that notification sends only a status, a title and a number — so the clause rendered blank. Values are now declared per notification and each sentence is checked against its own.
- Nothing required a notification to be written through a declared name. A new one could name itself inline, or hand the name to a shared helper, and every check above stayed green while it shipped with no translation in any language — the original bug arriving through the one door left open. Inline names are now rejected across the whole server, not just the package that happens to hold today's call sites.
- The slot pattern still described a narrower name than the translation library actually accepts: it also allows hyphens, dollars and surrounding spaces. An unrecognised slot is not merely missed, it is exempt from both value checks at once, so a translator hyphenating a name got a blank slot with the build green. The pattern now accepts anything in braces and lets the value check judge it.
- Which values are translated before landing in a sentence is stated twice, once in Go and once in the frontend, with nothing keeping the two in step. Adding one on the backend alone left the frontend splicing the raw English word into an otherwise translated sentence — the half-translated output the split exists to prevent. The two statements are now compared.

All seven are fixed and now fail as intended. What stays unenforceable is the writing side of the value contract: the values are assembled conditionally at each call site and cannot be read off the source, so a mistake there is still caught at runtime by the existing log rather than at build time.

## Sequencing

Independent of #243 (the id-ID release gate and raw-text ratchet), which is still open. The two branches share no files and this one touches no `.vue` templates, so neither invalidates the other and they can merge in either order.

This is a different surface from #243's raw-text check, which counts hardcoded English in the UI. Reading "#243 is merged" as covering notifications would be a mistake — that gap is what this closes.

