### PR TITLE
feat(i18n): make approval policy error messages translatable (#212)

### DIFF
--- a/internal/isms/api/api_policies.go
+++ b/internal/isms/api/api_policies.go
@@ -37,10 +37,10 @@ func (s *Server) handleAdminCreatePolicy(c echo.Context) error {
 	p.ID = 0
 	p.OrganizationID = orgID
 	if p.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return errRequired("name")
 	}
 	if p.PathPattern == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "path_pattern is required")
+		return errRequired("path_pattern")
 	}
 	p.Active = true // new policies are always active
 	if p.MinApprovals < 1 {
@@ -73,12 +73,12 @@ func (s *Server) handleAdminUpdatePolicy(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid policy id")
+		return errInvalidEntityID("policy")
 	}
 
 	existing, err := s.db.GetApprovalPolicy(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "policy not found")
+		return errNotFound("policy")
 	}
 
 	// Start from existing policy to preserve bool fields not sent in request
@@ -91,10 +91,10 @@ func (s *Server) handleAdminUpdatePolicy(c echo.Context) error {
 	p.ID = existing.ID
 	p.OrganizationID = orgID
 	if p.Name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		return errRequired("name")
 	}
 	if p.PathPattern == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "path_pattern is required")
+		return errRequired("path_pattern")
 	}
 	if p.MinApprovals < 1 {
 		p.MinApprovals = 1
@@ -126,12 +126,12 @@ func (s *Server) handleAdminDeletePolicy(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid policy id")
+		return errInvalidEntityID("policy")
 	}
 
 	existing, err := s.db.GetApprovalPolicy(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "policy not found")
+		return errNotFound("policy")
 	}
 
 	if err := s.db.DeleteApprovalPolicy(ctx, orgID, id); err != nil {
@@ -168,12 +168,12 @@ func (s *Server) handleReviewPolicyStatus(c echo.Context) error {
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid review id")
+		return errInvalidEntityID("review")
 	}
 
 	review, err := s.db.GetReview(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "review not found")
+		return errNotFound("review")
 	}
 
 	// Get the document path for policy matching

--- a/internal/isms/api/errors_test.go
+++ b/internal/isms/api/errors_test.go
@@ -230,8 +230,9 @@ func TestApiErrorRendering(t *testing.T) {
 		},
 		{
 			// field is humanised the same way entity is, so a snake_case JSON
-			// field name reads as prose in the CLI: today's literal at this
-			// call site says "path_pattern is required".
+			// field name reads as prose in the CLI. The two policy call sites
+			// used to spell the identifier ("path_pattern is required"); since
+			// they were converted they read "path pattern is required".
 			name:   "required wrapper humanises the field name",
 			err:    errRequired("path_pattern"),
 			msg:    "path pattern is required",


### PR DESCRIPTION
## What this changes

Attaches a machine-readable code to all 10 user-facing error messages in the approval policy endpoints, so the browser can eventually show them in the reader's language. This module is fully converted — only internal server faults remain untouched.

## What a user could notice

Two messages change wording: "path_pattern is required" now reads "path pattern is required". The old text quoted the field's internal name; the new text is the name the message was always meant to say out loud, and it is the same phrasing used everywhere else a required field is reported.

The other eight messages read exactly as before, and every message keeps the HTTP status it had.

## A stale comment, corrected

A comment in the error-handling tests used these two call sites as its example of a message that still quotes an internal field name. That stopped being true with this change, so the comment is updated in the same commit rather than left to mislead the next reader.

## Scope note

As on the earlier conversions: no screen renders these codes yet, so a user still sees English everywhere. Wiring the places the web app displays an error is separate, sequenced work — the reasoning is on #248.

## Risk

Low. One Go file plus a test comment, no schema change, no locale file touched, no API contract broken.

## Verification

gofmt clean, `go vet ./...`, full `go test ./internal/isms/api/...` green. Grepped the repository for anything asserting the old "path_pattern" wording before changing it. The guard that catches an entity name with no translation was confirmed to fire on this file by deliberately misspelling one.