### PR TITLE
feat(i18n): make the remaining module error messages translatable (#212)

### DIFF
--- a/internal/isms/api/api_asset_reviews.go
+++ b/internal/isms/api/api_asset_reviews.go
@@ -28,13 +28,13 @@ func (s *Server) handleCreateAssetReview(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 
 	// Verify asset exists in this org (cross-org safety).
 	asset, err := s.db.GetAsset(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "asset not found")
+		return errNotFound("asset")
 	}
 
 	var req assetReviewCreateRequest
@@ -71,7 +71,7 @@ func (s *Server) handleListAssetReviews(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 
 	reviews, err := s.db.ListAssetReviews(c.Request().Context(), orgID, id)

--- a/internal/isms/api/api_cf.go
+++ b/internal/isms/api/api_cf.go
@@ -88,7 +88,7 @@ func (s *Server) handleCFSession(c echo.Context) error {
 	email := claims.Email
 	if hdr := c.Request().Header.Get("Cf-Access-Authenticated-User-Email"); hdr != "" {
 		if email != "" && !strings.EqualFold(email, hdr) {
-			return echo.NewHTTPError(http.StatusUnauthorized, "token email mismatch")
+			return apiError(http.StatusUnauthorized, CodeTokenEmailMismatch)
 		}
 		if email == "" {
 			email = hdr
@@ -105,7 +105,7 @@ func (s *Server) handleCFSession(c echo.Context) error {
 			log.Printf("[cf-access] auto-provision failed for %s: %v", email, err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "auto-provision failed")
 		}
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	if created {
 		log.Printf("[cf-access] auto-provisioned user %s", email)
@@ -118,7 +118,7 @@ func (s *Server) handleCFSession(c echo.Context) error {
 	if slug, ok := c.Get("org_slug").(string); ok && slug != "" {
 		org, oerr := s.db.GetOrganizationBySlug(ctx, slug)
 		if oerr != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "organization not found")
+			return apiError(http.StatusBadRequest, CodeNotFound, Entity("organization"))
 		}
 		if _, merr := s.db.GetOrgMember(ctx, org.ID, user.ID); merr != nil {
 			// JIT-provisioned but not yet a member — an admin must add them.

--- a/internal/isms/api/api_diff.go
+++ b/internal/isms/api/api_diff.go
@@ -70,7 +70,7 @@ func (s *Server) handleDocumentDiff(c echo.Context) error {
 	// Get file path.
 	filePath := resolveDocPathFromStore(st, docID)
 	if filePath == "" {
-		return echo.NewHTTPError(http.StatusNotFound, "document not found")
+		return errNotFound("document")
 	}
 
 	// Compute diff using go-git.

--- a/internal/isms/api/api_entity_comments.go
+++ b/internal/isms/api/api_entity_comments.go
@@ -52,7 +52,7 @@ func (s *Server) handleCreateEntityComment(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "entity_type and entity_id are required")
 	}
 	if req.Body == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "body is required")
+		return errRequired("body")
 	}
 
 	comment := &db.EntityComment{
@@ -89,7 +89,7 @@ func (s *Server) handleResolveEntityComment(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 	if err := s.db.ResolveEntityComment(c.Request().Context(), orgID, id, getUserEmail(c)); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -104,7 +104,7 @@ func (s *Server) handleDeleteEntityComment(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 	if err := s.db.DeleteEntityComment(c.Request().Context(), orgID, id); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/internal/isms/api/api_legal.go
+++ b/internal/isms/api/api_legal.go
@@ -160,13 +160,13 @@ func (s *Server) handleGetLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+		return errInvalidEntityID("legal_requirement")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 	lr, err := s.db.GetLegalRequirement(c.Request().Context(), orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 	return c.JSON(http.StatusOK, lr)
 }
@@ -178,15 +178,15 @@ func (s *Server) handleUpdateLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+		return errInvalidEntityID("legal_requirement")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 
 	ctx := c.Request().Context()
 	existing, err := s.db.GetLegalRequirement(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 
 	var req legalUpdateRequest
@@ -308,9 +308,9 @@ func (s *Server) handleDeleteLegal(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := s.resolveLegalID(c.Request().Context(), orgID, c.Param("id"))
 	if errors.Is(err, errInvalidID) {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal requirement id")
+		return errInvalidEntityID("legal_requirement")
 	} else if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "legal requirement not found")
+		return errNotFound("legal_requirement")
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_oidc.go
+++ b/internal/isms/api/api_oidc.go
@@ -27,7 +27,7 @@ func (s *Server) handleOIDCProviders(c echo.Context) error {
 	ctx := c.Request().Context()
 	org, err := s.db.GetOrganizationBySlug(ctx, slug)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	providers, err := s.db.ListEnabledOIDCProviders(ctx, org.ID)
@@ -54,12 +54,12 @@ func (s *Server) handleOIDCAuthorize(c echo.Context) error {
 	ctx := c.Request().Context()
 	org, err := s.db.GetOrganizationBySlug(ctx, slug)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	provider, err := s.db.GetOIDCProvider(ctx, org.ID, providerName)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "OIDC provider not found")
+		return errNotFound("oidc_provider")
 	}
 	if !provider.Enabled {
 		return echo.NewHTTPError(http.StatusBadRequest, "OIDC provider is disabled")

--- a/internal/isms/api/api_readings.go
+++ b/internal/isms/api/api_readings.go
@@ -20,7 +20,7 @@ func (s *Server) handleListRiskReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	riskID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "risk", riskID)
 	if err != nil {
@@ -40,7 +40,7 @@ func (s *Server) handleCreateRiskReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	riskID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid risk id")
+		return errInvalidEntityID("risk")
 	}
 
 	var req struct {
@@ -164,7 +164,7 @@ func (s *Server) handleListAssetReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	assetID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "asset", assetID)
 	if err != nil {
@@ -184,7 +184,7 @@ func (s *Server) handleCreateAssetReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	assetID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid asset id")
+		return errInvalidEntityID("asset")
 	}
 
 	var req struct {
@@ -287,7 +287,7 @@ func (s *Server) handleListLegalReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	legalID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal id")
+		return errInvalidEntityID("legal_requirement")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "legal_requirement", legalID)
 	if err != nil {
@@ -307,7 +307,7 @@ func (s *Server) handleCreateLegalReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	legalID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid legal id")
+		return errInvalidEntityID("legal_requirement")
 	}
 
 	var req struct {
@@ -391,7 +391,7 @@ func (s *Server) handleListSupplierReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	supplierID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "supplier", supplierID)
 	if err != nil {
@@ -411,7 +411,7 @@ func (s *Server) handleCreateSupplierReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	supplierID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 
 	var req struct {
@@ -491,7 +491,7 @@ func (s *Server) handleListSystemReadings(c echo.Context) error {
 	ctx := c.Request().Context()
 	systemID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "system", systemID)
 	if err != nil {
@@ -511,7 +511,7 @@ func (s *Server) handleCreateSystemReading(c echo.Context) error {
 	ctx := c.Request().Context()
 	systemID, err := parseID(c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid system id")
+		return errInvalidEntityID("system")
 	}
 
 	var req struct {

--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -94,7 +94,7 @@ func (s *Server) handleCreateReference(c echo.Context) error {
 		TargetID   string `json:"target_id"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.SourceType == "" || req.SourceID == "" || req.TargetType == "" || req.TargetID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "source_type, source_id, target_type, target_id required")
@@ -140,7 +140,7 @@ func (s *Server) handleDeleteReference(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+		return apiError(http.StatusBadRequest, CodeInvalidID)
 	}
 
 	ctx := c.Request().Context()

--- a/internal/isms/api/api_supplier_reviews.go
+++ b/internal/isms/api/api_supplier_reviews.go
@@ -29,13 +29,13 @@ func (s *Server) handleCreateSupplierReview(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 
 	// Verify supplier exists in this org (cross-org safety).
 	sup, err := s.db.GetSupplier(ctx, orgID, id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "supplier not found")
+		return errNotFound("supplier")
 	}
 
 	var req supplierReviewCreateRequest
@@ -73,7 +73,7 @@ func (s *Server) handleListSupplierReviews(c echo.Context) error {
 	orgID := getOrgID(c)
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid supplier id")
+		return errInvalidEntityID("supplier")
 	}
 
 	reviews, err := s.db.ListSupplierReviews(c.Request().Context(), orgID, id)

--- a/internal/isms/api/api_users.go
+++ b/internal/isms/api/api_users.go
@@ -38,7 +38,7 @@ func (s *Server) handleMe(c echo.Context) error {
 	// Find existing user — never auto-create
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	// Update last_seen
 	s.db.TouchUser(ctx, email, user.Name)
@@ -152,7 +152,7 @@ func (s *Server) handleUpsertUser(c echo.Context) error {
 	}
 	validRoles := map[string]bool{"admin": true, "manager": true, "contributor": true, "reader": true}
 	if !validRoles[req.Role] {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid role")
+		return apiError(http.StatusBadRequest, CodeInvalidRole)
 	}
 
 	// Only admin can assign admin or manager roles
@@ -189,7 +189,7 @@ func (s *Server) handleMyOrganizations(c echo.Context) error {
 	email := getUserEmail(c)
 	user, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	orgs, err := s.db.ListUserOrgs(ctx, user.ID)
 	if err != nil {
@@ -219,7 +219,7 @@ func (s *Server) handleCreateOrganization(c echo.Context) error {
 		Template string `json:"template"` // optional: iso27001, soc2, nis2
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if req.Name == "" || req.Slug == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "name and slug are required")
@@ -233,7 +233,7 @@ func (s *Server) handleCreateOrganization(c echo.Context) error {
 	email := getUserEmail(c)
 	existingUser, err := s.db.GetUserByEmail(ctx, email)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "user not found")
+		return apiError(http.StatusUnauthorized, CodeNotFound, Entity("user"))
 	}
 	existingOrgs, err := s.db.ListUserOrgs(ctx, existingUser.ID)
 	if err != nil {
@@ -373,7 +373,7 @@ func (s *Server) handleAddTemplate(c echo.Context) error {
 		Template string `json:"template"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+		return apiError(http.StatusBadRequest, CodeInvalidRequest)
 	}
 	if !scaffold.IsValidTemplate(req.Template) {
 		available, _ := scaffold.ListTemplates()
@@ -398,7 +398,7 @@ func (s *Server) handleAddTemplate(c echo.Context) error {
 	}
 
 	if _, err := s.db.GetOrganization(ctx, orgID); err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	if err := scaffold.ScaffoldToRepo(st, req.Template, authorName, email); err != nil {
@@ -439,7 +439,7 @@ func (s *Server) handleRemoveTemplate(c echo.Context) error {
 
 	org, err := s.db.GetOrganization(ctx, orgID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "organization not found")
+		return errNotFound("organization")
 	}
 
 	st, err := s.storeForOrg(ctx, orgID)


### PR DESCRIPTION
## What this changes

Attaches a machine-readable code to 44 error messages across the last ten API modules — risk and asset reviews, legal requirements, users and organizations, single sign-on, entity comments, references and document diffs — so the browser can eventually show them in the reader's language.

This is the last batch. With it, every error message the catalogue covers is converted.

## Why these ten are one pull request

Each file contributes between one and ten near-identical substitutions. Sent separately that would be ten reviews of the same change, several of them a two-line diff. The earlier modules were split because each was large enough to hide a mistake in; these are not.

## What a user could notice

One message changes: "invalid legal id" becomes "invalid legal requirement id". The old text was truncated — "legal" on its own is not the name of anything in the app. The other 43 read exactly as before.

Every message keeps the HTTP status it had. That was checked by arithmetic rather than by eye: the 26 bad-request responses are accounted for as 8 written out plus 18 coming from shared helpers, the 13 not-found responses all come from the not-found helper, and the 5 unauthorized ones stay written out because "user not found" deliberately answers unauthorized in sign-in flows.

## Deliberately not converted

The git endpoints entirely — they are consumed by `git push`, never by a browser, so a translation there could never be read. The single sign-on and Cloudflare Access configuration messages, which tell whoever runs the server that a setting is missing. "too many attempts from this address", which says something more specific than the shared version and is not folded into it on resemblance alone. The review-notes prompt, which explains what to write rather than just naming a missing field. And the usual internal faults.

## Scope note

As on the earlier conversions: no screen renders these codes yet, so a user still sees English everywhere. Wiring the places the web app displays an error is separate, sequenced work — the reasoning is on #248.

## Risk

Low. Ten Go files, no schema change, no locale file touched, no API contract broken.

## Verification

gofmt clean, `go vet ./...`, full `go test ./...` across the repository green. Grepped for anything asserting the old "invalid legal id" wording before changing it, including comments. The guard that catches an entity name with no translation was confirmed to fire by deliberately misspelling one.