### PR TITLE
feat(i18n): make API error messages translatable across all modules (#212)

### DIFF
--- a/internal/isms/api/api_admin.go
+++ b/internal/isms/api/api_admin.go
@@ -54,22 +54,22 @@ func (s *Server) handleAdminUpdateRole(c echo.Context) error {
 
 	userID, err := strconv.Atoi(c.Param("userId"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid user ID")
+		return errInvalidEntityID("user")
 	}
 
 	var req struct {
 		Role string `json:"role"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Role == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "role is required")
+		return errRequired("role")
 	}
 
 	validRoles := map[string]bool{"admin": true, "manager": true, "contributor": true, "reader": true}
 	if !validRoles[req.Role] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+		return apiError(http.StatusBadRequest, CodeInvalidRole)
 	}
 
 	// Prevent self-downgrade if last admin
@@ -91,7 +91,7 @@ func (s *Server) handleAdminUpdateRole(c echo.Context) error {
 
 	// Verify user is already a member before updating role
 	if _, err := s.db.GetOrgMember(ctx, orgID, userID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "user is not a member of this organization")
+		return apiError(http.StatusNotFound, CodeNotOrgMember)
 	}
 	if err := s.db.AddOrgMember(ctx, orgID, userID, req.Role); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "updating role: "+err.Error())
@@ -114,7 +114,7 @@ func (s *Server) handleAdminRemoveMember(c echo.Context) error {
 
 	userID, err := strconv.Atoi(c.Param("userId"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid user ID")
+		return errInvalidEntityID("user")
 	}
 
 	// Prevent removing yourself
@@ -188,7 +188,7 @@ func (s *Server) handleAdminCreateOIDC(c echo.Context) error {
 
 	var p db.OIDCProvider
 	if err := c.Bind(&p); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	p.OrganizationID = orgID
 
@@ -222,21 +222,21 @@ func (s *Server) handleAdminUpdateOIDC(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid provider ID")
+		return errInvalidEntityID("oidc_provider")
 	}
 
 	// Fetch existing to verify ownership
 	existing, err := s.db.GetOIDCProviderByID(ctx, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "OIDC provider not found")
+		return errNotFound("oidc_provider")
 	}
 	if existing.OrganizationID != orgID {
-		return echo.NewHTTPError(http.StatusForbidden, "provider belongs to another organization")
+		return apiError(http.StatusForbidden, CodeProviderOtherOrg)
 	}
 
 	var p db.OIDCProvider
 	if err := c.Bind(&p); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	p.ID = id
 	p.OrganizationID = orgID
@@ -268,16 +268,16 @@ func (s *Server) handleAdminDeleteOIDC(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid provider ID")
+		return errInvalidEntityID("oidc_provider")
 	}
 
 	// Verify ownership
 	existing, err := s.db.GetOIDCProviderByID(ctx, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "OIDC provider not found")
+		return errNotFound("oidc_provider")
 	}
 	if existing.OrganizationID != orgID {
-		return echo.NewHTTPError(http.StatusForbidden, "provider belongs to another organization")
+		return apiError(http.StatusForbidden, CodeProviderOtherOrg)
 	}
 
 	if err := s.db.DeleteOIDCProvider(ctx, orgID, id); err != nil {
@@ -301,15 +301,15 @@ func (s *Server) handleAdminTestOIDC(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid provider ID")
+		return errInvalidEntityID("oidc_provider")
 	}
 
 	provider, err := s.db.GetOIDCProviderByID(ctx, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "OIDC provider not found")
+		return errNotFound("oidc_provider")
 	}
 	if provider.OrganizationID != orgID {
-		return echo.NewHTTPError(http.StatusForbidden, "provider belongs to another organization")
+		return apiError(http.StatusForbidden, CodeProviderOtherOrg)
 	}
 
 	// Test OIDC discovery
@@ -359,10 +359,10 @@ func (s *Server) handleAdminUpdateSetting(c echo.Context) error {
 		Value string `json:"value"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Key == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "key is required")
+		return errRequired("key")
 	}
 
 	// Validate the org default locale against the supported set. Resolve() would
@@ -373,7 +373,7 @@ func (s *Server) handleAdminUpdateSetting(c echo.Context) error {
 	if req.Key == "default_locale" && req.Value != "" {
 		tag, ok := i18n.Canonical(req.Value)
 		if !ok {
-			return echo.NewHTTPError(http.StatusBadRequest, "unsupported locale")
+			return apiError(http.StatusBadRequest, CodeUnsupportedLocale)
 		}
 		req.Value = tag // store the canonical form, not whatever casing was sent
 	}
@@ -438,7 +438,7 @@ func (s *Server) handleBrandingUpload(c echo.Context) error {
 
 	file, err := c.FormFile("file")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "file required")
+		return errRequired("file")
 	}
 
 	if file.Size > 2*1024*1024 {

--- a/internal/isms/api/api_asset_reviews.go
+++ b/internal/isms/api/api_asset_reviews.go
@@ -28,13 +28,13 @@ func (s *Server) handleCreateAssetReview(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 
 	// Verify asset exists in this org (cross-org safety).
 	asset, err := s.db.GetAsset(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "asset not found")
+		return errNotFound("asset")
 	}
 
 	var req assetReviewCreateRequest
@@ -71,7 +71,7 @@ func (s *Server) handleListAssetReviews(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 
 	reviews, err := s.db.ListAssetReviews(c.Request().Context(), orgID, id)

--- a/internal/isms/api/api_audit.go
+++ b/internal/isms/api/api_audit.go
@@ -112,7 +112,7 @@ func (s *Server) handleCreateAuditProgramme(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if req.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("title"))
 	}
 	if req.Year < 1900 || req.Year > 2200 {
 		return echo.NewHTTPError(http.StatusBadRequest, "year must be between 1900 and 2200")
@@ -121,7 +121,7 @@ func (s *Server) handleCreateAuditProgramme(c echo.Context) error {
 		req.Status = "active"
 	}
 	if !db.AuditProgrammeStatuses[req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(req.Status))
 	}
 	p := db.AuditProgramme{
 		Title:       req.Title,
@@ -169,7 +169,7 @@ func (s *Server) handleUpdateAuditProgramme(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if req.Status != nil && !db.AuditProgrammeStatuses[*req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+*req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(*req.Status))
 	}
 	if err := s.db.UpdateAuditProgramme(c.Request().Context(), orgID, id, req.Title, req.Description, req.Notes, req.Status); err != nil {
 		return pgxHTTPError(err)
@@ -244,7 +244,7 @@ func (s *Server) handleCreateAudit(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if req.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("title"))
 	}
 	// Scope and auditor are optional at create time — fill via the edit modal.
 	// Schema permits null auditor_id and empty scope.
@@ -258,7 +258,7 @@ func (s *Server) handleCreateAudit(c echo.Context) error {
 		req.Status = "planned"
 	}
 	if !db.AuditStatuses[req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(req.Status))
 	}
 	if err := s.validateOrgMember(c, req.Auditor); err != nil {
 		return err
@@ -306,11 +306,11 @@ func (s *Server) handleGetAudit(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit"))
 	}
 	audit, err := s.db.GetAudit(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 	return c.JSON(http.StatusOK, audit)
 }
@@ -322,12 +322,12 @@ func (s *Server) handleUpdateAudit(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit"))
 	}
 	ctx := c.Request().Context()
 	before, err := s.db.GetAudit(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 
 	var req auditUpdateRequest
@@ -338,7 +338,7 @@ func (s *Server) handleUpdateAudit(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit_type: "+*req.AuditType)
 	}
 	if req.Status != nil && !db.AuditStatuses[*req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+*req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(*req.Status))
 	}
 	if req.Auditor != nil && *req.Auditor != "" {
 		if err := s.validateOrgMember(c, *req.Auditor); err != nil {
@@ -356,7 +356,7 @@ func (s *Server) handleUpdateAudit(c echo.Context) error {
 	}
 	after, err := s.db.GetAudit(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 	actor := getUserEmail(c)
 	if changes := db.DiffFields("audit", int64(id), actor, c.QueryParam("reason"), before.ToChangeMap(), after.ToChangeMap()); len(changes) > 0 {
@@ -377,7 +377,7 @@ func (s *Server) handleUpdateAuditStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit"))
 	}
 	var req struct {
 		Status string `json:"status"`
@@ -386,12 +386,12 @@ func (s *Server) handleUpdateAuditStatus(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if !db.AuditStatuses[req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(req.Status))
 	}
 	ctx := c.Request().Context()
 	before, err := s.db.GetAudit(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 	if err := s.db.UpdateAuditStatus(ctx, orgID, id, req.Status); err != nil {
 		return pgxHTTPError(err)
@@ -470,12 +470,12 @@ func (s *Server) handleListAuditItems(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit"))
 	}
 	if exists, err := s.db.AuditExists(c.Request().Context(), orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	} else if !exists {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 	items, err := s.db.ListAuditItems(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -491,19 +491,19 @@ func (s *Server) handleCreateAuditItem(c echo.Context) error {
 	orgID := getOrgID(c)
 	auditID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit"))
 	}
 	if exists, err := s.db.AuditExists(c.Request().Context(), orgID, auditID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	} else if !exists {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 	var req auditItemCreateRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if req.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("title"))
 	}
 	if req.Result == "" {
 		req.Result = "not_assessed"
@@ -533,7 +533,7 @@ func (s *Server) handleDeleteAuditItem(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid item id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("item"))
 	}
 	if err := s.db.DeleteAuditItem(c.Request().Context(), orgID, id); err != nil {
 		return pgxHTTPError(err)
@@ -548,7 +548,7 @@ func (s *Server) handleUpdateAuditItem(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid item id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("item"))
 	}
 	var req auditItemUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -562,7 +562,7 @@ func (s *Server) handleUpdateAuditItem(c echo.Context) error {
 	}
 	out, err := s.db.GetAuditItem(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "item not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("item"))
 	}
 	if req.Result != nil {
 		s.logAndNotify(c.Request().Context(), orgID, &db.Activity{
@@ -580,12 +580,12 @@ func (s *Server) handleListAuditFindingsForAudit(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid audit id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit"))
 	}
 	if exists, err := s.db.AuditExists(c.Request().Context(), orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	} else if !exists {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit"))
 	}
 	findings, err := s.db.ListAuditFindings(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -643,11 +643,11 @@ func (s *Server) handleGetAuditFinding(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
 	f, err := s.db.GetAuditFinding(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "finding not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit_finding"))
 	}
 	return c.JSON(http.StatusOK, f)
 }
@@ -667,7 +667,7 @@ func (s *Server) handleAddAuditFinding(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "audit_id is required")
 	}
 	if req.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("title"))
 	}
 	// Description is optional at create time — fill via the edit modal.
 	if !db.AuditFindingTypes[req.FindingType] {
@@ -677,7 +677,7 @@ func (s *Server) handleAddAuditFinding(c echo.Context) error {
 	if exists, err := s.db.AuditExists(ctx, orgID, req.AuditID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	} else if !exists {
-		return echo.NewHTTPError(http.StatusNotFound, "audit not found in this organization")
+		return apiError(http.StatusNotFound, CodeNotFoundInOrg, Entity("audit"))
 	}
 	if req.Owner != "" {
 		if err := s.validateOrgMember(c, req.Owner); err != nil {
@@ -728,13 +728,13 @@ func (s *Server) handleUpdateAuditFinding(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
 	ctx := c.Request().Context()
 
 	before, err := s.db.GetAuditFinding(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "finding not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit_finding"))
 	}
 
 	var req auditFindingUpdateRequest
@@ -742,7 +742,7 @@ func (s *Server) handleUpdateAuditFinding(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if req.Status != nil && !db.AuditFindingStatuses[*req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+*req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(*req.Status))
 	}
 	if req.Owner != nil && *req.Owner != "" {
 		if err := s.validateOrgMember(c, *req.Owner); err != nil {
@@ -793,7 +793,7 @@ func (s *Server) handleUpdateAuditFindingStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
 	var req struct {
 		Status string `json:"status"`
@@ -802,12 +802,12 @@ func (s *Server) handleUpdateAuditFindingStatus(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if !db.AuditFindingStatuses[req.Status] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid status: "+req.Status)
+		return apiError(http.StatusBadRequest, CodeInvalidStatus, Value(req.Status))
 	}
 	ctx := c.Request().Context()
 	before, err := s.db.GetAuditFinding(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "finding not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit_finding"))
 	}
 	actor := getUserEmail(c)
 	if err := s.db.SetAuditFindingStatus(ctx, orgID, id, req.Status, actor); err != nil {
@@ -835,11 +835,11 @@ func (s *Server) handleDeleteAuditFinding(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid finding id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
 	ctx := c.Request().Context()
 	if _, err := s.db.GetAuditFinding(ctx, orgID, id); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "finding not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("audit_finding"))
 	}
 	if err := s.db.SoftDeleteAuditFinding(ctx, orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusConflict, err.Error())

--- a/internal/isms/api/api_auth.go
+++ b/internal/isms/api/api_auth.go
@@ -52,10 +52,10 @@ type loginResponse struct {
 func (s *Server) handleLogin(c echo.Context) error {
 	var req loginRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Email == "" || req.Password == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "email and password required")
+		return apiError(http.StatusBadRequest, CodeEmailAndPasswordNeeded)
 	}
 
 	ctx := c.Request().Context()
@@ -65,24 +65,24 @@ func (s *Server) handleLogin(c echo.Context) error {
 	if !rateLimitDisabled() {
 		count, _ := s.db.CountRecentLoginAttempts(ctx, req.Email)
 		if count >= maxLoginAttempts {
-			return echo.NewHTTPError(http.StatusTooManyRequests, "too many attempts, try again later")
+			return apiError(http.StatusTooManyRequests, CodeTooManyAttempts)
 		}
 	}
 
 	user, err := s.db.GetUserByEmail(ctx, req.Email)
 	if err != nil || user == nil {
 		s.db.RecordLoginAttempt(ctx, req.Email, clientIP)
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+		return apiError(http.StatusUnauthorized, CodeInvalidCredentials)
 	}
 
 	if !user.Active || !user.HasPassword() {
 		s.db.RecordLoginAttempt(ctx, req.Email, clientIP)
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+		return apiError(http.StatusUnauthorized, CodeInvalidCredentials)
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*user.PasswordHash), []byte(req.Password)); err != nil {
 		s.db.RecordLoginAttempt(ctx, req.Email, clientIP)
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+		return apiError(http.StatusUnauthorized, CodeInvalidCredentials)
 	}
 
 	// Check OTP if enabled
@@ -91,7 +91,7 @@ func (s *Server) handleLogin(c echo.Context) error {
 			return c.JSON(http.StatusOK, loginResponse{OTPRequired: true})
 		}
 		if !verifyTOTP(*user.OTPSecret, req.OTP) {
-			return echo.NewHTTPError(http.StatusUnauthorized, "invalid OTP code")
+			return apiError(http.StatusUnauthorized, CodeInvalidOTPCode)
 		}
 		// TOTP replay protection
 		alreadyUsed, err := s.db.CheckAndSetTOTPUsed(ctx, user.ID)
@@ -126,12 +126,12 @@ func (s *Server) handleLogin(c echo.Context) error {
 		// Explicit org slug provided — look it up
 		org, err := s.db.GetOrganizationBySlug(ctx, req.Organization)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "organization not found")
+			return apiError(http.StatusBadRequest, CodeNotFound, Entity("organization"))
 		}
 		// Verify user is a member
 		_, err = s.db.GetOrgMember(ctx, org.ID, user.ID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+			return apiError(http.StatusForbidden, CodeNotOrgMember)
 		}
 		orgID = org.ID
 		orgName = org.Name
@@ -202,16 +202,16 @@ func (s *Server) handleSignup(c echo.Context) error {
 
 	var req signupRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Email == "" || req.Password == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "email and password required")
+		return apiError(http.StatusBadRequest, CodeEmailAndPasswordNeeded)
 	}
 	if req.Name == "" {
 		req.Name = req.Email
 	}
 	if len(req.Password) < 7 {
-		return echo.NewHTTPError(http.StatusBadRequest, "password must be at least 7 characters")
+		return apiError(http.StatusBadRequest, CodePasswordTooShort, Count(7))
 	}
 
 	ctx := c.Request().Context()
@@ -291,7 +291,7 @@ func (s *Server) handleForgotPassword(c echo.Context) error {
 		Email string `json:"email"`
 	}
 	if err := c.Bind(&req); err != nil || req.Email == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "email is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("email"))
 	}
 	ctx := c.Request().Context()
 
@@ -336,7 +336,7 @@ func (s *Server) handleForgotPassword(c echo.Context) error {
 func (s *Server) handleRefresh(c echo.Context) error {
 	email := getUserEmail(c)
 	if email == "" {
-		return echo.NewHTTPError(http.StatusUnauthorized, "not authenticated")
+		return apiError(http.StatusUnauthorized, CodeNotAuthenticated)
 	}
 
 	ctx := c.Request().Context()
@@ -388,7 +388,7 @@ func (s *Server) handleSwitchOrg(c echo.Context) error {
 		Slug string `json:"slug"`
 	}
 	if err := c.Bind(&req); err != nil || req.Slug == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "slug is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("slug"))
 	}
 
 	ctx := c.Request().Context()
@@ -396,18 +396,18 @@ func (s *Server) handleSwitchOrg(c echo.Context) error {
 
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	org, err := s.db.GetOrganizationBySlug(ctx, req.Slug)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("organization"))
 	}
 
 	// Verify membership
 	role, err := s.db.GetUserRole(ctx, org.ID, user.ID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+		return apiError(http.StatusForbidden, CodeNotOrgMember)
 	}
 
 	token, err := s.createSessionJWT(user, org.ID, role, org.Slug, org.Name)
@@ -435,26 +435,26 @@ type changePasswordRequest struct {
 func (s *Server) handleChangePassword(c echo.Context) error {
 	var req changePasswordRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.NewPassword == "" || len(req.NewPassword) < 7 {
-		return echo.NewHTTPError(http.StatusBadRequest, "password must be at least 7 characters")
+		return apiError(http.StatusBadRequest, CodePasswordTooShort, Count(7))
 	}
 
 	ctx := c.Request().Context()
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	// If user already has a password, verify current one
 	if user.HasPassword() {
 		if req.CurrentPassword == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "current password required")
+			return apiError(http.StatusBadRequest, CodeCurrentPasswordNeeded)
 		}
 		if err := bcrypt.CompareHashAndPassword([]byte(*user.PasswordHash), []byte(req.CurrentPassword)); err != nil {
-			return echo.NewHTTPError(http.StatusUnauthorized, "current password is incorrect")
+			return apiError(http.StatusUnauthorized, CodeCurrentPasswordWrong)
 		}
 	}
 
@@ -486,12 +486,12 @@ type changeEmailRequest struct {
 func (s *Server) handleRequestEmailChange(c echo.Context) error {
 	var req changeEmailRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 
 	newEmail := strings.ToLower(strings.TrimSpace(req.NewEmail))
 	if newEmail == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "new_email is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("new_email"))
 	}
 	if addr, err := netmail.ParseAddress(newEmail); err != nil || addr.Address != newEmail {
 		return echo.NewHTTPError(http.StatusBadRequest, "new_email is not a valid email address")
@@ -500,7 +500,7 @@ func (s *Server) handleRequestEmailChange(c echo.Context) error {
 	ctx := c.Request().Context()
 	user, err := s.db.GetUserByEmail(ctx, getUserEmail(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	if newEmail == strings.ToLower(user.Email) {
@@ -518,7 +518,7 @@ func (s *Server) handleRequestEmailChange(c echo.Context) error {
 	// index on pending_email stops two concurrent requests to the same address,
 	// and the unique index on email is the final word at swap time.
 	if exists, _ := s.db.EmailExists(ctx, newEmail); exists {
-		return echo.NewHTTPError(http.StatusConflict, "that email address is already in use")
+		return apiError(http.StatusConflict, CodeEmailInUse)
 	}
 
 	// Fail before committing any state if mail can't be delivered — otherwise the
@@ -533,7 +533,7 @@ func (s *Server) handleRequestEmailChange(c echo.Context) error {
 
 	if err := s.db.SetPendingEmail(ctx, user.ID, newEmail); err != nil {
 		if err == db.ErrEmailTaken {
-			return echo.NewHTTPError(http.StatusConflict, "that email address is already in use")
+			return apiError(http.StatusConflict, CodeEmailInUse)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "recording email change: "+err.Error())
 	}
@@ -573,7 +573,7 @@ func (s *Server) handleCancelEmailChange(c echo.Context) error {
 	ctx := c.Request().Context()
 	user, err := s.db.GetUserByEmail(ctx, getUserEmail(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	if err := s.db.ClearPendingEmail(ctx, user.ID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "cancelling email change")
@@ -591,17 +591,17 @@ func (s *Server) handleVerifyEmailChange(c echo.Context) error {
 		Token string `json:"token"`
 	}
 	if err := c.Bind(&req); err != nil || req.Token == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "token is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("token"))
 	}
 
 	ctx := c.Request().Context()
 	hash := sha256.Sum256([]byte(req.Token))
 	verification, err := s.db.LookupEmailVerification(ctx, hex.EncodeToString(hash[:]))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid or expired confirmation link")
+		return apiError(http.StatusBadRequest, CodeInvalidConfirmLink)
 	}
 	if verification.Purpose != "email_change" {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid or expired confirmation link")
+		return apiError(http.StatusBadRequest, CodeInvalidConfirmLink)
 	}
 
 	// Consume the token before attempting the swap — a failed swap (address taken,
@@ -647,11 +647,11 @@ type updateProfileRequest struct {
 func (s *Server) handleUpdateProfile(c echo.Context) error {
 	var req updateProfileRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	// An empty name is still invalid; an absent one just means "not changing it".
 	if req.Name != nil && *req.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("name"))
 	}
 	// Require at least one field, so a caller cannot mistake an empty body for a
 	// successful update.
@@ -677,7 +677,7 @@ func (s *Server) handleUpdateProfile(c echo.Context) error {
 	if req.Locale != nil && *req.Locale != "" {
 		tag, ok := i18n.Canonical(*req.Locale)
 		if !ok {
-			return echo.NewHTTPError(http.StatusBadRequest, "unsupported locale")
+			return apiError(http.StatusBadRequest, CodeUnsupportedLocale)
 		}
 		nextLocale = &tag
 	}
@@ -686,7 +686,7 @@ func (s *Server) handleUpdateProfile(c echo.Context) error {
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	if req.Name != nil {
@@ -722,7 +722,7 @@ func (s *Server) handleOTPSetup(c echo.Context) error {
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	// Generate random secret
@@ -761,17 +761,17 @@ type otpVerifyRequest struct {
 func (s *Server) handleOTPVerify(c echo.Context) error {
 	var req otpVerifyRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Code == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "code is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("code"))
 	}
 
 	ctx := c.Request().Context()
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	if user.OTPSecret == nil || *user.OTPSecret == "" {
@@ -779,7 +779,7 @@ func (s *Server) handleOTPVerify(c echo.Context) error {
 	}
 
 	if !verifyTOTP(*user.OTPSecret, req.Code) {
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid OTP code")
+		return apiError(http.StatusUnauthorized, CodeInvalidOTPCode)
 	}
 
 	if err := s.db.VerifyOTP(ctx, user.ID); err != nil {
@@ -794,14 +794,14 @@ func (s *Server) handleOTPVerify(c echo.Context) error {
 func (s *Server) handleOTPDisable(c echo.Context) error {
 	var req otpVerifyRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 
 	ctx := c.Request().Context()
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	// Re-authenticate with the current OTP code before removing the second
@@ -813,7 +813,7 @@ func (s *Server) handleOTPDisable(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "current OTP code is required to disable OTP")
 	}
 	if !verifyTOTP(*user.OTPSecret, req.Code) {
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid OTP code")
+		return apiError(http.StatusUnauthorized, CodeInvalidOTPCode)
 	}
 
 	if err := s.db.ClearOTP(ctx, user.ID); err != nil {
@@ -838,10 +838,10 @@ func (s *Server) handleInviteUser(c echo.Context) error {
 	orgID := getOrgID(c)
 	var req inviteRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Email == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "email is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("email"))
 	}
 	if req.Name == "" {
 		req.Name = req.Email
@@ -851,7 +851,7 @@ func (s *Server) handleInviteUser(c echo.Context) error {
 	}
 	validRoles := map[string]bool{"admin": true, "manager": true, "contributor": true, "reader": true}
 	if !validRoles[req.Role] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+		return apiError(http.StatusBadRequest, CodeInvalidRole)
 	}
 
 	// Only admin can invite as admin or manager
@@ -920,19 +920,19 @@ func (s *Server) handleResendInvite(c echo.Context) error {
 		Email string `json:"email"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Email == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "email is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("email"))
 	}
 
 	user, err := s.db.GetUserByEmail(ctx, req.Email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "user not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("user"))
 	}
 	// Must be a member of this org — don't resend across organizations.
 	if _, err := s.db.GetOrgMember(ctx, orgID, user.ID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "user is not a member of this organization")
+		return apiError(http.StatusNotFound, CodeNotOrgMember)
 	}
 	// Only pending invites can be resent; an active user has already accepted.
 	if user.Active {
@@ -984,13 +984,13 @@ type verifyEmailRequest struct {
 func (s *Server) handleVerifyEmail(c echo.Context) error {
 	var req verifyEmailRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Token == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "token is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("token"))
 	}
 	if req.Password == "" || len(req.Password) < 7 {
-		return echo.NewHTTPError(http.StatusBadRequest, "password must be at least 7 characters")
+		return apiError(http.StatusBadRequest, CodePasswordTooShort, Count(7))
 	}
 
 	ctx := c.Request().Context()
@@ -1007,7 +1007,7 @@ func (s *Server) handleVerifyEmail(c echo.Context) error {
 	// Get the user
 	user, err := s.db.GetUserByID(ctx, verification.UserID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	// Hash password and save
@@ -1069,7 +1069,7 @@ func (s *Server) handleListMyAPIKeys(c echo.Context) error {
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	keys, err := s.db.ListUserAPIKeys(ctx, user.ID)
@@ -1095,10 +1095,10 @@ func (s *Server) handleCreateMyAPIKey(c echo.Context) error {
 		Scope       string `json:"scope"` // "org" (default) or "global"
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("name"))
 	}
 	if req.Permissions == "" {
 		req.Permissions = "read-write"
@@ -1138,7 +1138,7 @@ func (s *Server) handleRevokeMyAPIKey(c echo.Context) error {
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	id, err := strconv.Atoi(c.Param("id"))
@@ -1174,7 +1174,7 @@ func (s *Server) handleLogout(c echo.Context) error {
 	// Parse to get expiry time
 	claims, err := validateSessionJWT(rawToken, s.secret)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid token")
+		return apiError(http.StatusBadRequest, CodeInvalidToken)
 	}
 
 	tokenHash := sha256Hash(rawToken)
@@ -1209,10 +1209,10 @@ func generateAPIKey() (string, string) {
 func reauthenticate(user *db.User, password, otp string) error {
 	if user.HasPassword() {
 		if password == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "current password required")
+			return apiError(http.StatusBadRequest, CodeCurrentPasswordNeeded)
 		}
 		if err := bcrypt.CompareHashAndPassword([]byte(*user.PasswordHash), []byte(password)); err != nil {
-			return echo.NewHTTPError(http.StatusUnauthorized, "current password is incorrect")
+			return apiError(http.StatusUnauthorized, CodeCurrentPasswordWrong)
 		}
 	}
 	if user.HasOTP() {

--- a/internal/isms/api/api_cf.go
+++ b/internal/isms/api/api_cf.go
@@ -88,7 +88,7 @@ func (s *Server) handleCFSession(c echo.Context) error {
 	email := claims.Email
 	if hdr := c.Request().Header.Get("Cf-Access-Authenticated-User-Email"); hdr != "" {
 		if email != "" && !strings.EqualFold(email, hdr) {
-			return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
+			return apiError(http.StatusUnauthorized, CodeTokenEmailMismatch)
 		}
 		if email == "" {
 			email = hdr
@@ -105,7 +105,7 @@ func (s *Server) handleCFSession(c echo.Context) error {
 			log.Printf("[cf-access] auto-provision failed for %s: %v", email, err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "auto-provision failed")
 		}
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	if created {
 		log.Printf("[cf-access] auto-provisioned user %s", email)
@@ -118,7 +118,7 @@ func (s *Server) handleCFSession(c echo.Context) error {
 	if slug, ok := c.Get("org_slug").(string); ok && slug != "" {
 		org, oerr := s.db.GetOrganizationBySlug(ctx, slug)
 		if oerr != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "organization not found")
+			return apiError(http.StatusBadRequest, CodeNotFound, Entity("organization"))
 		}
 		if _, merr := s.db.GetOrgMember(ctx, org.ID, user.ID); merr != nil {
 			// JIT-provisioned but not yet a member — an admin must add them.

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -319,7 +319,7 @@ func (s *Server) handleCreateReview(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	if req.DocumentID == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "document_id is required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("document_id"))
 	}
 
 	// Capture current HEAD as the snapshot the review is anchored to. Best-effort —
@@ -366,11 +366,11 @@ func (s *Server) handleGetReview(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	review, err := s.db.GetReview(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 	// Return flat review with author_is_agent enrichment
 	type reviewWithAgent struct {
@@ -387,7 +387,7 @@ func (s *Server) handleListReviewAssignments(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	assignments, err := s.db.ListAssignmentsForReview(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -416,7 +416,7 @@ func (s *Server) handleUpdateReviewStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	var req struct {
 		Status string `json:"status"`
@@ -436,10 +436,10 @@ func (s *Server) handleUpdateReviewStatus(c echo.Context) error {
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 	if review.Status == "closed" || review.Status == "merged" {
-		return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("review is already %s", review.Status))
+		return apiError(http.StatusConflict, CodeReviewAlreadyStatus, Status(review.Status))
 	}
 
 	if err := s.db.UpdateReviewStatus(ctx, orgID, id, "closed"); err != nil {
@@ -466,7 +466,7 @@ func (s *Server) handleForwardReview(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	var req struct {
 		Reviewers []string `json:"reviewers"`
@@ -481,7 +481,7 @@ func (s *Server) handleForwardReview(c echo.Context) error {
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 
 	// Add assignments + status update in a single transaction with RLS
@@ -568,7 +568,7 @@ func (s *Server) handleReviewTimeline(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 
@@ -687,13 +687,13 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 
 	st, err := s.storeForOrg(ctx, orgID)
@@ -703,7 +703,7 @@ func (s *Server) handleReviewDiff(c echo.Context) error {
 
 	filePath := resolveDocPathFromStore(st, review.DocumentID)
 	if filePath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document file not found")
+		return apiError(http.StatusNotFound, CodeDocumentFileNotFound)
 	}
 
 	var diffText string
@@ -904,12 +904,12 @@ func (s *Server) isReviewParticipant(ctx context.Context, orgID int, review *db.
 func (s *Server) authorizeReviewComment(ctx context.Context, orgID int, reviewID int, actor, role string) (*db.Review, error) {
 	review, err := s.db.GetReview(ctx, orgID, reviewID)
 	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return nil, apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 	// A published or abandoned review is a closed record — nobody appends to it.
 	// Checked before the participant rule so the message names the real reason.
 	if review.Status == "merged" || review.Status == "closed" {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "review is "+review.Status)
+		return nil, apiError(http.StatusBadRequest, CodeReviewWrongStatus, Status(review.Status))
 	}
 	if role == "admin" || role == "manager" {
 		return review, nil
@@ -925,7 +925,7 @@ func (s *Server) handleAddReviewComment(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 
@@ -1005,13 +1005,13 @@ func (s *Server) handleReviewApprove(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 
 	var req struct {
@@ -1422,14 +1422,14 @@ func (s *Server) handleMergeReview(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 
 	if review.Status != "approved" {
@@ -1489,14 +1489,14 @@ func (s *Server) handleAcceptAndMerge(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 
 	// Only the author (requester) can accept a proposed revision
@@ -1580,7 +1580,7 @@ func (s *Server) handleUpdateReviewContent(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 	email := getUserEmail(c)
@@ -1606,10 +1606,10 @@ func (s *Server) handleUpdateReviewContent(c echo.Context) error {
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 	if review.Status == "merged" || review.Status == "closed" {
-		return echo.NewHTTPError(http.StatusBadRequest, "review is already "+review.Status)
+		return apiError(http.StatusBadRequest, CodeReviewAlreadyStatus, Status(review.Status))
 	}
 
 	var req struct {
@@ -1626,7 +1626,7 @@ func (s *Server) handleUpdateReviewContent(c echo.Context) error {
 
 	docPath := resolveDocPathFromStore(st, review.DocumentID)
 	if docPath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document file not found")
+		return apiError(http.StatusNotFound, CodeDocumentFileNotFound)
 	}
 
 	// Preserve frontmatter — read from review branch first, fall back to main
@@ -1689,13 +1689,13 @@ func (s *Server) handleGetReviewContent(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	ctx := c.Request().Context()
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 
 	st, err := s.storeForOrg(ctx, orgID)
@@ -1705,7 +1705,7 @@ func (s *Server) handleGetReviewContent(c echo.Context) error {
 
 	docPath := resolveDocPathFromStore(st, review.DocumentID)
 	if docPath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document file not found")
+		return apiError(http.StatusNotFound, CodeDocumentFileNotFound)
 	}
 
 	relPath := strings.TrimPrefix(docPath, st.Root()+"/")
@@ -1826,7 +1826,7 @@ func (s *Server) handleResolveCommentDB(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid comment id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("comment"))
 	}
 	resolvedBy := getUserEmail(c) // always use authenticated user
 	ctx := c.Request().Context()
@@ -1837,7 +1837,7 @@ func (s *Server) handleResolveCommentDB(c echo.Context) error {
 	// reviewer feedback is the common case).
 	comment, err := s.db.GetComment(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "comment not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("comment"))
 	}
 	role, _ := c.Get("user_role").(string)
 	if role != "admin" && role != "manager" && comment.Author != resolvedBy {
@@ -1872,14 +1872,14 @@ func (s *Server) handleAcceptSuggestion(c echo.Context) error {
 	orgID := getOrgID(c)
 	commentID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid comment id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("comment"))
 	}
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 
 	comment, err := s.db.GetComment(ctx, orgID, commentID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "comment not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("comment"))
 	}
 	if comment.SuggestionBody == nil || *comment.SuggestionBody == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "comment is not a suggestion")
@@ -1893,10 +1893,10 @@ func (s *Server) handleAcceptSuggestion(c echo.Context) error {
 
 	review, err := s.db.GetReview(ctx, orgID, *comment.ReviewID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("review"))
 	}
 	if review.Status == "merged" || review.Status == "closed" {
-		return echo.NewHTTPError(http.StatusBadRequest, "review is "+review.Status)
+		return apiError(http.StatusBadRequest, CodeReviewWrongStatus, Status(review.Status))
 	}
 
 	// Auth: only review author or admin/manager can accept suggestions
@@ -1911,7 +1911,7 @@ func (s *Server) handleAcceptSuggestion(c echo.Context) error {
 	}
 	docPath := resolveDocPathFromStore(st, review.DocumentID)
 	if docPath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("document"))
 	}
 
 	// Read from review branch or HEAD
@@ -2001,14 +2001,14 @@ func (s *Server) handleRejectSuggestion(c echo.Context) error {
 	orgID := getOrgID(c)
 	commentID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid comment id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("comment"))
 	}
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 
 	comment, err := s.db.GetComment(ctx, orgID, commentID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "comment not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("comment"))
 	}
 	if comment.SuggestionBody == nil || comment.SuggestionStatus == nil || *comment.SuggestionStatus != "pending" {
 		return echo.NewHTTPError(http.StatusBadRequest, "not a pending suggestion")
@@ -2019,7 +2019,7 @@ func (s *Server) handleRejectSuggestion(c echo.Context) error {
 		review, _ := s.db.GetReview(ctx, orgID, *comment.ReviewID)
 		if review != nil {
 			if review.Status == "merged" || review.Status == "closed" {
-				return echo.NewHTTPError(http.StatusBadRequest, "review is "+review.Status)
+				return apiError(http.StatusBadRequest, CodeReviewWrongStatus, Status(review.Status))
 			}
 			role, _ := c.Get("user_role").(string)
 			if role != "admin" && role != "manager" && review.RequestedBy != actor {
@@ -2047,7 +2047,7 @@ func (s *Server) handleListSuggestions(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	comments, err := s.db.CommentsForReview(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -2128,7 +2128,7 @@ func (s *Server) handleListReviewDecisions(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("review"))
 	}
 	records, err := s.db.GetReviewDecisions(c.Request().Context(), orgID, id)
 	if err != nil {
@@ -2282,9 +2282,9 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("task"))
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 	var req struct {
 		Status string `json:"status"`
@@ -2297,7 +2297,7 @@ func (s *Server) handleUpdateTaskStatus(c echo.Context) error {
 	}
 	before, err := s.db.GetTask(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 	// Ownership: a contributor may advance the status of a task assigned to them
 	// (doing their own work), but not other people's tasks. Managers/admins may
@@ -2328,16 +2328,16 @@ func (s *Server) handleGetTask(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("task"))
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 	task, err := s.db.GetTask(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 	if !canViewTask(c, task) {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 	return c.JSON(http.StatusOK, task)
 }
@@ -2350,14 +2350,14 @@ func (s *Server) handleUpdateTask(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("task"))
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 
 	old, err := s.db.GetTask(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 
 	var req taskUpdateRequest
@@ -2459,14 +2459,14 @@ func (s *Server) handleDeleteTask(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveTaskID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid task id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("task"))
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 
 	task, err := s.db.GetTask(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "task not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("task"))
 	}
 
 	if err := s.db.DeleteTask(ctx, orgID, id); err != nil {
@@ -2609,11 +2609,11 @@ func (s *Server) handleGetChange(c echo.Context) error {
 	// off-page items too (#166 review). resolveChangeID returns int64 → cast.
 	id, err := s.resolveChangeID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("change_request"))
 	}
 	cr, err := s.db.GetChangeRequest(c.Request().Context(), orgID, int(id))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("change_request"))
 	}
 	return c.JSON(http.StatusOK, cr)
 }
@@ -2720,12 +2720,12 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid change id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("change_request"))
 	}
 
 	old, err := s.db.GetChangeRequest(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("change_request"))
 	}
 	oldMap := old.ToChangeMap()
 
@@ -2814,7 +2814,7 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 	}
 	updated, _ := s.db.GetChangeRequest(ctx, orgID, id)
 	if updated == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("change_request"))
 	}
 
 	actor := getUserEmail(c)
@@ -2848,7 +2848,7 @@ func (s *Server) handleUpdateChangeStatus(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid change request id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("change_request"))
 	}
 
 	old, _ := s.db.GetChangeRequest(ctx, orgID, id)
@@ -2873,7 +2873,7 @@ func (s *Server) handleUpdateChangeStatus(c echo.Context) error {
 	}
 	updated, _ := s.db.GetChangeRequest(ctx, orgID, id)
 	if updated == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("change_request"))
 	}
 
 	actor := getUserEmail(c)
@@ -2957,12 +2957,12 @@ func (s *Server) handleDeleteChange(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid change request id")
+		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("change_request"))
 	}
 
 	cr, err := s.db.GetChangeRequest(ctx, orgID, id)
 	if err != nil || cr == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "change request not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("change_request"))
 	}
 
 	if err := s.db.DeleteChangeRequest(ctx, orgID, id); err != nil {
@@ -3334,7 +3334,7 @@ func (s *Server) handleListNotifications(c echo.Context) error {
 	ctx := c.Request().Context()
 	user, err := s.db.GetUserByEmail(ctx, getUserEmail(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "user not found")
+		return apiError(http.StatusBadRequest, CodeNotFound, Entity("user"))
 	}
 	unreadOnly := c.QueryParam("unread") == "true"
 	limit, _ := strconv.Atoi(c.QueryParam("limit"))
@@ -3358,7 +3358,7 @@ func (s *Server) handleMarkRead(c echo.Context) error {
 	email := getUserEmail(c)
 	user, userErr := s.db.GetUserByEmail(c.Request().Context(), email)
 	if userErr != nil || user == nil {
-		return echo.NewHTTPError(http.StatusForbidden, "user not found")
+		return apiError(http.StatusForbidden, CodeNotFound, Entity("user"))
 	}
 	if err := s.db.MarkRead(c.Request().Context(), orgID, id, user.ID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -3371,7 +3371,7 @@ func (s *Server) handleMarkAllRead(c echo.Context) error {
 	ctx := c.Request().Context()
 	user, err := s.db.GetUserByEmail(ctx, getUserEmail(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "user not found")
+		return apiError(http.StatusBadRequest, CodeNotFound, Entity("user"))
 	}
 	if err := s.db.MarkAllRead(ctx, orgID, user.ID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -3384,7 +3384,7 @@ func (s *Server) handleUnreadCount(c echo.Context) error {
 	ctx := c.Request().Context()
 	user, err := s.db.GetUserByEmail(ctx, getUserEmail(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "user not found")
+		return apiError(http.StatusBadRequest, CodeNotFound, Entity("user"))
 	}
 	count, err := s.db.UnreadCount(ctx, orgID, user.ID)
 	if err != nil {
@@ -3440,7 +3440,7 @@ func (s *Server) handleInbox(c echo.Context) error {
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 	if actor == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "user email required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("email"))
 	}
 
 	var items []inboxItem
@@ -3503,7 +3503,7 @@ func (s *Server) handleInboxDump(c echo.Context) error {
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 	if actor == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "user email required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("email"))
 	}
 
 	type replyInfo struct {
@@ -3730,7 +3730,7 @@ func (s *Server) handleConfirmDocumentReview(c echo.Context) error {
 
 	filePath := resolveDocPathFromStore(st, docID)
 	if filePath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return apiError(http.StatusNotFound, CodeNotFound, Entity("document"))
 	}
 
 	doc, err := st.LoadDocument(filePath)
@@ -3875,7 +3875,7 @@ func (s *Server) handleReviewSend(c echo.Context) error {
 	docID := c.Param("docId")
 	actor := getUserEmail(c)
 	if actor == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "user email required")
+		return apiError(http.StatusBadRequest, CodeRequired, Field("email"))
 	}
 
 	var req struct {

--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -173,13 +173,13 @@ func (s *Server) handleGetCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 	ca, err := s.db.GetCorrectiveAction(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 	return c.JSON(http.StatusOK, ca)
 }
@@ -191,15 +191,15 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 
 	ctx := c.Request().Context()
 	existing, err := s.db.GetCorrectiveAction(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 	prevStatus := existing.Status
 
@@ -308,9 +308,9 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 
 	var req struct {
@@ -330,7 +330,7 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 	if req.Status == "resolved" {
 		existing, err := s.db.GetCorrectiveAction(ctx, orgID, id)
 		if err != nil || existing == nil {
-			return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+			return errNotFound("corrective_action")
 		}
 		// An empty identifier is corrupt data — the open-task query can't
 		// match anything, so skipping would silently disable enforcement.
@@ -377,9 +377,9 @@ func (s *Server) handleDeleteCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_diff.go
+++ b/internal/isms/api/api_diff.go
@@ -70,7 +70,7 @@ func (s *Server) handleDocumentDiff(c echo.Context) error {
 	// Get file path.
 	filePath := resolveDocPathFromStore(st, docID)
 	if filePath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return errNotFound("document")
 	}
 
 	// Compute diff using go-git.

--- a/internal/isms/api/api_entity_comments.go
+++ b/internal/isms/api/api_entity_comments.go
@@ -52,7 +52,7 @@ func (s *Server) handleCreateEntityComment(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "entity_type and entity_id are required")
 	}
 	if req.Body == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "body is required")
+		return errRequired("body")
 	}
 
 	comment := &db.EntityComment{
@@ -89,7 +89,7 @@ func (s *Server) handleResolveEntityComment(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 	if err := s.db.ResolveEntityComment(c.Request().Context(), orgID, id, getUserEmail(c)); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -104,7 +104,7 @@ func (s *Server) handleDeleteEntityComment(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 	if err := s.db.DeleteEntityComment(c.Request().Context(), orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -258,13 +258,13 @@ func (s *Server) handleGetIncident(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 	inc, err := s.db.GetIncident(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 	return c.JSON(http.StatusOK, inc)
 }
@@ -276,16 +276,16 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	// Get existing incident first
 	ctx := c.Request().Context()
 	existing, err := s.db.GetIncident(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 	prevStatus := existing.Status
 
@@ -458,9 +458,9 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	var req struct {
@@ -482,7 +482,7 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 	if req.Status == "closed" || req.Status == "resolved" {
 		existing, err := s.db.GetIncident(ctx, orgID, id)
 		if err != nil || existing == nil {
-			return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+			return errNotFound("incident")
 		}
 		if n, err := s.db.CountOpenCAsByIncident(ctx, orgID, existing.Identifier); err == nil && n > 0 {
 			return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", statusVerb(req.Status), n))
@@ -559,14 +559,14 @@ func (s *Server) handleDeleteIncident(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	inc, err := s.db.GetIncident(ctx, orgID, id)
 	if err != nil || inc == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	if err := s.db.DeleteIncident(ctx, orgID, id); err != nil {

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -160,13 +160,13 @@ func (s *Server) handleGetLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+		return errInvalidEntityID("legal_requirement")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 	lr, err := s.db.GetLegalRequirement(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 	return c.JSON(http.StatusOK, lr)
 }
@@ -178,15 +178,15 @@ func (s *Server) handleUpdateLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+		return errInvalidEntityID("legal_requirement")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 
 	ctx := c.Request().Context()
 	existing, err := s.db.GetLegalRequirement(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 
 	var req legalUpdateRequest
@@ -308,9 +308,9 @@ func (s *Server) handleDeleteLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+		return errInvalidEntityID("legal_requirement")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -119,10 +119,10 @@ func (s *Server) handleCreateProgram(c echo.Context) error {
 	}
 
 	if p.Key == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "key is required")
+		return errRequired("key")
 	}
 	if p.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return errRequired("title")
 	}
 
 	if err := s.db.CreateProgram(ctx, orgID, &p); err != nil {
@@ -164,11 +164,11 @@ func (s *Server) handleGetProgram(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveProgramID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 	p, err := s.db.GetProgram(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 	return c.JSON(http.StatusOK, p)
 }
@@ -181,12 +181,12 @@ func (s *Server) handleUpdateProgram(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveProgramID(ctx, orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 
 	old, err := s.db.GetProgram(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 
 	var req programUpdateRequest
@@ -198,7 +198,7 @@ func (s *Server) handleUpdateProgram(c echo.Context) error {
 	p.ID = id
 	if req.Title != nil {
 		if *req.Title == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "title cannot be empty")
+			return apiError(http.StatusBadRequest, CodeFieldEmpty, Field("title"))
 		}
 		p.Title = *req.Title
 	}
@@ -235,7 +235,7 @@ func (s *Server) handleDeleteProgram(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveProgramID(ctx, orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "program not found")
+		return errNotFound("program")
 	}
 
 	if err := s.db.DeleteProgram(ctx, orgID, id); err != nil {
@@ -323,11 +323,11 @@ func (s *Server) handleCreateObjective(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "program_id is required")
 	}
 	if req.Title == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "title is required")
+		return errRequired("title")
 	}
 	// Cross-org parent guard: confirm the program belongs to this org.
 	if _, err := s.db.GetProgram(ctx, orgID, req.ProgramID); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "program not found in this organization")
+		return apiError(http.StatusBadRequest, CodeNotFoundInOrg, Entity("program"))
 	}
 	o := db.Objective{
 		ProgramID:         req.ProgramID,
@@ -379,11 +379,11 @@ func (s *Server) handleGetObjective(c echo.Context) error {
 	// deep-links resolve for off-page objectives too (#166).
 	id, err := s.resolveObjectiveID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
+		return errNotFound("objective")
 	}
 	o, err := s.db.GetObjective(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
+		return errNotFound("objective")
 	}
 	return c.JSON(http.StatusOK, o)
 }
@@ -396,12 +396,12 @@ func (s *Server) handleUpdateObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	old, err := s.db.GetObjective(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found")
+		return errNotFound("objective")
 	}
 
 	var req objectiveUpdateRequest
@@ -423,7 +423,7 @@ func (s *Server) handleUpdateObjective(c echo.Context) error {
 	o.ID = id
 	if req.Title != nil {
 		if *req.Title == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "title cannot be empty")
+			return apiError(http.StatusBadRequest, CodeFieldEmpty, Field("title"))
 		}
 		o.Title = *req.Title
 	}
@@ -490,7 +490,7 @@ func (s *Server) handleDeleteObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	if err := s.db.DeleteObjective(ctx, orgID, id); err != nil {
@@ -521,7 +521,7 @@ func (s *Server) handleArchiveObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	before, _ := s.db.GetObjective(ctx, orgID, id)
@@ -562,7 +562,7 @@ func (s *Server) handleUnarchiveObjective(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	before, _ := s.db.GetObjective(ctx, orgID, id)
@@ -607,7 +607,7 @@ func (s *Server) handleListCheckins(c echo.Context) error {
 	orgID := getOrgID(c)
 	objectiveID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid objective id")
+		return errInvalidEntityID("objective")
 	}
 
 	limit := 50
@@ -638,7 +638,7 @@ func (s *Server) handleCreateCheckin(c echo.Context) error {
 	ctx := c.Request().Context()
 	objectiveID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid objective id")
+		return errInvalidEntityID("objective")
 	}
 
 	var req checkinCreateRequest
@@ -647,7 +647,7 @@ func (s *Server) handleCreateCheckin(c echo.Context) error {
 	}
 	// Verify the objective belongs to this org before creating a checkin against it.
 	if _, err := s.db.GetObjective(ctx, orgID, objectiveID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "objective not found in this organization")
+		return apiError(http.StatusNotFound, CodeNotFoundInOrg, Entity("objective"))
 	}
 	ci := db.Checkin{
 		ObjectiveID:  objectiveID,
@@ -705,12 +705,12 @@ func (s *Server) handleUpdateCheckin(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	existing, err := s.db.GetCheckin(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "checkin not found")
+		return errNotFound("checkin")
 	}
 
 	var req checkinUpdateRequest
@@ -771,7 +771,7 @@ func (s *Server) handleDeleteCheckin(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	if err := s.db.DeleteCheckin(ctx, orgID, id); err != nil {
@@ -801,13 +801,13 @@ func (s *Server) handleUploadEvidence(c echo.Context) error {
 	ctx := c.Request().Context()
 	checkinID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid checkin id")
+		return errInvalidEntityID("checkin")
 	}
 
 	// Verify checkin exists and belongs to org
 	_, err = s.db.GetCheckin(ctx, orgID, checkinID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "checkin not found")
+		return errNotFound("checkin")
 	}
 
 	// Get org UUID for S3 key
@@ -818,7 +818,7 @@ func (s *Server) handleUploadEvidence(c echo.Context) error {
 
 	file, err := c.FormFile("file")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "file is required")
+		return errRequired("file")
 	}
 
 	title := c.FormValue("title")
@@ -881,7 +881,7 @@ func (s *Server) handleListEvidence(c echo.Context) error {
 	orgID := getOrgID(c)
 	checkinID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid checkin id")
+		return errInvalidEntityID("checkin")
 	}
 
 	evidence, err := s.db.ListEvidence(c.Request().Context(), orgID, checkinID)
@@ -896,7 +896,7 @@ func (s *Server) handleDownloadEvidence(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	org, err := s.db.GetOrganization(ctx, orgID)
@@ -906,7 +906,7 @@ func (s *Server) handleDownloadEvidence(c echo.Context) error {
 
 	ev, err := s.db.GetEvidence(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "evidence not found")
+		return errNotFound("evidence")
 	}
 
 	// S3 backend: return presigned URL. Local backend: serve file directly.
@@ -941,7 +941,7 @@ func (s *Server) handleDeleteEvidence(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	org, err := s.db.GetOrganization(ctx, orgID)
@@ -951,7 +951,7 @@ func (s *Server) handleDeleteEvidence(c echo.Context) error {
 
 	ev, err := s.db.GetEvidence(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "evidence not found")
+		return errNotFound("evidence")
 	}
 
 	_ = s.blobs.Delete(ctx, org.UUID, ev.ObjectKey)

--- a/internal/isms/api/api_oidc.go
+++ b/internal/isms/api/api_oidc.go
@@ -27,7 +27,7 @@ func (s *Server) handleOIDCProviders(c echo.Context) error {
 	ctx := c.Request().Context()
 	org, err := s.db.GetOrganizationBySlug(ctx, slug)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	providers, err := s.db.ListEnabledOIDCProviders(ctx, org.ID)
@@ -54,12 +54,12 @@ func (s *Server) handleOIDCAuthorize(c echo.Context) error {
 	ctx := c.Request().Context()
 	org, err := s.db.GetOrganizationBySlug(ctx, slug)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	provider, err := s.db.GetOIDCProvider(ctx, org.ID, providerName)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "OIDC provider not found")
+		return errNotFound("oidc_provider")
 	}
 	if !provider.Enabled {
 		return echo.NewHTTPError(http.StatusBadRequest, "OIDC provider is disabled")

--- a/internal/isms/api/api_passkey.go
+++ b/internal/isms/api/api_passkey.go
@@ -69,7 +69,7 @@ func (s *Server) handlePasskeyRegisterBegin(c echo.Context) error {
 
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	// Load existing credentials so the authenticator can exclude them.
@@ -113,7 +113,7 @@ func (s *Server) handlePasskeyRegisterComplete(c echo.Context) error {
 
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	raw, ok := s.passkeyRegistrations.LoadAndDelete(email)
@@ -184,10 +184,10 @@ func (s *Server) handlePasskeyLoginBegin(c echo.Context) error {
 
 	var req passkeyLoginBeginRequest
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Email == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "email is required")
+		return errRequired("email")
 	}
 
 	ctx := c.Request().Context()
@@ -198,18 +198,18 @@ func (s *Server) handlePasskeyLoginBegin(c echo.Context) error {
 	if !rateLimitDisabled() {
 		count, _ := s.db.CountRecentLoginAttempts(ctx, req.Email)
 		if count >= maxLoginAttempts {
-			return echo.NewHTTPError(http.StatusTooManyRequests, "too many attempts, try again later")
+			return apiError(http.StatusTooManyRequests, CodeTooManyAttempts)
 		}
 	}
 
 	user, err := s.db.GetUserByEmail(ctx, req.Email)
 	if err != nil || user == nil {
 		s.db.RecordLoginAttempt(ctx, req.Email, clientIP)
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+		return apiError(http.StatusUnauthorized, CodeInvalidCredentials)
 	}
 	if !user.Active {
 		s.db.RecordLoginAttempt(ctx, req.Email, clientIP)
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+		return apiError(http.StatusUnauthorized, CodeInvalidCredentials)
 	}
 
 	dbCreds, err := s.db.ListWebAuthnCredentials(ctx, user.ID)
@@ -250,7 +250,7 @@ func (s *Server) handlePasskeyLoginComplete(c echo.Context) error {
 
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil || user == nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+		return apiError(http.StatusUnauthorized, CodeInvalidCredentials)
 	}
 
 	raw, ok := s.passkeyLogins.LoadAndDelete(email)
@@ -292,11 +292,11 @@ func (s *Server) handlePasskeyLoginComplete(c echo.Context) error {
 	if orgSlug != "" {
 		org, err := s.db.GetOrganizationBySlug(ctx, orgSlug)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "organization not found")
+			return apiError(http.StatusBadRequest, CodeNotFound, Entity("organization"))
 		}
 		_, err = s.db.GetOrgMember(ctx, org.ID, user.ID)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+			return apiError(http.StatusForbidden, CodeNotOrgMember)
 		}
 		orgID = org.ID
 		orgName = org.Name
@@ -362,7 +362,7 @@ func (s *Server) handleListPasskeys(c echo.Context) error {
 
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	creds, err := s.db.ListWebAuthnCredentials(ctx, user.ID)
@@ -392,12 +392,12 @@ type renamePasskeyRequest struct {
 func (s *Server) handleRenamePasskey(c echo.Context) error {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	var req renamePasskeyRequest
 	if err := c.Bind(&req); err != nil || req.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return errRequired("name")
 	}
 
 	ctx := c.Request().Context()
@@ -406,15 +406,15 @@ func (s *Server) handleRenamePasskey(c echo.Context) error {
 	// Verify ownership.
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	cred, err := s.db.GetWebAuthnCredentialByID(ctx, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "passkey not found")
+		return errNotFound("passkey")
 	}
 	if cred.UserID != user.ID {
-		return echo.NewHTTPError(http.StatusForbidden, "not your passkey")
+		return apiError(http.StatusForbidden, CodeNotYourPasskey)
 	}
 
 	if err := s.db.RenameWebAuthnCredential(ctx, id, user.ID, req.Name); err != nil {
@@ -429,7 +429,7 @@ func (s *Server) handleRenamePasskey(c echo.Context) error {
 func (s *Server) handleDeletePasskey(c echo.Context) error {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	ctx := c.Request().Context()
@@ -437,15 +437,15 @@ func (s *Server) handleDeletePasskey(c echo.Context) error {
 
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 
 	cred, err := s.db.GetWebAuthnCredentialByID(ctx, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "passkey not found")
+		return errNotFound("passkey")
 	}
 	if cred.UserID != user.ID {
-		return echo.NewHTTPError(http.StatusForbidden, "not your passkey")
+		return apiError(http.StatusForbidden, CodeNotYourPasskey)
 	}
 
 	if err := s.db.DeleteWebAuthnCredential(ctx, id, user.ID); err != nil {

--- a/internal/isms/api/api_policies.go
+++ b/internal/isms/api/api_policies.go
@@ -37,10 +37,10 @@ func (s *Server) handleAdminCreatePolicy(c echo.Context) error {
 	p.ID = 0
 	p.OrganizationID = orgID
 	if p.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return errRequired("name")
 	}
 	if p.PathPattern == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "path_pattern is required")
+		return errRequired("path_pattern")
 	}
 	p.Active = true // new policies are always active
 	if p.MinApprovals < 1 {
@@ -73,12 +73,12 @@ func (s *Server) handleAdminUpdatePolicy(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid policy id")
+		return errInvalidEntityID("policy")
 	}
 
 	existing, err := s.db.GetApprovalPolicy(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "policy not found")
+		return errNotFound("policy")
 	}
 
 	// Start from existing policy to preserve bool fields not sent in request
@@ -91,10 +91,10 @@ func (s *Server) handleAdminUpdatePolicy(c echo.Context) error {
 	p.ID = existing.ID
 	p.OrganizationID = orgID
 	if p.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return errRequired("name")
 	}
 	if p.PathPattern == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "path_pattern is required")
+		return errRequired("path_pattern")
 	}
 	if p.MinApprovals < 1 {
 		p.MinApprovals = 1
@@ -126,12 +126,12 @@ func (s *Server) handleAdminDeletePolicy(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid policy id")
+		return errInvalidEntityID("policy")
 	}
 
 	existing, err := s.db.GetApprovalPolicy(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "policy not found")
+		return errNotFound("policy")
 	}
 
 	if err := s.db.DeleteApprovalPolicy(ctx, orgID, id); err != nil {
@@ -168,12 +168,12 @@ func (s *Server) handleReviewPolicyStatus(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return errInvalidEntityID("review")
 	}
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return errNotFound("review")
 	}
 
 	// Get the document path for policy matching

--- a/internal/isms/api/api_readings.go
+++ b/internal/isms/api/api_readings.go
@@ -20,7 +20,7 @@ func (s *Server) handleListRiskReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	riskID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "risk", riskID)
 	if err != nil {
@@ -40,7 +40,7 @@ func (s *Server) handleCreateRiskReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	riskID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 
 	var req struct {
@@ -164,7 +164,7 @@ func (s *Server) handleListAssetReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	assetID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "asset", assetID)
 	if err != nil {
@@ -184,7 +184,7 @@ func (s *Server) handleCreateAssetReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	assetID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 
 	var req struct {
@@ -287,7 +287,7 @@ func (s *Server) handleListLegalReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	legalID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal id")
+		return errInvalidEntityID("legal_requirement")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "legal_requirement", legalID)
 	if err != nil {
@@ -307,7 +307,7 @@ func (s *Server) handleCreateLegalReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	legalID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal id")
+		return errInvalidEntityID("legal_requirement")
 	}
 
 	var req struct {
@@ -391,7 +391,7 @@ func (s *Server) handleListSupplierReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	supplierID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "supplier", supplierID)
 	if err != nil {
@@ -411,7 +411,7 @@ func (s *Server) handleCreateSupplierReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	supplierID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 
 	var req struct {
@@ -491,7 +491,7 @@ func (s *Server) handleListSystemReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	systemID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "system", systemID)
 	if err != nil {
@@ -511,7 +511,7 @@ func (s *Server) handleCreateSystemReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	systemID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 
 	var req struct {

--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -94,7 +94,7 @@ func (s *Server) handleCreateReference(c echo.Context) error {
 		TargetID   string `json:"target_id"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.SourceType == "" || req.SourceID == "" || req.TargetType == "" || req.TargetID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "source_type, source_id, target_type, target_id required")
@@ -140,7 +140,7 @@ func (s *Server) handleDeleteReference(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_supplier_reviews.go
+++ b/internal/isms/api/api_supplier_reviews.go
@@ -29,13 +29,13 @@ func (s *Server) handleCreateSupplierReview(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 
 	// Verify supplier exists in this org (cross-org safety).
 	sup, err := s.db.GetSupplier(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "supplier not found")
+		return errNotFound("supplier")
 	}
 
 	var req supplierReviewCreateRequest
@@ -73,7 +73,7 @@ func (s *Server) handleListSupplierReviews(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 
 	reviews, err := s.db.ListSupplierReviews(c.Request().Context(), orgID, id)

--- a/internal/isms/api/api_users.go
+++ b/internal/isms/api/api_users.go
@@ -38,7 +38,7 @@ func (s *Server) handleMe(c echo.Context) error {
 	// Find existing user — never auto-create
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	// Update last_seen
 	s.db.TouchUser(ctx, email, user.Name)
@@ -152,7 +152,7 @@ func (s *Server) handleUpsertUser(c echo.Context) error {
 	}
 	validRoles := map[string]bool{"admin": true, "manager": true, "contributor": true, "reader": true}
 	if !validRoles[req.Role] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+		return apiError(http.StatusBadRequest, CodeInvalidRole)
 	}
 
 	// Only admin can assign admin or manager roles
@@ -189,7 +189,7 @@ func (s *Server) handleMyOrganizations(c echo.Context) error {
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	orgs, err := s.db.ListUserOrgs(ctx, user.ID)
 	if err != nil {
@@ -219,7 +219,7 @@ func (s *Server) handleCreateOrganization(c echo.Context) error {
 		Template string `json:"template"` // optional: iso27001, soc2, nis2
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Name == "" || req.Slug == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "name and slug are required")
@@ -233,7 +233,7 @@ func (s *Server) handleCreateOrganization(c echo.Context) error {
 	email := getUserEmail(c)
 	existingUser, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	existingOrgs, err := s.db.ListUserOrgs(ctx, existingUser.ID)
 	if err != nil {
@@ -373,7 +373,7 @@ func (s *Server) handleAddTemplate(c echo.Context) error {
 		Template string `json:"template"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if !scaffold.IsValidTemplate(req.Template) {
 		available, _ := scaffold.ListTemplates()
@@ -398,7 +398,7 @@ func (s *Server) handleAddTemplate(c echo.Context) error {
 	}
 
 	if _, err := s.db.GetOrganization(ctx, orgID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	if err := scaffold.ScaffoldToRepo(st, req.Template, authorName, email); err != nil {
@@ -439,7 +439,7 @@ func (s *Server) handleRemoveTemplate(c echo.Context) error {
 
 	org, err := s.db.GetOrganization(ctx, orgID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	st, err := s.storeForOrg(ctx, orgID)

--- a/internal/isms/api/errors.go
+++ b/internal/isms/api/errors.go
@@ -350,6 +350,7 @@ func humanizeParam(p ErrorParam) string {
 // locale file agree, which TestOverridesMatchTheEnglishCatalogue checks rather
 // than assumes.
 var paramMessageOverrides = map[string]string{
+	"checkin":       "check-in",
 	"oidc_provider": "OIDC provider",
 	"api_key":       "API key",
 	"document_id":   "document ID",

--- a/internal/isms/api/errors_test.go
+++ b/internal/isms/api/errors_test.go
@@ -230,8 +230,9 @@ func TestApiErrorRendering(t *testing.T) {
 		},
 		{
 			// field is humanised the same way entity is, so a snake_case JSON
-			// field name reads as prose in the CLI: today's literal at this
-			// call site says "path_pattern is required".
+			// field name reads as prose in the CLI. The two policy call sites
+			// used to spell the identifier ("path_pattern is required"); since
+			// they were converted they read "path pattern is required".
 			name:   "required wrapper humanises the field name",
 			err:    errRequired("path_pattern"),
 			msg:    "path pattern is required",

--- a/internal/isms/api/errors_test.go
+++ b/internal/isms/api/errors_test.go
@@ -401,6 +401,36 @@ func TestEnglishCatalogueMatchesTheGoTemplates(t *testing.T) {
 // An override claims Go and the en locale agree on an identifier's English
 // prose. Checking it means the CLI and the browser cannot disagree the way
 // they would have for "oidc provider" / "OIDC provider".
+// TestCatalogueValuesMatchGoProse is TestOverridesMatchTheEnglishCatalogue run
+// the other way round. That one checks the exceptions: every declared override
+// equals what the catalogue says. This one checks the rule: every catalogue
+// value equals what Go would actually render, whether it gets there through an
+// override or through the underscore de-slug.
+//
+// The distinction is not academic. `checkin` has no underscore, so the de-slug
+// returned it unchanged while `common.entity_inline.checkin` said "check-in" —
+// one code, one language, two texts, which is the exact failure the
+// oidc_provider override exists to prevent. Nothing caught it, because a test
+// that pins the declared exceptions is not a test that pins the rule.
+//
+// It walks the catalogue rather than the call sites on purpose. The AST scan
+// sees only what Go emits today, so a checkin-shaped key that no call site uses
+// yet would stay invisible until some later conversion reached it — the same
+// reasoning that made the common.field.* mirror wholesale rather than
+// call-site-driven.
+func TestCatalogueValuesMatchGoProse(t *testing.T) {
+	for _, group := range []string{"entity_inline", "field"} {
+		for value, catalogued := range commonGroup(t, "en", group) {
+			got := humanizeParam(ErrorParam{Key: ParamEntity, Value: value})
+			if got != catalogued {
+				t.Errorf("common.%s.%s: the en catalogue says %q but Go renders %q — "+
+					"add a paramMessageOverrides entry so the wire message and the browser agree",
+					group, value, catalogued, got)
+			}
+		}
+	}
+}
+
 func TestOverridesMatchTheEnglishCatalogue(t *testing.T) {
 	entities := commonGroup(t, "en", "entity_inline")
 	fields := commonGroup(t, "en", "field")

--- a/internal/isms/api/middleware.go
+++ b/internal/isms/api/middleware.go
@@ -107,11 +107,11 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 								// Enforce org scope: if the token is scoped to a specific org,
 								// reject requests targeting a different org.
 								if tok.OrganizationID != nil && *tok.OrganizationID != resolvedOrgID {
-									return echo.NewHTTPError(http.StatusForbidden, "API key is not authorized for this organization")
+									return apiError(http.StatusForbidden, CodeAPIKeyWrongOrg)
 								}
 								role, err := cfg.DB.GetUserRole(c.Request().Context(), resolvedOrgID, tok.UserID)
 								if err != nil {
-									return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+									return apiError(http.StatusForbidden, CodeNotOrgMember)
 								}
 								c.Set("user_role", role)
 							} else if orgUUID := c.Request().Header.Get("X-Organization-UUID"); orgUUID != "" {
@@ -120,7 +120,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 									// Enforce org scope: if the token is scoped to a specific org,
 									// reject requests targeting a different org.
 									if tok.OrganizationID != nil && *tok.OrganizationID != org.ID {
-										return echo.NewHTTPError(http.StatusForbidden, "API key is not authorized for this organization")
+										return apiError(http.StatusForbidden, CodeAPIKeyWrongOrg)
 									}
 									if role, err := cfg.DB.GetUserRole(c.Request().Context(), org.ID, tok.UserID); err == nil {
 										c.Set("org_id", org.ID)
@@ -143,7 +143,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 								if cfg.DB.IsUserAgent(c.Request().Context(), tok.UserEmail) {
 									aiEnabled, _ := cfg.DB.GetOrgSetting(c.Request().Context(), resolvedOrgID, "ai_enabled")
 									if aiEnabled == "false" {
-										return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+										return apiError(http.StatusForbidden, CodeAIDisabled)
 									}
 								}
 							}
@@ -193,7 +193,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 								if jwtUser.IsAgent {
 									aiEnabled, _ := cfg.DB.GetOrgSetting(c.Request().Context(), claims.OrganizationID, "ai_enabled")
 									if aiEnabled == "false" {
-										return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+										return apiError(http.StatusForbidden, CodeAIDisabled)
 									}
 								}
 							}
@@ -205,7 +205,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 					}
 				}
 
-				return echo.NewHTTPError(http.StatusUnauthorized, "invalid token")
+				return apiError(http.StatusUnauthorized, CodeInvalidToken)
 			}
 
 			// For git paths: challenge with WWW-Authenticate so git client sends credentials
@@ -217,12 +217,12 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			// 2. Cloudflare Zero Trust JWT
 			email := c.Request().Header.Get("Cf-Access-Authenticated-User-Email")
 			if email == "" {
-				return echo.NewHTTPError(http.StatusUnauthorized, "API key required. Use: isms server api-key create")
+				return apiError(http.StatusUnauthorized, CodeAPIKeyRequired)
 			}
 
 			// CF headers are only trusted when Cloudflare is configured
 			if keyCache == nil {
-				return echo.NewHTTPError(http.StatusUnauthorized, "API key required. Use: isms server api-key create")
+				return apiError(http.StatusUnauthorized, CodeAPIKeyRequired)
 			}
 
 			cfName := ""
@@ -236,7 +236,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 					return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("invalid token: %v", err))
 				}
 				if claims.Email != "" && !strings.EqualFold(claims.Email, email) {
-					return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
+					return apiError(http.StatusUnauthorized, CodeTokenEmailMismatch)
 				}
 				cfName = claims.Name
 			}
@@ -249,7 +249,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				if errors.Is(err, errProvisionFailed) {
 					return echo.NewHTTPError(http.StatusInternalServerError, "auto-provision failed")
 				}
-				return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+				return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 			}
 			if created {
 				log.Printf("[cf-access] auto-provisioned user %s", email)
@@ -260,7 +260,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if resolvedOrgID, ok := c.Get("org_id").(int); ok && resolvedOrgID > 0 {
 				member, err := cfg.DB.GetOrgMember(ctx, resolvedOrgID, user.ID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+					return apiError(http.StatusForbidden, CodeNotOrgMember)
 				}
 				c.Set("org_id", resolvedOrgID)
 				c.Set("user_role", member.Role)
@@ -269,7 +269,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				if user.IsAgent {
 					aiEnabled, _ := cfg.DB.GetOrgSetting(ctx, resolvedOrgID, "ai_enabled")
 					if aiEnabled == "false" {
-						return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+						return apiError(http.StatusForbidden, CodeAIDisabled)
 					}
 				}
 
@@ -282,7 +282,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				var err error
 				org, err = cfg.DB.GetOrganizationByUUID(ctx, orgUUID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+					return errNotFound("organization")
 				}
 			}
 
@@ -290,7 +290,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if org != nil {
 				member, err := cfg.DB.GetOrgMember(ctx, org.ID, user.ID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+					return apiError(http.StatusForbidden, CodeNotOrgMember)
 				}
 				c.Set("org_id", org.ID)
 				c.Set("user_role", member.Role)
@@ -306,7 +306,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				}
 				member, err := cfg.DB.GetOrgMember(ctx, orgs[0].ID, user.ID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+					return apiError(http.StatusForbidden, CodeNotOrgMember)
 				}
 				c.Set("org_id", orgs[0].ID)
 				c.Set("user_role", member.Role)
@@ -317,7 +317,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if resolvedOrgID > 0 && user.IsAgent {
 				aiEnabled, _ := cfg.DB.GetOrgSetting(ctx, resolvedOrgID, "ai_enabled")
 				if aiEnabled == "false" {
-					return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+					return apiError(http.StatusForbidden, CodeAIDisabled)
 				}
 			}
 

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1182,7 +1182,7 @@ func (s *Server) handleGetDocument(c echo.Context) error {
 	})
 
 	if found == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return errNotFound("document")
 	}
 
 	raw, _ := st.ReadFile(found.Path)
@@ -1352,7 +1352,7 @@ func (s *Server) handleUpdateDocumentMetadata(c echo.Context) error {
 	// Only manager/admin can update document metadata
 	role, _ := c.Get("user_role").(string)
 	if role != "manager" && role != "admin" {
-		return echo.NewHTTPError(http.StatusForbidden, "requires manager or admin role")
+		return apiError(http.StatusForbidden, CodeManagerOrAdminRequired)
 	}
 
 	var req struct {
@@ -1391,7 +1391,7 @@ func (s *Server) handleUpdateDocumentMetadata(c echo.Context) error {
 
 	docPath := st.FindDocumentByID(docID)
 	if docPath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return errNotFound("document")
 	}
 
 	email := getUserEmail(c)
@@ -1404,7 +1404,7 @@ func (s *Server) handleUpdateDocumentMetadata(c echo.Context) error {
 	commitHash, err := st.UpdateDocumentMetadataMulti(docPath, req.Fields, authorName, email)
 	if err != nil {
 		if err == store.ErrConflict {
-			return echo.NewHTTPError(http.StatusConflict, "the document was modified by another user — please refresh and try again")
+			return apiError(http.StatusConflict, CodeDocumentModified)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "updating document: "+err.Error())
 	}
@@ -1562,7 +1562,7 @@ func (s *Server) handleDeleteDocument(c echo.Context) error {
 
 	docPath := st.FindDocumentByID(docID)
 	if docPath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return errNotFound("document")
 	}
 
 	email := getUserEmail(c)
@@ -1617,7 +1617,7 @@ func (s *Server) handleUpdateDocumentContent(c echo.Context) error {
 	// Only manager/admin can update document content
 	role, _ := c.Get("user_role").(string)
 	if role != "manager" && role != "admin" {
-		return echo.NewHTTPError(http.StatusForbidden, "requires manager or admin role")
+		return apiError(http.StatusForbidden, CodeManagerOrAdminRequired)
 	}
 
 	var req struct {
@@ -1637,7 +1637,7 @@ func (s *Server) handleUpdateDocumentContent(c echo.Context) error {
 
 	docPath := st.FindDocumentByID(docID)
 	if docPath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return errNotFound("document")
 	}
 
 	// Load current document to get frontmatter
@@ -1693,7 +1693,7 @@ func (s *Server) handleUpdateDocumentContent(c echo.Context) error {
 	commitHash, err := st.CommitFile(docPath, []byte(newContent), authorName, email, message, expectedHead)
 	if err != nil {
 		if err == store.ErrConflict {
-			return echo.NewHTTPError(http.StatusConflict, "the document was modified by another user — please refresh and try again")
+			return apiError(http.StatusConflict, CodeDocumentModified)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "saving document: "+err.Error())
 	}
@@ -1909,11 +1909,11 @@ func (s *Server) handleGetAsset(c echo.Context) error {
 	// off-page items too (#166 review).
 	id, err := s.resolveAssetID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "asset not found")
+		return errNotFound("asset")
 	}
 	a, err := s.db.GetAsset(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "asset not found")
+		return errNotFound("asset")
 	}
 	return c.JSON(http.StatusOK, a)
 }
@@ -1972,7 +1972,7 @@ func (s *Server) handleDeleteAsset(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 	old, _ := s.db.GetAsset(ctx, orgID, id)
 	if err := s.db.DeleteAsset(ctx, orgID, id); err != nil {
@@ -2039,11 +2039,11 @@ func (s *Server) handleGetSystem(c echo.Context) error {
 	// identifier is SYSTEM-5, not row id 5, if the per-org seq has drifted (#166 review).
 	id, err := s.resolveSystemID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "system not found")
+		return errNotFound("system")
 	}
 	sys, err := s.db.GetSystem(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "system not found")
+		return errNotFound("system")
 	}
 	return c.JSON(http.StatusOK, sys)
 }
@@ -2083,7 +2083,7 @@ func (s *Server) handleCreateSystem(c echo.Context) error {
 	// Verify supplier belongs to this org if referenced.
 	if sys.SupplierID != nil && *sys.SupplierID > 0 {
 		if _, err := s.db.GetSupplier(ctx, orgID, *sys.SupplierID); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "supplier not found in this organization")
+			return apiError(http.StatusBadRequest, CodeNotFoundInOrg, Entity("supplier"))
 		}
 	}
 	if err := s.db.CreateSystem(ctx, orgID, &sys); err != nil {
@@ -2111,11 +2111,11 @@ func (s *Server) handleGetRisk(c echo.Context) error {
 	// off-page items too (#166 review).
 	id, err := s.resolveRiskID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "risk not found")
+		return errNotFound("risk")
 	}
 	r, err := s.db.GetRisk(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "risk not found")
+		return errNotFound("risk")
 	}
 	return c.JSON(http.StatusOK, r)
 }
@@ -2316,12 +2316,12 @@ func (s *Server) handleRiskAdvisories(c echo.Context) error {
 
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 
 	risk, err := s.db.GetRisk(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "risk not found")
+		return errNotFound("risk")
 	}
 
 	// Find linked assets via entity_references (both directions). References
@@ -2415,7 +2415,7 @@ func (s *Server) handleDeleteRisk(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 	old, _ := s.db.GetRisk(ctx, orgID, id)
 	if err := s.db.DeleteRisk(ctx, orgID, id); err != nil {
@@ -2480,11 +2480,11 @@ func (s *Server) handleGetSupplier(c echo.Context) error {
 	// even if the per-org seq has drifted from the primary key (#166 review).
 	id, err := s.resolveSupplierID(c.Request().Context(), orgID, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "supplier not found")
+		return errNotFound("supplier")
 	}
 	sup, err := s.db.GetSupplier(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "supplier not found")
+		return errNotFound("supplier")
 	}
 	return c.JSON(http.StatusOK, sup)
 }
@@ -2547,11 +2547,11 @@ func (s *Server) handleUpdateAsset(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 	old, err := s.db.GetAsset(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "asset not found")
+		return errNotFound("asset")
 	}
 	var req assetUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -2640,11 +2640,11 @@ func (s *Server) handleUpdateRisk(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 	old, err := s.db.GetRisk(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "risk not found")
+		return errNotFound("risk")
 	}
 	var req riskUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -2807,11 +2807,11 @@ func (s *Server) handleUpdateSystem(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 	old, err := s.db.GetSystem(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "system not found")
+		return errNotFound("system")
 	}
 	var req systemUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -2834,7 +2834,7 @@ func (s *Server) handleUpdateSystem(c echo.Context) error {
 	}
 	if req.SupplierID != nil && *req.SupplierID != nil && **req.SupplierID > 0 {
 		if _, err := s.db.GetSupplier(ctx, orgID, **req.SupplierID); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "supplier not found in this organization")
+			return apiError(http.StatusBadRequest, CodeNotFoundInOrg, Entity("supplier"))
 		}
 	}
 	if req.Owner != nil && *req.Owner != "" {
@@ -2922,7 +2922,7 @@ func (s *Server) handleDeleteSystem(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 	old, _ := s.db.GetSystem(ctx, orgID, id)
 	if err := s.db.DeleteSystem(ctx, orgID, id); err != nil {
@@ -2945,7 +2945,7 @@ func (s *Server) handleListAccessReviews(c echo.Context) error {
 	ctx := c.Request().Context()
 	systemID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 	reviews, err := s.db.ListAccessReviews(ctx, orgID, systemID)
 	if err != nil {
@@ -2965,7 +2965,7 @@ func (s *Server) handleCreateAccessReview(c echo.Context) error {
 	ctx := c.Request().Context()
 	systemID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 	var ar db.AccessReview
 	if err := c.Bind(&ar); err != nil {
@@ -2973,7 +2973,7 @@ func (s *Server) handleCreateAccessReview(c echo.Context) error {
 	}
 	// Verify the system belongs to this org before creating an access review.
 	if _, err := s.db.GetSystem(ctx, orgID, systemID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "system not found in this organization")
+		return apiError(http.StatusNotFound, CodeNotFoundInOrg, Entity("system"))
 	}
 	ar.SystemID = systemID
 	if ar.ReviewedBy == "" {
@@ -3002,7 +3002,7 @@ func (s *Server) handleDeleteAccessReview(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid access review id")
+		return errInvalidEntityID("access_review")
 	}
 	if err := s.db.DeleteAccessReview(ctx, orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -3018,11 +3018,11 @@ func (s *Server) handleUpdateSupplier(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 	old, err := s.db.GetSupplier(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "supplier not found")
+		return errNotFound("supplier")
 	}
 	var req supplierUpdateRequest
 	if err := c.Bind(&req); err != nil {
@@ -3125,7 +3125,7 @@ func (s *Server) handleDeleteSupplier(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 	old, _ := s.db.GetSupplier(ctx, orgID, id)
 	if err := s.db.DeleteSupplier(ctx, orgID, id); err != nil {


### PR DESCRIPTION
## What this changes

Every error the API returns used to be an English sentence and nothing else, so the web app had no way to show it in the reader's language. This branch attaches a stable machine-readable code, plus a small set of named values, to 385 of them — across every module the shared vocabulary covers.

Nothing a user sees changes yet, and that is deliberate. This is the groundwork; connecting the screens to it is separate work, sequenced after this.

## Why one pull request

There were 24 API modules and roughly 900 error sites to work through. Sent individually that would have been twenty-odd reviews of the same mechanical substitution. Each module still got its own pull request, its own automated checks and its own commit against this branch — the per-module record and history survive — but the decision to ship reaches master once, here.

## What landed

| Module | Sites |
|---|---|
| Reviews and tasks (#249) | 71 |
| Sign-in and accounts (#250) | 62 |
| Audits and findings (#251) | 36 |
| Documents and registers (#255) | 36 |
| Objectives and programs (#253) | 32 |
| Admin and single sign-on (#256) | 21 |
| Passkeys (#257) | 20 |
| Auth middleware (#259) | 16 |
| Incidents (#258) | 12 |
| Corrective actions (#260) | 11 |
| Approval policies (#261) | 10 |
| The remaining ten modules, batched (#262) | 44 |
| Vocabulary fix for "check-in" (#263) | — |

Plus the earlier groundwork already on master: the code catalogue itself and the client-side renderer (#245, #248).

## What a user could notice

Almost nothing. The large majority of these 385 messages read exactly as they did before, word for word. A handful now read better, and each is the shared vocabulary doing its job rather than an incidental edit:

- "invalid provider ID" says "invalid OIDC provider id" — the old text was truncated and did not name which kind of provider.
- "invalid legal id" says "invalid legal requirement id", for the same reason.
- "user is not a member of this organization" says "not a member of this organization", matching the eight other places that already said it that way.
- "path_pattern is required" says "path pattern is required" — the old text quoted an internal field name.
- "checkin" is spelled "check-in", consistently on both the server and the screen.

Every message keeps the HTTP status it had. That was verified per module by arithmetic rather than by eye, since a silent status change in an authentication path is the one mistake this work could plausibly have introduced.

## What was deliberately left alone

Roughly 520 sites remain untouched, and they are not a backlog:

- **Internal faults** — "creating user", "reading document" — which describe a server problem and are read in a log.
- **Operator configuration messages** — the WebAuthn, SMTP, single sign-on and Cloudflare Access setup errors, read by whoever deploys the server.
- **The git endpoints entirely**, which are consumed by `git push` and never rendered in a browser.
- **One-off sentences** whose wording is not settled. A message that appears once gets its phrasing decided on its own rather than guessed at during a mechanical pass.

## Risk

Low, and it did not grow as modules were added. The old and new styles coexist by design: an unconverted error is indistinguishable to any client from a converted one, the added fields are additive, and no schema or API contract changes.

The one genuine defect found during the work was caught by review on #253 — the server and the shared vocabulary disagreed on how to spell "check-in" — and #263 fixes it and adds the check that would have caught it. That check was missing because the existing one verified the declared exceptions rather than the rule itself.

## Merging

**Merge with a merge commit or a rebase, not a squash.** Each module is a separate commit so that any one of them can be reverted on its own, and so history still shows which change touched which file. A squash would collapse 385 changes across 23 files into a single commit.

## Verification

gofmt clean, `go vet ./...`, and the full `go test ./...` suite green on the branch. Master is an ancestor of this branch, so there is no drift to resolve.
