### PR TITLE
feat(i18n): make objective error messages translatable (#212)

### DIFF
--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -119,10 +119,10 @@ func (s *Server) handleCreateProgram(c echo.Context) error {
 	}
 
 	if p.Key == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "key is required")
+		return errRequired("key")
 	}
 	if p.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return errRequired("title")
 	}
 
 	if err := s.db.CreateProgram(ctx, orgID, &p); err != nil {
@@ -164,11 +164,11 @@ func (s *Server) handleGetProgram(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveProgramID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 	p, err := s.db.GetProgram(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 	return c.JSON(http.StatusOK, p)
 }
@@ -181,12 +181,12 @@ func (s *Server) handleUpdateProgram(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveProgramID(ctx, orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 
 	old, err := s.db.GetProgram(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 
 	var req programUpdateRequest
@@ -198,7 +198,7 @@ func (s *Server) handleUpdateProgram(c echo.Context) error {
 	p.ID = id
 	if req.Title != nil {
 		if *req.Title == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "title cannot be empty")
+			return apiError(http.StatusBadRequest, CodeFieldEmpty, Field("title"))
 		}
 		p.Title = *req.Title
 	}
@@ -235,7 +235,7 @@ func (s *Server) handleDeleteProgram(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveProgramID(ctx, orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 
 	if err := s.db.DeleteProgram(ctx, orgID, id); err != nil {
@@ -323,11 +323,11 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "program_id is required")
 	}
 	if req.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return errRequired("title")
 	}
 	// Cross-org parent guard: confirm the program belongs to this org.
 	if _, err := s.db.GetProgram(ctx, orgID, req.ProgramID); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "program not found in this organization")
+		return apiError(http.StatusBadRequest, CodeNotFoundInOrg, Entity("program"))
 	}
 	o := db.Objective{
 		ProgramID:         req.ProgramID,
@@ -379,11 +379,11 @@ func (s *Server) handleGetObjective(c echo.Context) error {
 	// deep-links resolve for off-page objectives too (#166).
 	id, err := s.resolveObjectiveID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
+		return errNotFound("objective")
 	}
 	o, err := s.db.GetObjective(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
+		return errNotFound("objective")
 	}
 	return c.JSON(http.StatusOK, o)
 }
@@ -396,12 +396,12 @@ func (s *Server) handleUpdateObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	old, err := s.db.GetObjective(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
+		return errNotFound("objective")
 	}
 
 	var req objectiveUpdateRequest
@@ -423,7 +423,7 @@ func (s *Server) handleUpdateObjective(c echo.Context) error {
 	o.ID = id
 	if req.Title != nil {
 		if *req.Title == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "title cannot be empty")
+			return apiError(http.StatusBadRequest, CodeFieldEmpty, Field("title"))
 		}
 		o.Title = *req.Title
 	}
@@ -490,7 +490,7 @@ func (s *Server) handleDeleteObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	if err := s.db.DeleteObjective(ctx, orgID, id); err != nil {
@@ -521,7 +521,7 @@ func (s *Server) handleArchiveObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	before, _ := s.db.GetObjective(ctx, orgID, id)
@@ -562,7 +562,7 @@ func (s *Server) handleUnarchiveObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	before, _ := s.db.GetObjective(ctx, orgID, id)
@@ -607,7 +607,7 @@ func (s *Server) handleListCheckins(c echo.Context) error {
 	orgID := getOrgID(c)
 	objectiveID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid objective id")
+		return errInvalidEntityID("objective")
 	}
 
 	limit := 50
@@ -638,7 +638,7 @@ func (s *Server) handleCreateCheckin(c echo.Context) error {
 	ctx := c.Request().Context()
 	objectiveID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid objective id")
+		return errInvalidEntityID("objective")
 	}
 
 	var req checkinCreateRequest
@@ -647,7 +647,7 @@ func (s *Server) handleCreateCheckin(c echo.Context) error {
 	}
 	// Verify the objective belongs to this org before creating a checkin against it.
 	if _, err := s.db.GetObjective(ctx, orgID, objectiveID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found in this organization")
+		return apiError(http.StatusNotFound, CodeNotFoundInOrg, Entity("objective"))
 	}
 	ci := db.Checkin{
 		ObjectiveID:  objectiveID,
@@ -705,12 +705,12 @@ func (s *Server) handleUpdateCheckin(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	existing, err := s.db.GetCheckin(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "checkin not found")
+		return errNotFound("checkin")
 	}
 
 	var req checkinUpdateRequest
@@ -771,7 +771,7 @@ func (s *Server) handleDeleteCheckin(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	if err := s.db.DeleteCheckin(ctx, orgID, id); err != nil {
@@ -801,13 +801,13 @@ func (s *Server) handleUploadEvidence(c echo.Context) error {
 	ctx := c.Request().Context()
 	checkinID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid checkin id")
+		return errInvalidEntityID("checkin")
 	}
 
 	// Verify checkin exists and belongs to org
 	_, err = s.db.GetCheckin(ctx, orgID, checkinID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "checkin not found")
+		return errNotFound("checkin")
 	}
 
 	// Get org UUID for S3 key
@@ -818,7 +818,7 @@ func (s *Server) handleUploadEvidence(c echo.Context) error {
 
 	file, err := c.FormFile("file")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "file is required")
+		return errRequired("file")
 	}
 
 	title := c.FormValue("title")
@@ -881,7 +881,7 @@ func (s *Server) handleListEvidence(c echo.Context) error {
 	orgID := getOrgID(c)
 	checkinID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid checkin id")
+		return errInvalidEntityID("checkin")
 	}
 
 	evidence, err := s.db.ListEvidence(c.Request().Context(), orgID, checkinID)
@@ -896,7 +896,7 @@ func (s *Server) handleDownloadEvidence(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	org, err := s.db.GetOrganization(ctx, orgID)
@@ -906,7 +906,7 @@ func (s *Server) handleDownloadEvidence(c echo.Context) error {
 
 	ev, err := s.db.GetEvidence(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "evidence not found")
+		return errNotFound("evidence")
 	}
 
 	// S3 backend: return presigned URL. Local backend: serve file directly.
@@ -941,7 +941,7 @@ func (s *Server) handleDeleteEvidence(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	org, err := s.db.GetOrganization(ctx, orgID)
@@ -951,7 +951,7 @@ func (s *Server) handleDeleteEvidence(c echo.Context) error {
 
 	ev, err := s.db.GetEvidence(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "evidence not found")
+		return errNotFound("evidence")
 	}
 
 	_ = s.blobs.Delete(ctx, org.UUID, ev.ObjectKey)


### PR DESCRIPTION
## What this changes

Error messages from the Objectives and Programs endpoints now travel with a machine-readable code, so the browser can eventually show them in the reader's own language instead of always in English. Today they still read exactly the same; this is the plumbing that makes translation possible later.

32 of the 53 error sites in this module are converted. Every code and word it needed was already in the shared catalogue, so this adds no new translatable text and touches one file.

## What a user could notice

Nothing, on its own. **Corrected after review:** this description originally claimed four messages change to "check-in not found" and "invalid check-in id". That was wrong. The app's shared vocabulary does spell it "check-in", but the server generates its own English by turning underscores into spaces, and "checkin" has no underscore — so on this branch alone those four messages still read "checkin". #263 adds the missing entry that makes the server agree with the vocabulary; with that merged, the four messages do read "check-in" and the original claim holds.

Nothing else changes. Every message keeps the same HTTP status it had, including two "not found in this organization" cases that deliberately answer with different statuses.

## Deliberately not converted

The remaining 21 sites are server faults and operator messages — "failed to read file", internal errors passed through verbatim — which are read in logs by whoever runs the server, not by end users. Two more are held back on purpose: "program_id is required" has no catalogued field name yet, and "evidence file not found" says something genuinely different from "evidence not found" and would lose that distinction if folded in.

## Scope note

As on the earlier conversions: no screen renders these codes yet, so a user still sees English everywhere. Wiring the ~196 places the web app displays an error is separate, deliberately sequenced work — the reasoning is on #248, which added the renderer this depends on.

## Risk

Low. One Go file, no schema change, no locale file touched, no API contract broken — `code` and `params` are additive and a client ignoring them behaves exactly as before.

## Verification

gofmt clean, `go vet ./...`, full `go test ./internal/isms/api/...` green. The guard that catches an entity name with no translation was confirmed to actually fire on this file by deliberately misspelling one and watching it fail.
