### PR TITLE
fix(test): unblock the go-unit CI job on master

### DIFF
--- a/internal/isms/api/errors_test.go
+++ b/internal/isms/api/errors_test.go
@@ -30,13 +30,15 @@ import (
 
 // ---- locale catalogue loading -------------------------------------------
 
-func localesDir(t *testing.T) string {
+// requireLocalesDir returns the shared locale root declared in
+// notification_keys_test.go, failing if it is missing. A missing catalogue is
+// the failure these tests exist to report, so it must never skip.
+func requireLocalesDir(t *testing.T) string {
 	t.Helper()
-	dir := filepath.Join("..", "..", "..", "web", "src", "locales")
-	if _, err := os.Stat(dir); err != nil {
-		t.Fatalf("locales directory not found at %s: %v", dir, err)
+	if _, err := os.Stat(localesDir); err != nil {
+		t.Fatalf("locales directory not found at %s: %v", localesDir, err)
 	}
-	return dir
+	return localesDir
 }
 
 // commonErrors returns the `common.error` group of one locale, flattened to
@@ -45,7 +47,7 @@ func localesDir(t *testing.T) string {
 // rather than at render time.
 func commonErrors(t *testing.T, locale string) map[string]string {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(localesDir(t), locale, "common.json"))
+	raw, err := os.ReadFile(filepath.Join(requireLocalesDir(t), locale, "common.json"))
 	if err != nil {
 		t.Fatalf("reading %s/common.json: %v", locale, err)
 	}
@@ -68,7 +70,7 @@ func commonErrors(t *testing.T, locale string) map[string]string {
 
 func commonGroup(t *testing.T, locale, group string) map[string]string {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(localesDir(t), locale, "common.json"))
+	raw, err := os.ReadFile(filepath.Join(requireLocalesDir(t), locale, "common.json"))
 	if err != nil {
 		t.Fatalf("reading %s/common.json: %v", locale, err)
 	}
@@ -87,7 +89,7 @@ func commonGroup(t *testing.T, locale, group string) map[string]string {
 
 func enumInlineGroup(t *testing.T, locale, group string) map[string]string {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(localesDir(t), locale, "common.json"))
+	raw, err := os.ReadFile(filepath.Join(requireLocalesDir(t), locale, "common.json"))
 	if err != nil {
 		t.Fatalf("reading %s/common.json: %v", locale, err)
 	}
@@ -102,7 +104,7 @@ func enumInlineGroup(t *testing.T, locale, group string) map[string]string {
 
 func localeDirs(t *testing.T) []string {
 	t.Helper()
-	entries, err := os.ReadDir(localesDir(t))
+	entries, err := os.ReadDir(requireLocalesDir(t))
 	if err != nil {
 		t.Fatalf("listing locales: %v", err)
 	}


### PR DESCRIPTION
## What is broken

The `go-unit` check on `master` is currently red, so every new pull request inherits a failing build. Nothing is wrong in production — the application itself compiles and runs, and the integration check is still green. Only the automated test suite fails to start.

## Why it happened

Two recent pieces of translation work landed close together:

- one added a guard that keeps notification messages in step with the translation files
- one added a guard that keeps API error messages in step with the translation files

Both needed to point at the same folder of translation files, and each one independently created a setting with the same name for that path. Each change passed its own checks before merging, because neither branch could see the other's new name. They only collide once both are on `master`.

This is a normal side effect of two parallel changes touching the same area, not a defect in either one. Both guards are still wanted and both stay.

## What this changes

The two guards now share a single definition of where the translation files live, instead of each declaring their own. The safety behaviour is unchanged: if the translation files are ever missing or moved, the tests still fail loudly rather than quietly passing.

Test-only change. No effect on the product, the database, or anything a customer sees.

## Verification

The full test suite for the affected area was run locally and passes; formatting and static checks are clean. Merging this returns `master` to green.

## Risk

Low. One test-support file touched, no product code.