### PR TITLE
feat(i18n): make corrective action error messages translatable (#212)

### DIFF
--- a/internal/isms/api/api_corrective.go
+++ b/internal/isms/api/api_corrective.go
@@ -173,13 +173,13 @@ func (s *Server) handleGetCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 	ca, err := s.db.GetCorrectiveAction(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 	return c.JSON(http.StatusOK, ca)
 }
@@ -191,15 +191,15 @@ func (s *Server) handleUpdateCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 
 	ctx := c.Request().Context()
 	existing, err := s.db.GetCorrectiveAction(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 	prevStatus := existing.Status
 
@@ -308,9 +308,9 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 
 	var req struct {
@@ -330,7 +330,7 @@ func (s *Server) handleUpdateCorrectiveActionStatus(c echo.Context) error {
 	if req.Status == "resolved" {
 		existing, err := s.db.GetCorrectiveAction(ctx, orgID, id)
 		if err != nil || existing == nil {
-			return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+			return errNotFound("corrective_action")
 		}
 		// An empty identifier is corrupt data — the open-task query can't
 		// match anything, so skipping would silently disable enforcement.
@@ -377,9 +377,9 @@ func (s *Server) handleDeleteCorrectiveAction(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveCorrectiveActionID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid corrective action id")
+		return errInvalidEntityID("corrective_action")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "corrective action not found")
+		return errNotFound("corrective_action")
 	}
 
 	ctx := c.Request().Context()


### PR DESCRIPTION
## What this changes

Attaches a machine-readable code to the 11 "corrective action not found" and "invalid corrective action id" messages, so the browser can eventually show them in the reader's language.

## What a user could notice

Nothing. Every message reads exactly as it did before, and each keeps the HTTP status it had.

## Deliberately not converted

Eight sites: internal faults passed through verbatim, the conflict raised when two people edit the same corrective action at once, and the guard that blocks resolving one while implementation tasks are still open — that one names both a record and a count, so it needs its own sentence rather than a shared template.

## Scope note

As on the earlier conversions: no screen renders these codes yet, so a user still sees English everywhere. Wiring the places the web app displays an error is separate, sequenced work — the reasoning is on #248.

## Risk

Low. One Go file, no schema change, no locale file touched, no API contract broken.

## Verification

gofmt clean, `go vet ./...`, full `go test ./internal/isms/api/...` green. The guard that catches an entity name with no translation was confirmed to fire on this file by deliberately misspelling one.