### PR TITLE
fix(i18n): make the server's English match the catalogue for checkin (#212)

### DIFF
--- a/internal/isms/api/errors.go
+++ b/internal/isms/api/errors.go
@@ -350,6 +350,7 @@ func humanizeParam(p ErrorParam) string {
 // locale file agree, which TestOverridesMatchTheEnglishCatalogue checks rather
 // than assumes.
 var paramMessageOverrides = map[string]string{
+	"checkin":       "check-in",
 	"oidc_provider": "OIDC provider",
 	"api_key":       "API key",
 	"document_id":   "document ID",

--- a/internal/isms/api/errors_test.go
+++ b/internal/isms/api/errors_test.go
@@ -401,6 +401,36 @@ func TestEnglishCatalogueMatchesTheGoTemplates(t *testing.T) {
 // An override claims Go and the en locale agree on an identifier's English
 // prose. Checking it means the CLI and the browser cannot disagree the way
 // they would have for "oidc provider" / "OIDC provider".
+// TestCatalogueValuesMatchGoProse is TestOverridesMatchTheEnglishCatalogue run
+// the other way round. That one checks the exceptions: every declared override
+// equals what the catalogue says. This one checks the rule: every catalogue
+// value equals what Go would actually render, whether it gets there through an
+// override or through the underscore de-slug.
+//
+// The distinction is not academic. `checkin` has no underscore, so the de-slug
+// returned it unchanged while `common.entity_inline.checkin` said "check-in" —
+// one code, one language, two texts, which is the exact failure the
+// oidc_provider override exists to prevent. Nothing caught it, because a test
+// that pins the declared exceptions is not a test that pins the rule.
+//
+// It walks the catalogue rather than the call sites on purpose. The AST scan
+// sees only what Go emits today, so a checkin-shaped key that no call site uses
+// yet would stay invisible until some later conversion reached it — the same
+// reasoning that made the common.field.* mirror wholesale rather than
+// call-site-driven.
+func TestCatalogueValuesMatchGoProse(t *testing.T) {
+	for _, group := range []string{"entity_inline", "field"} {
+		for value, catalogued := range commonGroup(t, "en", group) {
+			got := humanizeParam(ErrorParam{Key: ParamEntity, Value: value})
+			if got != catalogued {
+				t.Errorf("common.%s.%s: the en catalogue says %q but Go renders %q — "+
+					"add a paramMessageOverrides entry so the wire message and the browser agree",
+					group, value, catalogued, got)
+			}
+		}
+	}
+}
+
 func TestOverridesMatchTheEnglishCatalogue(t *testing.T) {
 	entities := commonGroup(t, "en", "entity_inline")
 	fields := commonGroup(t, "en", "field")


### PR DESCRIPTION
## What this fixes

Raised by review on #253.

The app's shared vocabulary spells it "check-in". The server, generating its own English from the same identifier, only knows how to turn underscores into spaces — and "checkin" has no underscore, so it rendered "checkin not found" while the browser would render "check-in not found". The same message, in the same language, in two different spellings depending on which side produced it.

There is already a small list of identifiers whose English the server cannot work out on its own ("OIDC provider", "API key"). This adds "check-in" to it. A sweep of the whole vocabulary confirms it was the only one out of step.

## The more useful half

The existing check verified that every *declared* exception matches the vocabulary. Nothing verified the opposite direction — that an identifier with no exception declared still produces the right English on its own. That is precisely why this slipped through, and it is the second time in this project a review has found a hole in a check rather than in the feature.

So this adds the reverse check: every word in the shared vocabulary must equal what the server would actually print. It walks the vocabulary rather than the places the code uses it, so a word that no code path has reached yet is still held to the rule — otherwise the next person to use one inherits the same bug.

I ran the new check before adding the fix and confirmed it fails, naming "check-in" and nothing else.

## Correction to #253

That pull request's description said four messages change wording to "check-in". That was wrong: without this fix they did not change at all, because the server never produced the hyphenated form. With this merged, the claim becomes true. I have corrected #253's description.

## Risk

Low. One entry in a lookup table and one new test. No behaviour change beyond the four messages now spelling "check-in" as intended.

## Verification

gofmt clean, `go vet ./...`, full `go test ./...` across the repository green.