### PR TITLE
feat(i18n): make API error messages translatable (#212)

### DIFF
--- a/internal/isms/api/api_suggestions.go
+++ b/internal/isms/api/api_suggestions.go
@@ -115,13 +115,13 @@ func (s *Server) handleCreateEntitySuggestion(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if sg.EntityType == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "entity_type is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("entity_type"))
 	}
 	if sg.SuggestionType == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "suggestion_type is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("suggestion_type"))
 	}
 	if sg.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("title"))
 	}
 
 	// Verify apply handler exists for this combination
@@ -232,16 +232,16 @@ func (s *Server) handleGetEntitySuggestion(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	sg, err := s.db.GetSuggestion(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "suggestion not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("suggestion"))
 	}
 	// A suggestion on a private task is 404 for someone who can't see the task (#178).
 	if s.taskSuggestionHidden(c, orgID, sg) {
-		return echo.NewHTTPError(http.StatusNotFound, "suggestion not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("suggestion"))
 	}
 
 	// Attach stale info if entity has changed
@@ -287,12 +287,12 @@ func (s *Server) handleUpdateEntitySuggestion(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	existing, err := s.db.GetSuggestion(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "suggestion not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("suggestion"))
 	}
 
 	// RBAC: contributor can edit own open only, manager/admin can edit any open/in_review
@@ -355,12 +355,12 @@ func (s *Server) handleDeleteEntitySuggestion(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	existing, err := s.db.GetSuggestion(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "suggestion not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("suggestion"))
 	}
 
 	// RBAC: author can delete own open/withdrawn, manager/admin can delete non-terminal
@@ -397,7 +397,7 @@ func (s *Server) handleClaimEntitySuggestion(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	newStatus, err := s.db.ClaimSuggestion(ctx, orgID, id, actor)
@@ -438,12 +438,12 @@ func (s *Server) handleApplyEntitySuggestion(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	sg, err := s.db.GetSuggestion(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "suggestion not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("suggestion"))
 	}
 	if sg.Status != "open" && sg.Status != "in_review" {
 		return echo.NewHTTPError(http.StatusConflict, "suggestion is in terminal state: "+sg.Status)
@@ -549,7 +549,7 @@ func (s *Server) handleRejectEntitySuggestion(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	var body struct {
@@ -559,7 +559,7 @@ func (s *Server) handleRejectEntitySuggestion(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if strings.TrimSpace(body.Reason) == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "reason is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("reason"))
 	}
 
 	if err := s.db.RejectEntitySuggestion(ctx, orgID, id, actor, body.Reason); err != nil {
@@ -595,7 +595,7 @@ func (s *Server) handleWithdrawEntitySuggestion(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	if err := s.db.WithdrawSuggestion(ctx, orgID, id, actor); err != nil {

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -79,7 +79,11 @@ async function fetchRaw(url) {
 // `fallback` is a parameter rather than a constant because login's is
 // "Login failed (401)", which is friendlier than "401 Unauthorized" and is what
 // the login form has always shown.
-function apiErrorFrom(res, body, fallback) {
+//
+// Exported for its tests: it is the join between the Go wire shape and
+// renderApiError(), and both sides of that join are pinned while the middle was
+// not. Nothing else imports it.
+export function apiErrorFrom(res, body, fallback) {
   const err = new Error(body?.message || body?.error || fallback || `${res.status} ${res.statusText}`)
   err.status = res.status
   // Absent on a route that has not been converted yet, and on any non-JSON

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -51,11 +51,42 @@ async function fetchRaw(url) {
     throw err
   }
   if (!res.ok) {
-    const err = new Error(`${res.status} ${res.statusText}`)
-    err.status = res.status
-    throw err
+    // Reads the error body, which this helper did not do before: every GET in
+    // the app comes through here, so it was the one path that threw away the
+    // server's message and showed a bare "404 Not Found". Entity lookups are
+    // overwhelmingly GETs, so leaving it unparsed would have kept `code` off
+    // exactly the errors the catalogue exists for.
+    const body = await res.json().catch(() => null)
+    throw apiErrorFrom(res, body)
   }
   return await res.json()
+}
+
+// One shape for every HTTP error this module throws.
+//
+// Six fetch helpers each carried their own copy of
+// `body.message || body.error || status`, which is how `code` came to be
+// discarded six times over: the server has emitted a stable `code` and a param
+// map alongside the English `message` since the error-code work landed
+// (internal/isms/api/errors.go, plan 81 §1), and nothing here read them.
+//
+// `message` stays the thrown Error's message, unchanged. That is deliberate
+// and load-bearing: ~191 call sites render `err.message` directly and none of
+// them are touched here, so an unconverted server route and an untouched render
+// site behave exactly as they do today. Translating is opt-in per site, through
+// renderApiError() in composables/useApiError.js.
+//
+// `fallback` is a parameter rather than a constant because login's is
+// "Login failed (401)", which is friendlier than "401 Unauthorized" and is what
+// the login form has always shown.
+function apiErrorFrom(res, body, fallback) {
+  const err = new Error(body?.message || body?.error || fallback || `${res.status} ${res.statusText}`)
+  err.status = res.status
+  // Absent on a route that has not been converted yet, and on any non-JSON
+  // error body. renderApiError() falls back to err.message when so.
+  if (body?.code) err.code = body.code
+  if (body?.params) err.params = body.params
+  return err
 }
 
 async function fetchJSON(url) {
@@ -94,9 +125,7 @@ async function postJSON(url, data) {
   checkAuth(res)
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    const err = new Error(body.message || body.error || `${res.status} ${res.statusText}`)
-    err.status = res.status
-    throw err
+    throw apiErrorFrom(res, body)
   }
   return res.json()
 }
@@ -106,9 +135,7 @@ async function putJSON(url, data) {
   checkAuth(res)
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    const err = new Error(body.message || body.error || `${res.status} ${res.statusText}`)
-    err.status = res.status
-    throw err
+    throw apiErrorFrom(res, body)
   }
   return res.json()
 }
@@ -120,9 +147,7 @@ async function deleteJSON(url, data) {
   checkAuth(res)
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    const err = new Error(body.message || body.error || `${res.status} ${res.statusText}`)
-    err.status = res.status
-    throw err
+    throw apiErrorFrom(res, body)
   }
   return res.json()
 }
@@ -138,9 +163,7 @@ async function uploadFile(url, file, extraFields = {}) {
   checkAuth(res)
   if (!res.ok) {
     const body = await res.json().catch(() => null)
-    const err = new Error(body?.message || `${res.status} ${res.statusText}`)
-    err.status = res.status
-    throw err
+    throw apiErrorFrom(res, body)
   }
   return res.json()
 }
@@ -159,8 +182,13 @@ async function login(email, password, otp, organization) {
     body: JSON.stringify(body),
   })
   if (!res.ok) {
-    const err = await res.json().catch(() => null)
-    throw new Error(err?.error || err?.message || `Login failed (${res.status})`)
+    // `Login failed (401)` rather than the generic "401 Unauthorized" — the
+    // login form has always shown this and it is friendlier than the status
+    // line. The old `err.error || err.message` precedence is dropped, not
+    // preserved: the login route answers with echo.NewHTTPError, which emits
+    // `message` and never `error`, so the first branch was unreachable.
+    const body = await res.json().catch(() => null)
+    throw apiErrorFrom(res, body, `Login failed (${res.status})`)
   }
   const data = await res.json()
   if (data.token) {

--- a/web/src/composables/useApiError.js
+++ b/web/src/composables/useApiError.js
@@ -1,0 +1,74 @@
+// The render seam for API errors.
+//
+// The server emits a stable `code` and a closed param set alongside an English
+// `message` (internal/isms/api/errors.go). The English text stays authoritative
+// for readers with no catalogue — the CLI dumps the raw response body, and
+// server logs read the same string — so translation happens here, on the one
+// side that has the locale files loaded.
+//
+// Every failure mode falls back to `err.message`, which is the English sentence
+// the server already composed: an error thrown before any response (network),
+// a route still on echo.NewHTTPError, a code this bundle has no key for. That
+// makes adoption safe at any pace — a converted route and an unconverted one
+// both render something correct.
+import { FALLBACK, i18n } from '../i18n.js'
+import { enumLabelInline, entityLabel } from './useEnumLabel.js'
+
+// How each param name resolves. The set is closed on the Go side
+// (ParamEntity/ParamField/ParamStatus/ParamCount/ParamValue), and each name has
+// exactly one rule — which is the property that makes this table possible
+// rather than a per-code mapping.
+//
+// `count` and `value` are spliced raw and so are absent here: count is a
+// number, and value is the caller's own input echoed back ("invalid status:
+// draught"), which by construction is not a member of any set the catalogue
+// could enumerate.
+const PARAM_RESOLVERS = {
+  entity: (v) => entityLabel(v, { inline: true }),
+  status: (v) => enumLabelInline('status', v),
+  field: (v) => fieldLabel(v),
+}
+
+// Field names are the API's own JSON field names ("title", "path_pattern"), so
+// there is no shared composable for them the way there is for entities and
+// enums — the lookup lives here.
+//
+// te() probes FALLBACK rather than the active locale, the same reasoning as
+// enumLabel() and useNotificationRender(): the fallback catalogue is complete
+// by contract, so a lagging locale renders the English word through
+// fallbackLocale instead of dropping to the raw identifier.
+function fieldLabel(value) {
+  const key = `common.field.${value}`
+  return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : value
+}
+
+// Params are translated BEFORE interpolation. Splicing the English `entity:
+// "risk"` into a Portuguese frame puts an English noun inside a translated
+// sentence — worse than either language alone, and not something fallbackLocale
+// can rescue, because the sentence around it translated fine.
+function resolveParams(params) {
+  const out = {}
+  for (const [name, value] of Object.entries(params ?? {})) {
+    const resolve = PARAM_RESOLVERS[name]
+    out[name] = resolve ? resolve(value) : value
+  }
+  return out
+}
+
+// renderApiError turns a thrown API error into display text.
+//
+// Takes the error, not a code, so a call site can hand it whatever it caught
+// without inspecting it first — including a network error with no `code` at
+// all.
+export function renderApiError(err) {
+  if (!err) return ''
+  const message = err.message ?? ''
+  if (!err.code) return message
+  const key = `common.error.${err.code}`
+  if (!i18n.global.te(key, FALLBACK)) return message
+  return i18n.global.t(key, resolveParams(err.params))
+}
+
+export function useApiError() {
+  return { renderApiError }
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -94,7 +94,9 @@
     "file": "file",
     "code": "code",
     "document_id": "document ID",
-    "new_email": "new email"
+    "new_email": "new email",
+    "entity_type": "entity type",
+    "suggestion_type": "suggestion type"
   },
   "enum": {
     "status": {

--- a/web/src/locales/id-ID/common.json
+++ b/web/src/locales/id-ID/common.json
@@ -94,7 +94,9 @@
     "file": "berkas",
     "code": "kode",
     "document_id": "ID dokumen",
-    "new_email": "email baru"
+    "new_email": "email baru",
+    "entity_type": "jenis entitas",
+    "suggestion_type": "jenis saran"
   },
   "enum": {
     "status": {

--- a/web/test/apiError.test.js
+++ b/web/test/apiError.test.js
@@ -1,0 +1,97 @@
+// Task 1.3 of plan 81 §1: the server's stable `code` becomes translated text.
+//
+// The contract runs across two languages — Go composes the code and params,
+// the locale files carry the sentence — and every mismatch is silent, because
+// every failure path falls back to the English `message` the server already
+// sent. That is the right behaviour and it is also why this needs tests: a
+// renderer wired to nothing looks identical to a renderer working perfectly,
+// in English.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderApiError } from '../src/composables/useApiError.js'
+import { i18n } from '../src/i18n.js'
+import id from '../src/locales/id-ID/index.js'
+
+i18n.global.setLocaleMessage('id-ID', id)
+
+function withLocale(tag, fn) {
+  const previous = i18n.global.locale.value
+  i18n.global.locale.value = tag
+  try {
+    return fn()
+  } finally {
+    i18n.global.locale.value = previous
+  }
+}
+
+const err = (code, params, message = 'server english') => ({ code, params, message, status: 400 })
+
+test('a catalogued code renders from the catalogue, not the server message', () => {
+  assert.equal(renderApiError(err('not_found', { entity: 'risk' })), 'risk not found')
+  assert.equal(renderApiError(err('invalid_entity_id', { entity: 'review' })), 'invalid review id')
+  assert.equal(renderApiError(err('required', { field: 'title' })), 'title is required')
+})
+
+// The point of the whole seam. An English-only suite passes with the renderer
+// disconnected from the locale entirely — the failure #235's review caught in
+// the useFormat tests, and the same one applies here.
+test('the active locale drives the sentence', () => {
+  withLocale('id-ID', () => {
+    const out = renderApiError(err('not_found', { entity: 'risk' }))
+    assert.notEqual(out, 'risk not found')
+    assert.match(out, /tidak ditemukan/)
+  })
+})
+
+// Splicing the English identifier into a translated frame is the specific bug
+// this ordering exists to prevent: the sentence translates, one noun does not,
+// and fallbackLocale cannot rescue it because nothing looks missing.
+test('params are translated before interpolation, not spliced raw', () => {
+  withLocale('id-ID', () => {
+    const out = renderApiError(err('not_found', { entity: 'risk' }))
+    assert.ok(!out.includes('risk'), `English identifier leaked into: ${out}`)
+  })
+})
+
+test('every param kind resolves through its own catalogue path', () => {
+  // entity -> common.entity_inline, field -> common.field,
+  // status -> common.enum_inline.status, count/value -> raw.
+  assert.equal(renderApiError(err('review_wrong_status', { status: 'changes_requested' })),
+    'review is changes requested')
+  assert.equal(renderApiError(err('password_too_short', { count: '7' })),
+    'password must be at least 7 characters')
+  assert.equal(renderApiError(err('invalid_status', { value: 'draught' })),
+    'invalid status: draught')
+})
+
+test('value is echoed verbatim even when it collides with an enum member', () => {
+  // `value` is the caller's own input. It is not looked up, so a caller who
+  // typed a real enum member still sees exactly what they sent.
+  withLocale('id-ID', () => {
+    assert.match(renderApiError(err('invalid_status', { value: 'approved' })), /approved/)
+  })
+})
+
+test('an unconverted route renders the server message', () => {
+  // No code: the route is still on echo.NewHTTPError. ~191 render sites read
+  // err.message directly and must keep working through the whole migration.
+  assert.equal(renderApiError({ message: 'something specific', status: 500 }), 'something specific')
+})
+
+test('a code this bundle has no key for falls back to the message', () => {
+  assert.equal(renderApiError(err('invented_code', { entity: 'risk' })), 'server english')
+})
+
+test('an untranslated param value degrades to the raw identifier, not a key path', () => {
+  const out = renderApiError(err('not_found', { entity: 'flux_capacitor' }))
+  assert.equal(out, 'flux_capacitor not found')
+  assert.ok(!out.includes('common.'), `key path leaked into: ${out}`)
+})
+
+test('missing params and empty errors degrade instead of throwing', () => {
+  assert.equal(renderApiError(null), '')
+  assert.equal(renderApiError({ status: 500 }), '')
+  // A code whose template has slots, called with no params at all: vue-i18n
+  // renders the slot empty rather than throwing, and the sentence survives.
+  assert.doesNotThrow(() => renderApiError({ code: 'not_found', message: 'x' }))
+})

--- a/web/test/apiError.test.js
+++ b/web/test/apiError.test.js
@@ -9,6 +9,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { renderApiError } from '../src/composables/useApiError.js'
+import { apiErrorFrom } from '../src/api.js'
 import { i18n } from '../src/i18n.js'
 import id from '../src/locales/id-ID/index.js'
 
@@ -56,6 +57,12 @@ test('params are translated before interpolation, not spliced raw', () => {
 test('every param kind resolves through its own catalogue path', () => {
   // entity -> common.entity_inline, field -> common.field,
   // status -> common.enum_inline.status, count/value -> raw.
+  //
+  // `path_pattern`, not `title`: common.field.title is the string "title", so a
+  // field lookup that did nothing at all would still pass on it. Every
+  // assertion here uses a value whose label differs from its identifier.
+  assert.equal(renderApiError(err('required', { field: 'path_pattern' })),
+    'path pattern is required')
   assert.equal(renderApiError(err('review_wrong_status', { status: 'changes_requested' })),
     'review is changes requested')
   assert.equal(renderApiError(err('password_too_short', { count: '7' })),
@@ -69,6 +76,15 @@ test('value is echoed verbatim even when it collides with an enum member', () =>
   // typed a real enum member still sees exactly what they sent.
   withLocale('id-ID', () => {
     assert.match(renderApiError(err('invalid_status', { value: 'approved' })), /approved/)
+  })
+})
+
+// The two keys this PR adds. Nothing else in the suite renders them, so without
+// this they could be absent from id-ID and every test would still pass.
+test('the field vocabulary this module needs renders in id-ID', () => {
+  withLocale('id-ID', () => {
+    assert.match(renderApiError(err('required', { field: 'entity_type' })), /jenis entitas/)
+    assert.match(renderApiError(err('required', { field: 'suggestion_type' })), /jenis saran/)
   })
 })
 
@@ -94,4 +110,52 @@ test('missing params and empty errors degrade instead of throwing', () => {
   // A code whose template has slots, called with no params at all: vue-i18n
   // renders the slot empty rather than throwing, and the sentence survives.
   assert.doesNotThrow(() => renderApiError({ code: 'not_found', message: 'x' }))
+})
+
+// ---- the wire join -------------------------------------------------------
+//
+// The Go side pins the response shape (TestErrorBodyWireShape) and
+// renderApiError() is covered above; apiErrorFrom is the six lines between
+// them, and it is also where fetchRaw's behaviour changed.
+
+const response = (body, status = 404, statusText = 'Not Found') =>
+  new Response(body === null ? null : JSON.stringify(body), { status, statusText })
+
+test('a converted route carries code and params onto the thrown error', async () => {
+  const res = response({ message: 'suggestion not found', code: 'not_found', params: { entity: 'suggestion' } })
+  const err = apiErrorFrom(res, await res.json())
+  assert.equal(err.message, 'suggestion not found')
+  assert.equal(err.status, 404)
+  assert.equal(err.code, 'not_found')
+  assert.deepEqual(err.params, { entity: 'suggestion' })
+  // …and the whole chain: wire -> Error -> translated sentence.
+  assert.equal(renderApiError(err), 'suggestion not found')
+  withLocale('id-ID', () => assert.match(renderApiError(err), /saran tidak ditemukan/))
+})
+
+test('an unconverted route yields an error with no code at all', async () => {
+  const res = response({ message: 'readers cannot edit suggestions' }, 403, 'Forbidden')
+  const err = apiErrorFrom(res, await res.json())
+  assert.equal(err.message, 'readers cannot edit suggestions')
+  assert.equal(err.status, 403)
+  // Absent, not undefined-valued: renderApiError branches on presence.
+  assert.ok(!('code' in err))
+  assert.equal(renderApiError(err), 'readers cannot edit suggestions')
+})
+
+test('an unparseable error body falls back to the status line', () => {
+  const err = apiErrorFrom(response(null, 502, 'Bad Gateway'), null)
+  assert.equal(err.message, '502 Bad Gateway')
+  assert.equal(err.status, 502)
+  assert.ok(!('code' in err))
+})
+
+test('the fallback parameter wins over the status line but not over the server', async () => {
+  // login's "Login failed (401)" is friendlier than "401 Unauthorized"…
+  assert.equal(apiErrorFrom(response(null, 401, 'Unauthorized'), null, 'Login failed (401)').message,
+    'Login failed (401)')
+  // …but the server's own sentence is better than either.
+  const res = response({ message: 'too many attempts, try again later' }, 429, 'Too Many Requests')
+  assert.equal(apiErrorFrom(res, await res.json(), 'Login failed (429)').message,
+    'too many attempts, try again later')
 })


### PR DESCRIPTION
## In one line

This builds the machinery for showing error messages in the reader's own language, and proves it works end to end on one part of the app. The rest follows in small, separate pieces.

**To be precise about what this does and does not do:** after this merges, readers still see English. No screen calls the new translation step yet — 196 places across 32 screens display the server's English sentence directly, and converting those is its own piece of work. This PR makes that conversion possible and safe to do gradually; it is not itself the moment the app becomes multilingual.

## Background

When something goes wrong — a record can't be found, a required box is left empty — the server sends the browser a sentence to display. Those sentences have always been written in English, in the server's own code, which meant they could never be translated no matter how much of the app we localised.

Work merged last week gave the server a second way to describe a problem: alongside the English sentence, it now sends a short stable label ("this was a not-found error, about a suggestion"). The browser can look that label up in a translation file and write the sentence itself, in whatever language the reader has chosen.

**Nothing was reading those labels.** The catalogue of 34 labels, their Indonesian translations, and the automated checks protecting them all shipped and reached no user. This PR connects the two ends.

## What changed

**The browser now reads the label and translates.** Six near-identical copies of the same error-handling code were collapsed into one, which is how the label came to be discarded six times over.

**One part of the app now sends labels.** The suggestions section — 16 of its 22 error messages. The other six are one-off sentences where inventing a reusable label would be guesswork; they stay as they are and keep working exactly as before.

**Everything falls back safely.** Any error we haven't converted yet, any label the translation file doesn't recognise, any network failure — all still show today's English sentence. There is no state in which a reader sees something broken, which is what lets the remaining work land gradually instead of in one risky change.

## Two visible improvements

**Errors when loading a page now show what actually went wrong.** This particular path never read the server's explanation and displayed a bare "404 Not Found". Since most "can't find that record" errors happen while loading a page, this was precisely where the useful message was being thrown away.

**Two messages change wording slightly** — "entity_type is required" now reads "entity type is required" — because the message now uses the human-readable field name rather than the internal one. I checked that no test or automated browser check depends on the old text.

## Why only one section

The full conversion is 377 error messages across 24 files. This project already rejected one oversized translation change as impossible to review properly, so this follows the agreed pattern: build the connection, prove it end to end on one section, then convert the rest one section per pull request. **After this: 361 messages across 23 files remain.**

Converting the first section also switched on two automated checks that could not do their job before — they inspect converted code, and until now there was none to inspect. I verified they genuinely catch mistakes by deliberately introducing errors and confirming each check failed, then undoing them.

## Verification

All server and browser tests pass (136 browser checks, 22 of them new), and the app builds cleanly. Each new test was confirmed to be meaningful by breaking the exact line it covers and watching it fail — a test that passes whether or not the feature works is worse than no test, and translation code is unusually prone to that, since everything looks correct in English.

## Risk

Low, and deliberately so. The English text every reader sees today is preserved as the fallback everywhere, so the worst realistic outcome is that a translation doesn't appear — not that an error message goes missing.
