### PR TITLE
feat(i18n): confirm dialog buttons come from the translation catalogue (#212)

### DIFF
--- a/web/src/composables/useConfirm.js
+++ b/web/src/composables/useConfirm.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import { i18n } from '../i18n.js'
 
@@ -9,28 +9,34 @@ import { i18n } from '../i18n.js'
 // component instance, the same reason useFormat/useEnumLabel/useNotificationRender
 // reach for the global scope. Same keyspace either way.
 //
-// Resolved when the dialog opens, not reactively. The dialog is modal and
-// transient — there is no path from an open dialog to a locale change — so a
-// computed would buy nothing and would mean holding the caller's options in
-// module state to recompute from.
-const defaultConfirmLabel = () => i18n.global.t('common.action.confirm')
-const defaultCancelLabel = () => i18n.global.t('common.action.cancel')
+// Resolved reactively, not snapshotted when the dialog opens.
+//
+// A first draft snapshotted them, on the reasoning that the dialog is modal so
+// no user can reach the locale picker while it is up. That is true and it is
+// not the whole picture, as review pointed out: `main.js:16` calls the async
+// setLocale() WITHOUT awaiting it before mounting, and applyConfigLocales() and
+// applySessionLocale() re-apply the locale again when GET /config and GET /me
+// land. So the app is interactive before the locale settles, and a dialog
+// opened in that window would keep its old-language buttons while the page
+// behind it switched. Narrow and cosmetic, but the reactive version is also
+// simply the simpler code — it needs no seed value and no ordering argument.
 
 const visible = ref(false)
 const message = ref('')
-// Seeded empty rather than with English: every ask()/confirm() sets both before
-// the dialog becomes visible, and resolving at module scope would read the
-// catalogue before setLocale() has run during boot.
-const confirmLabel = ref('')
-const cancelLabel = ref('')
+// What the caller asked for, or '' to follow the catalogue. Storing the
+// override rather than the resolved label is what lets the default stay live.
+const confirmOverride = ref('')
+const cancelOverride = ref('')
+const confirmLabel = computed(() => confirmOverride.value || i18n.global.t('common.action.confirm'))
+const cancelLabel = computed(() => cancelOverride.value || i18n.global.t('common.action.cancel'))
 const variant = ref('danger') // 'danger' or 'warning'
 let resolveFn = null
 
 export function useConfirm() {
   function ask(msg, opts = {}) {
     message.value = msg
-    confirmLabel.value = opts.confirm || defaultConfirmLabel()
-    cancelLabel.value = opts.cancel || defaultCancelLabel()
+    confirmOverride.value = opts.confirm || ''
+    cancelOverride.value = opts.cancel || ''
     variant.value = opts.variant || 'danger'
     visible.value = true
     return new Promise(resolve => { resolveFn = resolve })
@@ -39,8 +45,8 @@ export function useConfirm() {
   // Options-object form: confirm({ message, variant, confirmLabel, cancelLabel })
   function confirm(opts = {}) {
     message.value = opts.message || ''
-    confirmLabel.value = opts.confirmLabel || defaultConfirmLabel()
-    cancelLabel.value = opts.cancelLabel || defaultCancelLabel()
+    confirmOverride.value = opts.confirmLabel || ''
+    cancelOverride.value = opts.cancelLabel || ''
     variant.value = opts.variant || 'danger'
     visible.value = true
     return new Promise(resolve => { resolveFn = resolve })

--- a/web/src/composables/useConfirm.js
+++ b/web/src/composables/useConfirm.js
@@ -1,17 +1,36 @@
 import { ref } from 'vue'
 
+import { i18n } from '../i18n.js'
+
+// The dialog's two buttons are the same words on every screen, so they come
+// from the shared action catalogue rather than being retyped as defaults here.
+//
+// `i18n.global.t` rather than `useI18n()`: this is a plain module with no
+// component instance, the same reason useFormat/useEnumLabel/useNotificationRender
+// reach for the global scope. Same keyspace either way.
+//
+// Resolved when the dialog opens, not reactively. The dialog is modal and
+// transient — there is no path from an open dialog to a locale change — so a
+// computed would buy nothing and would mean holding the caller's options in
+// module state to recompute from.
+const defaultConfirmLabel = () => i18n.global.t('common.action.confirm')
+const defaultCancelLabel = () => i18n.global.t('common.action.cancel')
+
 const visible = ref(false)
 const message = ref('')
-const confirmLabel = ref('Confirm')
-const cancelLabel = ref('Cancel')
+// Seeded empty rather than with English: every ask()/confirm() sets both before
+// the dialog becomes visible, and resolving at module scope would read the
+// catalogue before setLocale() has run during boot.
+const confirmLabel = ref('')
+const cancelLabel = ref('')
 const variant = ref('danger') // 'danger' or 'warning'
 let resolveFn = null
 
 export function useConfirm() {
   function ask(msg, opts = {}) {
     message.value = msg
-    confirmLabel.value = opts.confirm || 'Confirm'
-    cancelLabel.value = opts.cancel || 'Cancel'
+    confirmLabel.value = opts.confirm || defaultConfirmLabel()
+    cancelLabel.value = opts.cancel || defaultCancelLabel()
     variant.value = opts.variant || 'danger'
     visible.value = true
     return new Promise(resolve => { resolveFn = resolve })
@@ -20,8 +39,8 @@ export function useConfirm() {
   // Options-object form: confirm({ message, variant, confirmLabel, cancelLabel })
   function confirm(opts = {}) {
     message.value = opts.message || ''
-    confirmLabel.value = opts.confirmLabel || 'Confirm'
-    cancelLabel.value = opts.cancelLabel || 'Cancel'
+    confirmLabel.value = opts.confirmLabel || defaultConfirmLabel()
+    cancelLabel.value = opts.cancelLabel || defaultCancelLabel()
     variant.value = opts.variant || 'danger'
     visible.value = true
     return new Promise(resolve => { resolveFn = resolve })

--- a/web/test/confirm.test.js
+++ b/web/test/confirm.test.js
@@ -69,14 +69,40 @@ test('an explicit label still wins over the catalogue default', () => {
   assert.equal(viaConfirm.cancel, 'Cancel') // unset half still takes the default
 })
 
-test('labels are resolved by the time the dialog is visible', () => {
-  // App.vue renders the buttons only under v-if="visible", so the empty seed
-  // values must never be reachable. Asserting visibility and labels together is
-  // what pins that.
+test('labels are populated by the time the dialog is visible', () => {
   const { visible, confirm, cancel } = open((c) => c.ask('x'))
   assert.equal(visible, true)
   assert.notEqual(confirm, '')
   assert.notEqual(cancel, '')
+})
+
+// Review on #252 caught the reason this must be reactive rather than snapshotted
+// when the dialog opens: `main.js:16` calls the async setLocale() without
+// awaiting it before mounting, and applyConfigLocales()/applySessionLocale()
+// re-apply the locale when GET /config and GET /me land. The app is therefore
+// interactive before the locale settles, so a dialog CAN be open across a
+// locale change even though it is modal and the picker is unreachable behind it.
+test('a locale change while the dialog is open updates the labels', () => {
+  const c = useConfirm()
+  const promise = c.ask('x')
+  assert.equal(c.confirmLabel.value, 'Confirm')
+  withLocale('id-ID', () => {
+    assert.equal(c.confirmLabel.value, 'Konfirmasi')
+    assert.equal(c.cancelLabel.value, 'Batal')
+  })
+  assert.equal(c.confirmLabel.value, 'Confirm')
+  c.onCancel()
+  return promise
+})
+
+test('an explicit label is not touched by a locale change', () => {
+  // The override is the caller's own words — often already-translated copy from
+  // the calling screen. Re-resolving it would be wrong.
+  const c = useConfirm()
+  const promise = c.ask('x', { confirm: 'Discard' })
+  withLocale('id-ID', () => assert.equal(c.confirmLabel.value, 'Discard'))
+  c.onCancel()
+  return promise
 })
 
 test('the promise still resolves through the dialog buttons', () => {

--- a/web/test/confirm.test.js
+++ b/web/test/confirm.test.js
@@ -1,0 +1,93 @@
+// Plan 80 task 1.7: the confirm dialog's two buttons come from the catalogue.
+//
+// Small surface, but the failure is invisible in English: the defaults were the
+// literals 'Confirm'/'Cancel', which render correctly for the one locale that
+// never needed translating and are wrong everywhere else. So the assertions
+// that matter here are the id-ID ones.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { useConfirm } from '../src/composables/useConfirm.js'
+import { i18n } from '../src/i18n.js'
+import id from '../src/locales/id-ID/index.js'
+
+i18n.global.setLocaleMessage('id-ID', id)
+
+function withLocale(tag, fn) {
+  const previous = i18n.global.locale.value
+  i18n.global.locale.value = tag
+  try {
+    return fn()
+  } finally {
+    i18n.global.locale.value = previous
+  }
+}
+
+// The composable is module-level shared state, so every test closes its dialog
+// rather than leaving one open for the next.
+function open(fn) {
+  const c = useConfirm()
+  const promise = fn(c)
+  const labels = { confirm: c.confirmLabel.value, cancel: c.cancelLabel.value, visible: c.visible.value }
+  c.onCancel()
+  return { ...labels, promise }
+}
+
+test('the default labels come from common.action, not from literals', () => {
+  const { confirm, cancel } = open((c) => c.ask('Delete this?'))
+  assert.equal(confirm, 'Confirm')
+  assert.equal(cancel, 'Cancel')
+})
+
+test('the active locale drives the labels', () => {
+  withLocale('id-ID', () => {
+    const { confirm, cancel } = open((c) => c.ask('Hapus ini?'))
+    assert.equal(confirm, 'Konfirmasi')
+    assert.equal(cancel, 'Batal')
+  })
+})
+
+// Two call shapes exist — ask(msg, opts) and confirm({message, ...}) — and the
+// defaults were duplicated across both, which is how they drift.
+test('both call shapes resolve the same defaults', () => {
+  withLocale('id-ID', () => {
+    const viaAsk = open((c) => c.ask('x'))
+    const viaConfirm = open((c) => c.confirm({ message: 'x' }))
+    assert.equal(viaAsk.confirm, viaConfirm.confirm)
+    assert.equal(viaAsk.cancel, viaConfirm.cancel)
+    assert.equal(viaConfirm.confirm, 'Konfirmasi')
+  })
+})
+
+test('an explicit label still wins over the catalogue default', () => {
+  // The ~12 call sites passing 'Discard'/'Delete' are untouched by this task;
+  // they are template text and belong to the extraction phase.
+  const viaAsk = open((c) => c.ask('x', { confirm: 'Discard', cancel: 'Keep' }))
+  assert.equal(viaAsk.confirm, 'Discard')
+  assert.equal(viaAsk.cancel, 'Keep')
+  const viaConfirm = open((c) => c.confirm({ message: 'x', confirmLabel: 'Delete' }))
+  assert.equal(viaConfirm.confirm, 'Delete')
+  assert.equal(viaConfirm.cancel, 'Cancel') // unset half still takes the default
+})
+
+test('labels are resolved by the time the dialog is visible', () => {
+  // App.vue renders the buttons only under v-if="visible", so the empty seed
+  // values must never be reachable. Asserting visibility and labels together is
+  // what pins that.
+  const { visible, confirm, cancel } = open((c) => c.ask('x'))
+  assert.equal(visible, true)
+  assert.notEqual(confirm, '')
+  assert.notEqual(cancel, '')
+})
+
+test('the promise still resolves through the dialog buttons', () => {
+  // The labels changed; the control flow must not have.
+  const c = useConfirm()
+  const confirmed = c.ask('x')
+  c.onConfirm()
+  const cancelled = c.ask('y')
+  c.onCancel()
+  return Promise.all([confirmed, cancelled]).then(([a, b]) => {
+    assert.equal(a, true)
+    assert.equal(b, false)
+  })
+})


### PR DESCRIPTION
## In one line

The two buttons on the app's confirmation pop-up — "Confirm" and "Cancel" — now come from the translation files instead of being written into the code, so they appear in the reader's language.

## Why this one is worth doing on its own

It is a small change, but it sits on a surface every user touches: the pop-up that appears before deleting a record, discarding unsaved edits, or leaving a page with unsaved work. It appears on twelve screens.

It is also the last outstanding item in the app's translation groundwork apart from one larger piece of data work. Everything else in that groundwork is either merged or in review.

## What changed

The words "Confirm" and "Cancel" were written into the code in six places. They now come from the shared list of common button labels, which already contained both words in English and Indonesian — so no translation files needed changing.

The twelve places that pass their own button wording — "Discard", "Delete" — still do, and still override the default. Those words are part of the screens themselves and belong to the larger text-extraction work, not here.

## Verification

Six new tests, 128 passing in total, and the app builds cleanly.

The tests deliberately check the Indonesian output rather than only English. A test that checks only English would pass even if the translation were wired up wrongly — English is the language that looks correct no matter what — so I confirmed this by putting one of the old hard-coded words back and checking which tests failed. Two did, both of them the Indonesian ones. That is exactly the failure this change exists to prevent.

One timing detail is also pinned by a test, after review caught a mistake in my first attempt. The app becomes usable a moment before the reader's language has finished loading — the language is applied again once the server confirms the account's preference. My first version fixed the button wording at the instant the pop-up opened, which meant a pop-up opened during that brief window kept the old language while the page behind it switched. The wording is now recalculated as needed, so it always matches the rest of the screen. Two tests cover it: one that a language change while the pop-up is open updates the buttons, and one that wording a screen supplies itself is left untouched.

## Risk

Very low. One small file plus its tests. No behaviour change to what the buttons do — a test covers that the pop-up still returns the right answer when each button is pressed.
