### PR TITLE
feat(i18n): make incident error messages translatable (#212)

### DIFF
--- a/internal/isms/api/api_incidents.go
+++ b/internal/isms/api/api_incidents.go
@@ -258,13 +258,13 @@ func (s *Server) handleGetIncident(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 	inc, err := s.db.GetIncident(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 	return c.JSON(http.StatusOK, inc)
 }
@@ -276,16 +276,16 @@ func (s *Server) handleUpdateIncident(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	// Get existing incident first
 	ctx := c.Request().Context()
 	existing, err := s.db.GetIncident(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 	prevStatus := existing.Status
 
@@ -458,9 +458,9 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	var req struct {
@@ -482,7 +482,7 @@ func (s *Server) handleUpdateIncidentStatus(c echo.Context) error {
 	if req.Status == "closed" || req.Status == "resolved" {
 		existing, err := s.db.GetIncident(ctx, orgID, id)
 		if err != nil || existing == nil {
-			return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+			return errNotFound("incident")
 		}
 		if n, err := s.db.CountOpenCAsByIncident(ctx, orgID, existing.Identifier); err == nil && n > 0 {
 			return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("cannot %s incident: %d open corrective action(s) still linked", statusVerb(req.Status), n))
@@ -559,14 +559,14 @@ func (s *Server) handleDeleteIncident(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := s.resolveIncidentID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+		return errInvalidEntityID("incident")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	inc, err := s.db.GetIncident(ctx, orgID, id)
 	if err != nil || inc == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "incident not found")
+		return errNotFound("incident")
 	}
 
 	if err := s.db.DeleteIncident(ctx, orgID, id); err != nil {


### PR DESCRIPTION
## What this changes

Attaches a machine-readable code to the 12 "incident not found" and "invalid incident id" messages across the incident endpoints, so the browser can eventually show them in the reader's language.

## What a user could notice

Nothing. Every message reads exactly as it did before, and every one keeps the HTTP status it had — checked by comparing the statuses removed against the ones each site now uses.

## Deliberately not converted

Seven sites: internal faults passed through verbatim, the conflict raised when two people edit the same incident at once (which surfaces the underlying message), and the guard that blocks closing an incident while corrective actions are still open — that one names both an action and a count, so it needs its own sentence rather than a shared template.

## Scope note

As on the earlier conversions: no screen renders these codes yet, so a user still sees English everywhere. Wiring the places the web app displays an error is separate, sequenced work — the reasoning is on #248.

## Risk

Low. One Go file, no schema change, no locale file touched, no API contract broken.

## Verification

gofmt clean, `go vet ./...`, full `go test ./internal/isms/api/...` green. The guard that catches an entity name with no translation was confirmed to fire on this file by deliberately misspelling one.