### PR TITLE
test(web): stop the date-format tests asserting the runner's timezone

### DIFF
--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -48,9 +48,17 @@ test('epoch numbers are read as seconds or milliseconds by magnitude', () => {
 
 test('English formats British, so adopting the seam keeps the shape the UI had', () => {
   // The message bundle is tagged `en`; bare `en` would order dates US-style.
-  assert.equal(formatDate('2026-08-24T10:30:00Z'), '24 Aug 2026')
-  assert.equal(formatDate('2026-08-24T10:30:00Z', 'dayMonth'), '24 Aug')
-  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonthTime'), /^24 Aug, \d{2}:\d{2}$/)
+  //
+  // The day floats and the assertions do not name it. formatDate() renders an
+  // instant in the machine's zone, which is correct — only formatDay() pins to
+  // UTC, and the test below owns that. A fixed instant lands on a different
+  // calendar day either side of UTC (10:30Z is the 25th at UTC+14, the 23rd at
+  // UTC-12), so an exact-day expectation asserts the runner's timezone rather
+  // than the formatter. What matters here is the shape: day before month, short
+  // month name, four-digit year — "Aug 24, 2026" fails all three.
+  assert.match(formatDate('2026-08-24T10:30:00Z'), /^\d{1,2} Aug 2026$/)
+  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonth'), /^\d{1,2} Aug$/)
+  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonthTime'), /^\d{1,2} Aug, \d{2}:\d{2}$/)
 })
 
 test('relative time picks the largest fitting unit in both directions', () => {
@@ -67,7 +75,8 @@ test('recent timestamps read as relative, older ones pin to a date', () => {
   assert.equal(formatRecent(Date.now() - 2 * 60 * 60 * 1000), '2 hours ago')
   // Past the surface's threshold the wording gives way to an absolute date, so
   // a year-old item does not read "12 months ago".
-  assert.equal(formatRecent('2020-08-24T10:30:00Z'), '24 Aug 2020')
+  // Day omitted for the timezone reason given above; the year is the assertion.
+  assert.match(formatRecent('2020-08-24T10:30:00Z'), /^\d{1,2} Aug 2020$/)
   assert.equal(formatRecent(Date.now() - 2 * DAY, { within: DAY }), formatDate(Date.now() - 2 * DAY))
   assert.equal(formatRecent(null), '')
 })
@@ -95,9 +104,11 @@ test('the active locale drives every shape, not just the English fallback', asyn
   // Intl needs the tag, not the message bundle, so no loader is involved here.
   i18n.global.locale.value = 'id-ID'
   try {
-    assert.equal(formatDate('2026-08-05T14:30:00Z'), '5 Agu 2026')
+    // "Agu", not "Aug" — the locale is doing the work. Day omitted for the
+    // timezone reason given above; formatDay() below pins it and can assert it.
+    assert.match(formatDate('2026-08-05T14:30:00Z'), /^\d{1,2} Agu 2026$/)
     // Indonesian separates hours from minutes with a dot.
-    assert.match(formatDate('2026-08-05T14:30:00Z', 'datetime'), /5 Agu 2026, \d{2}\.\d{2}/)
+    assert.match(formatDate('2026-08-05T14:30:00Z', 'datetime'), /^\d{1,2} Agu 2026, \d{2}\.\d{2}$/)
     assert.equal(formatDay(Date.UTC(2026, 7, 5) / 1000), '5 Agu 2026')
     const now = Date.parse('2026-08-24T12:00:00Z')
     assert.equal(formatRelative(new Date(now - 5 * 60 * 1000), now), '5 menit yang lalu')
@@ -106,8 +117,9 @@ test('the active locale drives every shape, not just the English fallback', asyn
   } finally {
     i18n.global.locale.value = previous
   }
-  // …and the switch is not sticky.
-  assert.equal(formatDate('2026-08-05T14:30:00Z'), '5 Aug 2026')
+  // …and the switch is not sticky: "Aug" again, not "Agu". Day omitted for the
+  // timezone reason given above.
+  assert.match(formatDate('2026-08-05T14:30:00Z'), /^\d{1,2} Aug 2026$/)
 })
 
 test('useFormat exposes the seam under the names the contract documents', () => {

--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -56,9 +56,13 @@ test('English formats British, so adopting the seam keeps the shape the UI had',
   // UTC-12), so an exact-day expectation asserts the runner's timezone rather
   // than the formatter. What matters here is the shape: day before month, short
   // month name, four-digit year — "Aug 24, 2026" fails all three.
-  assert.match(formatDate('2026-08-24T10:30:00Z'), /^\d{1,2} Aug 2026$/)
-  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonth'), /^\d{1,2} Aug$/)
-  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonthTime'), /^\d{1,2} Aug, \d{2}:\d{2}$/)
+  // The day is constrained, not dropped: 10:30Z is the 23rd at UTC-12 and the
+  // 25th at UTC+14, and nothing in between reaches any other date. A bare
+  // \d{1,2} would also accept "99 Aug 2026", so a regression shifting the
+  // instant by weeks would pass.
+  assert.match(formatDate('2026-08-24T10:30:00Z'), /^(?:23|24|25) Aug 2026$/)
+  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonth'), /^(?:23|24|25) Aug$/)
+  assert.match(formatDate('2026-08-24T10:30:00Z', 'dayMonthTime'), /^(?:23|24|25) Aug, \d{2}:\d{2}$/)
 })
 
 test('relative time picks the largest fitting unit in both directions', () => {
@@ -75,8 +79,8 @@ test('recent timestamps read as relative, older ones pin to a date', () => {
   assert.equal(formatRecent(Date.now() - 2 * 60 * 60 * 1000), '2 hours ago')
   // Past the surface's threshold the wording gives way to an absolute date, so
   // a year-old item does not read "12 months ago".
-  // Day omitted for the timezone reason given above; the year is the assertion.
-  assert.match(formatRecent('2020-08-24T10:30:00Z'), /^\d{1,2} Aug 2020$/)
+  // Same instant-of-day as above, so the same three possible dates.
+  assert.match(formatRecent('2020-08-24T10:30:00Z'), /^(?:23|24|25) Aug 2020$/)
   assert.equal(formatRecent(Date.now() - 2 * DAY, { within: DAY }), formatDate(Date.now() - 2 * DAY))
   assert.equal(formatRecent(null), '')
 })
@@ -104,11 +108,11 @@ test('the active locale drives every shape, not just the English fallback', asyn
   // Intl needs the tag, not the message bundle, so no loader is involved here.
   i18n.global.locale.value = 'id-ID'
   try {
-    // "Agu", not "Aug" — the locale is doing the work. Day omitted for the
-    // timezone reason given above; formatDay() below pins it and can assert it.
-    assert.match(formatDate('2026-08-05T14:30:00Z'), /^\d{1,2} Agu 2026$/)
+    // "Agu", not "Aug" — the locale is doing the work. 14:30Z is the 5th at
+    // UTC-12 and the 6th at UTC+14, so those are the only two possible days.
+    assert.match(formatDate('2026-08-05T14:30:00Z'), /^(?:5|6) Agu 2026$/)
     // Indonesian separates hours from minutes with a dot.
-    assert.match(formatDate('2026-08-05T14:30:00Z', 'datetime'), /^\d{1,2} Agu 2026, \d{2}\.\d{2}$/)
+    assert.match(formatDate('2026-08-05T14:30:00Z', 'datetime'), /^(?:5|6) Agu 2026, \d{2}\.\d{2}$/)
     assert.equal(formatDay(Date.UTC(2026, 7, 5) / 1000), '5 Agu 2026')
     const now = Date.parse('2026-08-24T12:00:00Z')
     assert.equal(formatRelative(new Date(now - 5 * 60 * 1000), now), '5 menit yang lalu')
@@ -117,9 +121,8 @@ test('the active locale drives every shape, not just the English fallback', asyn
   } finally {
     i18n.global.locale.value = previous
   }
-  // …and the switch is not sticky: "Aug" again, not "Agu". Day omitted for the
-  // timezone reason given above.
-  assert.match(formatDate('2026-08-05T14:30:00Z'), /^\d{1,2} Aug 2026$/)
+  // …and the switch is not sticky: "Aug" again, not "Agu".
+  assert.match(formatDate('2026-08-05T14:30:00Z'), /^(?:5|6) Aug 2026$/)
 })
 
 test('useFormat exposes the seam under the names the contract documents', () => {


### PR DESCRIPTION
## The problem

Four checks in our date-formatting test suite would fail for any developer working far enough east — New Zealand, Fiji, Samoa. The code they were testing is correct; the checks themselves were written in a way that depends on where the person running them happens to be.

Our automated build server runs on UTC, so it never noticed. Anyone in those timezones would clone the project and immediately see four red tests on code nobody had touched — the kind of thing that costs a new contributor an afternoon and teaches everyone else to ignore red tests.

This surfaced during a pre-release review of the date-formatting work that went in recently. Nothing customers can see is affected.

## Why it happened

A moment in time is a different calendar day depending on where you are. The same instant can be the 23rd, the 24th or the 25th of the month depending on the timezone. The checks named one specific day, so they were really recording the timezone of the machine that ran them rather than testing the formatter.

## What this changes

The checks now confirm the *shape* of the date — day before month, short month name, four-digit year, and the Indonesian month name when the app is in Indonesian — rather than one particular day. That was always the point of these checks: to prove British-style dates stay British and that switching language changes the output.

Nothing is weakened. Dates that must land on an exact day — a due date, a review date — are handled by a separate helper with its own test, and that test still pins the exact day and is unaffected by timezone.

## Verification

The suite passes in full (122 checks) in seven timezones spanning the entire world, from the furthest behind UTC to the furthest ahead. I also confirmed the relaxed checks still do their job by deliberately breaking the date format to the American style — five checks fail, as they should.

## Risk

None to the product. One test file changed; no application code touched.