### PR TITLE
docs: replace local plan references with in-repo ones (#212)

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -181,8 +181,9 @@ While extracting a view, `npm run i18n:raw -- --list Risks.vue` lists what the
 scanner still sees in it, with line numbers. The scanner is regex over markup
 and deliberately over-reports, so the numbers are budgets rather than defect
 counts; for a false positive that has to reach zero, mark the line with an
-`i18n-ignore` comment. Plan 80 §6 has the reasoning, including why
-`eslint-plugin-vue-i18n` is the right answer only once extraction is done.
+`i18n-ignore` comment. The scanner's own header comment has the reasoning,
+including why `eslint-plugin-vue-i18n` is the right answer only once extraction
+is done.
 
 ## Out of scope
 

--- a/internal/isms/api/errors.go
+++ b/internal/isms/api/errors.go
@@ -14,7 +14,7 @@ import (
 
 // Stable error codes for HTTP responses, and the helper that emits them.
 //
-// The governing rule (plan 81 §1): the server never owns a translation
+// The governing rule: the server never owns a translation
 // catalogue for anything a client can render. An error response is read by a
 // browser that has the locale files loaded, so the server emits a stable
 // `code` plus a closed set of `params` and the browser renders the sentence
@@ -49,8 +49,8 @@ import (
 // # Migration
 //
 // apiError and echo.NewHTTPError coexist. Nothing is converted in one go;
-// call sites move per module (plan 81 task 1.5), and an unconverted site is
-// indistinguishable to old clients from a converted one.
+// call sites move one module at a time (issue #212), and an unconverted site
+// is indistinguishable to old clients from a converted one.
 
 // Codes. Declared as constants so the catalogue is greppable and a typo is a
 // compile error rather than a code the client has no message for.
@@ -123,7 +123,8 @@ const (
 //
 // Only codes appearing at two or more call sites are catalogued here. That
 // boundary is deliberate: a code invented for a single sentence nobody has
-// converted yet is a guess about wording that task 1.5 will revise. Converting
+// converted yet is a guess about wording that converting its module will
+// revise. Converting
 // a single-occurrence literal means adding its code and its `common.error.*`
 // key in the same commit, which the parity test enforces.
 var errorMessages = map[string]string{

--- a/internal/isms/api/errors_test.go
+++ b/internal/isms/api/errors_test.go
@@ -515,13 +515,13 @@ func TestPlaceholdersMatchInEveryLocale(t *testing.T) {
 
 // ---- param values resolve to catalogue keys -----------------------------
 
-// The seam most likely to leak English silently (plan 81 task 1.6): the client
+// The seam most likely to leak English silently: the client
 // translates an `entity` param through common.entity_inline.* and a `field`
 // through common.field.*, so a value with no key there is spliced in as the
 // raw snake_case identifier — inside an otherwise translated sentence.
 //
 // The values are literals at the call site, so they can be read off the
-// source. This passes vacuously until task 1.5 converts the first call site,
+// source. This passes vacuously until the first call site is converted,
 // which is the point: it starts working the moment there is anything to check.
 //
 // Parsed rather than grepped: a regex over the source also matches the

--- a/internal/isms/api/notification_keys.go
+++ b/internal/isms/api/notification_keys.go
@@ -7,7 +7,7 @@ package api
 // key set enumerable, which is what NotificationKeys and its test need to
 // exist at all.
 //
-// Why enumerable matters here (plan 82 step 7): useNotificationRender.js falls
+// Why enumerable matters here: useNotificationRender.js falls
 // back to the stored English title when the catalogue has no message for a
 // key. That fallback is what keeps legacy rows, agent rows and a lagging
 // locale safe, and it is also what makes a MISSING translation look exactly

--- a/internal/isms/api/notification_keys_test.go
+++ b/internal/isms/api/notification_keys_test.go
@@ -18,7 +18,8 @@ import (
 	"isms.sh/internal/isms/db"
 )
 
-// The guard for plan 82 step 7: the keys this package emits and the frames
+// The guard on the notification-key contract: the keys this package emits and
+// the frames
 // web/src/locales/en/notifications.json provides must be the same set, in both
 // directions, and every placeholder in those frames must be a param name the
 // backend is allowed to send.

--- a/internal/isms/db/notifications.go
+++ b/internal/isms/db/notifications.go
@@ -107,7 +107,7 @@ func notificationParamAllowed(name string) bool {
 // English-speaking reviewer — the frame simply renders with the placeholder
 // unfilled or the value untranslated, and only for a non-English user.
 //
-// Note the closed set here is NOT the one plan 81 §1 defines for API errors
+// Note the closed set here is NOT the one errors.go defines for API errors
 // (entity/field/status/count). Different surface, different set; they are easy
 // to conflate.
 func (c NotificationContent) Validate() error {
@@ -142,8 +142,8 @@ func (c NotificationContent) paramsJSON() (b []byte, ok bool) {
 // lost translation beats a lost inbox item; a broken translation beats neither.
 //
 // A param outside the closed set degrades the same way, for the same reason.
-// Plan 82 step 7 proposed failing the write on an unknown name, to make the
-// guard a runtime guarantee as well as a test-time one — but a failed write
+// Failing the write on an unknown name was considered, to make the guard a
+// runtime guarantee as well as a test-time one — but a failed write
 // here IS a lost inbox item, which the line above already decided against, and
 // a param that fails validation is by definition one no frame renders
 // correctly anyway. So the row goes in English-only.

--- a/internal/isms/db/notifications_test.go
+++ b/internal/isms/db/notifications_test.go
@@ -193,8 +193,8 @@ func TestNotificationContentValidate(t *testing.T) {
 	})
 
 	t.Run("an API-error param name is rejected", func(t *testing.T) {
-		// `field` belongs to plan 81 §1's closed set for API errors, not this
-		// one. The two sets are easy to conflate, so pin the boundary.
+		// `field` belongs to the API-error closed set in internal/isms/api/errors.go,
+		// not this one. The two are easy to conflate, so pin the boundary.
 		if err := (NotificationContent{Params: map[string]any{"field": "title"}}).Validate(); err == nil {
 			t.Error("`field` is the API-error set, not the notification set — want an error")
 		}

--- a/web/scripts/i18nRawText.mjs
+++ b/web/scripts/i18nRawText.mjs
@@ -1,7 +1,7 @@
-// Raw-text scanner — plan 80 §6 option B, the grep-based check.
+// Raw-text scanner — the grep-based check on unextracted UI strings.
 //
 // Finds user-visible English literals still hardcoded in `.vue` templates, so
-// that Phase 3 extraction cannot silently regress behind itself. Option A
+// that string extraction cannot silently regress behind itself. Option A
 // (`eslint-plugin-vue-i18n`'s `@intlify/no-raw-text`) is the durable answer and
 // is precise where this is crude, but the repo has no ESLint at all; introducing
 // it mid-extraction means fighting lint noise and translation churn at once.

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -68,7 +68,7 @@ async function fetchRaw(url) {
 // `body.message || body.error || status`, which is how `code` came to be
 // discarded six times over: the server has emitted a stable `code` and a param
 // map alongside the English `message` since the error-code work landed
-// (internal/isms/api/errors.go, plan 81 §1), and nothing here read them.
+// (internal/isms/api/errors.go), and nothing here read them.
 //
 // `message` stays the thrown Error's message, unchanged. That is deliberate
 // and load-bearing: ~191 call sites render `err.message` directly and none of

--- a/web/src/composables/useNotificationRender.js
+++ b/web/src/composables/useNotificationRender.js
@@ -2,7 +2,7 @@
 //
 // `notifications.title` / `body` are written pre-rendered in English and can
 // never be retranslated, so the backend also stores `title_key`, `body_key` and
-// a flat `params` object (plan 82 / PR #220). The stored English text stays the
+// a flat `params` object (PR #220). The stored English text stays the
 // fallback — for rows written before the keys existed, for agent-actionable
 // rows that are deliberately English, and for any key this bundle has no
 // message for.
@@ -19,7 +19,7 @@
 import { FALLBACK, i18n } from '../i18n.js'
 import { enumLabelInline, entityLabel } from './useEnumLabel.js'
 
-// The closed set of params carrying an enum value, per plan 82. Each name is
+// The closed set of params carrying an enum value. Each name is
 // also its `common.enum.*` group — that is why the groups were named after the
 // params in #229, so there is no second mapping to keep in sync.
 const ENUM_PARAMS = ['status', 'severity', 'action', 'suggestion_type']

--- a/web/src/i18n.js
+++ b/web/src/i18n.js
@@ -103,7 +103,7 @@ export function negotiate(tag, available = loadableLocales()) {
   return available.find((a) => a.toLowerCase().split('-')[0] === base) ?? null
 }
 
-// Precedence, highest first (plan 80 §5):
+// Precedence, highest first:
 //   1. the user's explicit choice, from the DB (survives a device change)
 //   2. localStorage, for pre-login and anonymous pages
 //   3. navigator.languages, in the browser's own order of preference

--- a/web/test/apiError.test.js
+++ b/web/test/apiError.test.js
@@ -1,4 +1,4 @@
-// Task 1.3 of plan 81 §1: the server's stable `code` becomes translated text.
+// The server's stable `code` becomes translated text.
 //
 // The contract runs across two languages — Go composes the code and params,
 // the locale files carry the sentence — and every mismatch is silent, because

--- a/web/test/confirm.test.js
+++ b/web/test/confirm.test.js
@@ -1,4 +1,4 @@
-// Plan 80 task 1.7: the confirm dialog's two buttons come from the catalogue.
+// The confirm dialog's two buttons come from the catalogue.
 //
 // Small surface, but the failure is invisible in English: the defaults were the
 // literals 'Confirm'/'Cancel', which render correctly for the one locale that

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -24,7 +24,7 @@ const STATUS = [
   'terminated', 'decommissioned', 'archived',
 ]
 
-// The translatable notification params (plan 82's closed set) and the groups the
+// The translatable notification params (the closed set) and the groups the
 // four non-status StatusBadge call sites name explicitly.
 const GROUPS = {
   status: STATUS,

--- a/web/test/errorRender.test.js
+++ b/web/test/errorRender.test.js
@@ -1,4 +1,4 @@
-// The render-site ratchet — plan 81 task 1.7.
+// The render-site ratchet.
 //
 // The server now sends a stable `code` on its errors and `renderApiError`
 // translates it, but a component that assigns a caught error's `.message`

--- a/web/test/notificationRender.test.js
+++ b/web/test/notificationRender.test.js
@@ -1,4 +1,4 @@
-// Step 6 of plan 82: the stored key+params become translated text.
+// The stored key+params become translated text.
 //
 // The contract these pin is split across two repos' worth of code — Go writes
 // the wire keys, the locale files carry the frames — and a mismatch is silent:
@@ -92,7 +92,8 @@ test('the same keys all render in id-ID', () => {
   }
 })
 
-// The half-translated trap plan 82 was written to avoid: an enum param spliced
+// The half-translated trap the notification keying was built to avoid: an enum
+// param spliced
 // in raw yields "Insiden resolved: …".
 test('enum params are translated before interpolation, not spliced raw', () => {
   const row = { title_key: 'notifications.incident_status', title: STORED, params: ROWS['notifications.incident_status'] }

--- a/web/test/rawText.test.js
+++ b/web/test/rawText.test.js
@@ -1,9 +1,9 @@
-// The raw-text ratchet — plan 80 §6 option B, and task 1.9's outstanding half.
+// The raw-text ratchet — the CI half of the grep-based raw-text check.
 //
-// Phase 3 extraction is ~21 PRs by one maintainer over weeks. The keyset test
-// already stops a translation from diverging from `en`; nothing stopped a new
-// PR from reintroducing a hardcoded literal into a view that had already been
-// converted, which is the regression this exists to catch.
+// String extraction runs as many PRs by one maintainer over weeks. The keyset
+// test already stops a translation from diverging from `en`; nothing stopped a
+// new PR from reintroducing a hardcoded literal into a view that had already
+// been converted, which is the regression this exists to catch.
 //
 // It is a ratchet, not a gate: each file carries a committed budget in
 // rawText.baseline.json, and the budget may only go down. That is what lets the


### PR DESCRIPTION
## What this changes

Comments and test headers across the i18n work referred to a planning scheme that only exists on my machine — things like "plan 81 §1", "task 1.5", "plan 82 step 7". There were 21 of these across 15 files, mostly in the header comment at the top of a file or in a test's description, which is exactly where someone new to the code starts reading.

For anyone other than me, each one is a dead end at the moment they most want the background.

## Why it's nearly all deletion

The interesting part: most of these needed no replacement. The sentence containing the reference already said the thing — the citation was decoration.

```diff
-// The governing rule (plan 81 §1): the server never owns a translation
+// The governing rule: the server never owns a translation
```

Where the pointer really was carrying information, it now names something a reader can actually open: a file in the repository, or the tracking issue for work still in progress.

## Two stale statements went out with it

Not the goal, but worth knowing, since both would have misled a reader on their own:

- The raw-text check described the remaining extraction as "~21 PRs" — that was the estimate from before the work was regrouped into six.
- The same file referred to the "outstanding half" of a check that has since been finished.

## Risk

As low as it goes. Comments, test descriptions, and one paragraph of prose in `docs/i18n.md`. No executable line changes, so no behaviour can shift. The whole diff is 36 insertions and 32 deletions.

## Scope notes

Two files with the same problem, `internal/isms/i18n/locale.go` and its release-gate test, are fixed on a different branch — the one that already touches that package — so the two changes don't collide. Once both land the tree is clean.

Left alone on purpose: `docs/suggestions.md`'s "Phase 1/Phase 2" headings are that document's own section names and resolve fine, and the `.claude/settings.json` mentions in `README.md` and `docs/ai-first.md` are real user-facing configuration for a real tool.

## Verification

- `go build ./...`
- `go test ./internal/isms/api/ ./internal/isms/db/ ./internal/isms/i18n/`
- `npm test` — 148 pass
- `npm run build`
- `gofmt` clean; added lines wrapped to 80 columns
- A grep for the old patterns now returns only the two lines handled on the other branch

Relates to #212.