### PR TITLE
feat(i18n): make auth middleware error messages translatable (#212)

### DIFF
--- a/internal/isms/api/middleware.go
+++ b/internal/isms/api/middleware.go
@@ -107,11 +107,11 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 								// Enforce org scope: if the token is scoped to a specific org,
 								// reject requests targeting a different org.
 								if tok.OrganizationID != nil && *tok.OrganizationID != resolvedOrgID {
-									return echo.NewHTTPError(http.StatusForbidden, "API key is not authorized for this organization")
+									return apiError(http.StatusForbidden, CodeAPIKeyWrongOrg)
 								}
 								role, err := cfg.DB.GetUserRole(c.Request().Context(), resolvedOrgID, tok.UserID)
 								if err != nil {
-									return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+									return apiError(http.StatusForbidden, CodeNotOrgMember)
 								}
 								c.Set("user_role", role)
 							} else if orgUUID := c.Request().Header.Get("X-Organization-UUID"); orgUUID != "" {
@@ -120,7 +120,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 									// Enforce org scope: if the token is scoped to a specific org,
 									// reject requests targeting a different org.
 									if tok.OrganizationID != nil && *tok.OrganizationID != org.ID {
-										return echo.NewHTTPError(http.StatusForbidden, "API key is not authorized for this organization")
+										return apiError(http.StatusForbidden, CodeAPIKeyWrongOrg)
 									}
 									if role, err := cfg.DB.GetUserRole(c.Request().Context(), org.ID, tok.UserID); err == nil {
 										c.Set("org_id", org.ID)
@@ -143,7 +143,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 								if cfg.DB.IsUserAgent(c.Request().Context(), tok.UserEmail) {
 									aiEnabled, _ := cfg.DB.GetOrgSetting(c.Request().Context(), resolvedOrgID, "ai_enabled")
 									if aiEnabled == "false" {
-										return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+										return apiError(http.StatusForbidden, CodeAIDisabled)
 									}
 								}
 							}
@@ -193,7 +193,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 								if jwtUser.IsAgent {
 									aiEnabled, _ := cfg.DB.GetOrgSetting(c.Request().Context(), claims.OrganizationID, "ai_enabled")
 									if aiEnabled == "false" {
-										return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+										return apiError(http.StatusForbidden, CodeAIDisabled)
 									}
 								}
 							}
@@ -205,7 +205,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 					}
 				}
 
-				return echo.NewHTTPError(http.StatusUnauthorized, "invalid token")
+				return apiError(http.StatusUnauthorized, CodeInvalidToken)
 			}
 
 			// For git paths: challenge with WWW-Authenticate so git client sends credentials
@@ -217,12 +217,12 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			// 2. Cloudflare Zero Trust JWT
 			email := c.Request().Header.Get("Cf-Access-Authenticated-User-Email")
 			if email == "" {
-				return echo.NewHTTPError(http.StatusUnauthorized, "API key required. Use: isms server api-key create")
+				return apiError(http.StatusUnauthorized, CodeAPIKeyRequired)
 			}
 
 			// CF headers are only trusted when Cloudflare is configured
 			if keyCache == nil {
-				return echo.NewHTTPError(http.StatusUnauthorized, "API key required. Use: isms server api-key create")
+				return apiError(http.StatusUnauthorized, CodeAPIKeyRequired)
 			}
 
 			cfName := ""
@@ -236,7 +236,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 					return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("invalid token: %v", err))
 				}
 				if claims.Email != "" && !strings.EqualFold(claims.Email, email) {
-					return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
+					return apiError(http.StatusUnauthorized, CodeTokenEmailMismatch)
 				}
 				cfName = claims.Name
 			}
@@ -249,7 +249,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				if errors.Is(err, errProvisionFailed) {
 					return echo.NewHTTPError(http.StatusInternalServerError, "auto-provision failed")
 				}
-				return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+				return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 			}
 			if created {
 				log.Printf("[cf-access] auto-provisioned user %s", email)
@@ -260,7 +260,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if resolvedOrgID, ok := c.Get("org_id").(int); ok && resolvedOrgID > 0 {
 				member, err := cfg.DB.GetOrgMember(ctx, resolvedOrgID, user.ID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+					return apiError(http.StatusForbidden, CodeNotOrgMember)
 				}
 				c.Set("org_id", resolvedOrgID)
 				c.Set("user_role", member.Role)
@@ -269,7 +269,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				if user.IsAgent {
 					aiEnabled, _ := cfg.DB.GetOrgSetting(ctx, resolvedOrgID, "ai_enabled")
 					if aiEnabled == "false" {
-						return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+						return apiError(http.StatusForbidden, CodeAIDisabled)
 					}
 				}
 
@@ -282,7 +282,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				var err error
 				org, err = cfg.DB.GetOrganizationByUUID(ctx, orgUUID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+					return errNotFound("organization")
 				}
 			}
 
@@ -290,7 +290,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if org != nil {
 				member, err := cfg.DB.GetOrgMember(ctx, org.ID, user.ID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+					return apiError(http.StatusForbidden, CodeNotOrgMember)
 				}
 				c.Set("org_id", org.ID)
 				c.Set("user_role", member.Role)
@@ -306,7 +306,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 				}
 				member, err := cfg.DB.GetOrgMember(ctx, orgs[0].ID, user.ID)
 				if err != nil {
-					return echo.NewHTTPError(http.StatusForbidden, "not a member of this organization")
+					return apiError(http.StatusForbidden, CodeNotOrgMember)
 				}
 				c.Set("org_id", orgs[0].ID)
 				c.Set("user_role", member.Role)
@@ -317,7 +317,7 @@ func AuthMiddleware(cfg AuthConfig) echo.MiddlewareFunc {
 			if resolvedOrgID > 0 && user.IsAgent {
 				aiEnabled, _ := cfg.DB.GetOrgSetting(ctx, resolvedOrgID, "ai_enabled")
 				if aiEnabled == "false" {
-					return echo.NewHTTPError(http.StatusForbidden, "AI features are disabled for this organization")
+					return apiError(http.StatusForbidden, CodeAIDisabled)
 				}
 			}
 


### PR DESCRIPTION
## What this changes

Attaches a machine-readable code to 16 error messages in the authentication and authorization middleware — the checks every single request passes through — so the browser can eventually show them in the reader's language.

## What a user could notice

Nothing. Every message reads exactly as it did before, word for word.

Because this file sits in front of the whole API, the HTTP status each message answers with was verified rather than assumed: ten forbidden and five unauthorized responses carry their status explicitly, and the one not-found case takes it from the shared helper. "user not found" stays an unauthorized response here, consistent with the sign-in and passkey flows.

## Deliberately not converted

Eleven single-site sentences with no shared entry yet — "invalid API key", "token revoked", "read-only access", "insufficient permissions" and similar — plus the database constraint messages, which quote the driver.

One judgment call worth naming: "authentication required" was left alone rather than folded into the existing "not authenticated". They look interchangeable but say different things — one states a requirement, the other states a condition — and merging two sentences into one is a wording decision, not a mechanical substitution.

## Scope note

As on the earlier conversions: no screen renders these codes yet, so a user still sees English everywhere. Wiring the places the web app displays an error is separate, sequenced work — the reasoning is on #248.

## Risk

Low, but this is the most-traversed file converted so far, so the full test suite was run rather than just this package's. One Go file, no schema change, no locale file touched, no API contract broken.

## Verification

gofmt clean, `go vet ./...`, full `go test ./...` across the repository green. The guard that catches an entity name with no translation was confirmed to fire on this file by deliberately misspelling one.