### PR TITLE
feat(i18n): extract the application shell, landing page and organizations view (#212)

### DIFF
--- a/internal/isms/i18n/locale.go
+++ b/internal/isms/i18n/locale.go
@@ -58,10 +58,12 @@ type entry struct {
 // path.
 //
 // Why id-ID is disabled: the bundle is complete and validated in CI
-// (web/test/localeKeyset.test.js), but only ~5% of the UI is extracted, so
-// selecting it yields a near-entirely English app that claims to be Indonesian.
-// Enabling it is flipping this one flag once Phase 3 extraction lands — see
-// .claude/plans/79-issue-212-i18n-foundation.md.
+// (web/test/localeKeyset.test.js), but most of the UI still holds hardcoded
+// English, so selecting it yields a near-entirely English app that claims to be
+// Indonesian. Enabling it is flipping this one flag once string extraction has
+// progressed far enough; TestSecondLocaleRequiresExtraction asserts that
+// threshold against the web raw-text baseline, so it fails if the flag is
+// flipped too early. Tracking issue: #212.
 //
 // Indonesian is tagged id-ID rather than the barer id. Both are valid and the
 // canonicalization below treats them interchangeably (a browser sending either

--- a/internal/isms/i18n/release_gate_test.go
+++ b/internal/isms/i18n/release_gate_test.go
@@ -80,7 +80,8 @@ func TestSecondLocaleRequiresExtraction(t *testing.T) {
 			"%d locales are enabled (%v) but the UI is not extracted: the raw-text baseline "+
 				"totals %d across %d files, over the %d threshold.\n\n"+
 				"Offering a language the app cannot actually speak is worse than offering none. "+
-				"Finish extraction (plan 79 Phase 3) so the ratchet falls, then enable the locale.\n"+
+				"Finish extracting the remaining views (issue #212) so the ratchet falls, then "+
+				"enable the locale.\n"+
 				"If the threshold is what is wrong, change extractionGateThreshold and say why in "+
 				"the commit message.",
 			len(enabled), enabled, total, len(budgets), extractionGateThreshold,

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -711,6 +711,16 @@ onMounted(() => {
     e.preventDefault()
     router.push(resolved.fullPath)
   })
+  // Per-button copy state for the delegate below: the button's resting label,
+  // and the timer that restores it. Keyed on the element and weakly held, so a
+  // re-rendered markdown block does not leak its old buttons.
+  //
+  // The resting label has to be remembered rather than re-read on each click.
+  // Reading `textContent` at click time works once, but a second click inside
+  // the 1.5s window reads "Copied" — and that click's timer then restores
+  // "Copied", leaving the button stuck on it for good.
+  const copyState = new WeakMap()
+
   // Global click delegate for the copy buttons on rendered code blocks
   // (emitted by the shared markdown renderer in useRenderMd). Copies the raw
   // <code> textContent so the clipboard gets clean source, not span markup.
@@ -725,10 +735,19 @@ onMounted(() => {
       // Restore the label the markdown renderer wrote, rather than hardcoding
       // "Copy" back: the two live in different files, and a hardcoded reset
       // would silently desync the moment the renderer's label is translated.
-      const idle = btn.textContent
+      // Captured on the first click only — see copyState above.
+      let state = copyState.get(btn)
+      if (!state) {
+        state = { idle: btn.textContent, timer: 0 }
+        copyState.set(btn, state)
+      }
+      clearTimeout(state.timer)
       btn.classList.add('copied')
       btn.textContent = t('common.state.copied')
-      setTimeout(() => { btn.classList.remove('copied'); btn.textContent = idle }, 1500)
+      state.timer = setTimeout(() => {
+        btn.classList.remove('copied')
+        btn.textContent = state.idle
+      }, 1500)
     }
     // Clipboard API needs a secure context (https / localhost). Self-hosted
     // deployments on plain http (e.g. a LAN box) don't have it, so fall back

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -17,7 +17,7 @@
         ]">
 
         <!-- Logo + org name -->
-        <router-link :to="orgHomeLink" class="flex items-center border-b border-slate-800 hover:opacity-90 transition-opacity" :class="sidebarCollapsed ? 'px-3 py-4 justify-center' : 'px-4 py-4 gap-3'" :title="sidebarCollapsed ? (orgName || 'ISMS') : undefined">
+        <router-link :to="orgHomeLink" class="flex items-center border-b border-slate-800 hover:opacity-90 transition-opacity" :class="sidebarCollapsed ? 'px-3 py-4 justify-center' : 'px-4 py-4 gap-3'" :title="sidebarCollapsed ? (orgName || $t('common.brand.product_name')) : undefined">
           <img v-if="logoUrl && !logoError" :src="logoUrl" @error="logoError = true" alt="" class="flex-shrink-0 object-contain" :class="sidebarCollapsed ? 'h-8 w-8' : 'h-9 max-w-[8rem]'" />
           <div v-else class="flex-shrink-0 rounded-lg flex items-center justify-center" :class="sidebarCollapsed ? 'w-8 h-8' : 'w-9 h-9'" style="background: var(--brand-color, #3b82f6)">
             <svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
@@ -25,7 +25,7 @@
             </svg>
           </div>
           <div v-if="!sidebarCollapsed" class="min-w-0">
-            <div class="text-sm font-bold truncate brand-org-name">{{ orgName || 'ISMS' }}</div>
+            <div class="text-sm font-bold truncate brand-org-name">{{ orgName || $t('common.brand.product_name') }}</div>
             <div v-if="orgSlug" class="text-[10px] text-slate-500 truncate">{{ orgSlug }}</div>
           </div>
         </router-link>
@@ -37,7 +37,7 @@
               {{ (orgName || orgSlug || '?').charAt(0).toUpperCase() }}
             </div>
             <div class="flex-1 min-w-0">
-              <div class="text-sm font-medium text-white truncate">{{ orgName || orgSlug || 'No org' }}</div>
+              <div class="text-sm font-medium text-white truncate">{{ orgName || orgSlug || $t('shell.org.none') }}</div>
               <div class="text-[10px] text-slate-500 truncate">{{ currentUserData?.organization_slug }}</div>
             </div>
             <svg class="w-3 h-3 text-slate-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
@@ -49,7 +49,7 @@
           <div v-if="showOrgMenu" class="absolute left-3 right-3 top-auto mt-1 bg-slate-800 border border-slate-700 rounded-xl shadow-xl z-50 py-1">
             <!-- Current org header -->
             <div class="px-4 py-2.5 border-b border-slate-700">
-              <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Current organization</div>
+              <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ $t('shell.org.current_heading') }}</div>
               <div class="text-sm font-medium text-white">{{ orgName }}</div>
               <div class="text-xs text-slate-500">{{ currentUserData?.organization_slug }}</div>
             </div>
@@ -62,16 +62,16 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                   <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
-                Organization settings
+                {{ $t('shell.org.settings') }}
               </router-link>
             </div>
 
             <!-- Switch to other orgs -->
             <div v-if="otherOrgs.length > 0" class="py-1 border-b border-slate-700">
-              <div class="px-4 py-1 text-[10px] text-slate-500 uppercase tracking-wider">Switch to</div>
+              <div class="px-4 py-1 text-[10px] text-slate-500 uppercase tracking-wider">{{ $t('shell.org.switch_to') }}</div>
               <button v-for="org in otherOrgs" :key="org.slug" @click="switchOrg(org)" class="w-full px-4 py-2 text-left text-sm text-slate-300 hover:text-white hover:bg-slate-700/50 transition-colors flex items-center justify-between">
                 <span>{{ org.name }}</span>
-                <span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="org.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : 'bg-slate-500/20 text-slate-400'">{{ org.role }}</span>
+                <span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="org.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : 'bg-slate-500/20 text-slate-400'">{{ roleLabel(org.role) }}</span>
               </button>
             </div>
 
@@ -81,7 +81,7 @@
             <router-link v-if="!subdomainBound && subdomainRoutingEnabled" to="/organizations" @click="showOrgMenu = false"
               class="flex items-center gap-2 px-4 py-2.5 text-sm text-slate-400 hover:text-white hover:bg-slate-700/50 transition-colors">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
-              Create new organization
+              {{ $t('shell.org.create') }}
             </router-link>
           </div>
         </div>
@@ -96,11 +96,11 @@
             <button v-if="hasOrg" @click="globalSearchRef?.open()"
               class="w-full flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors text-slate-400 hover:text-white hover:bg-slate-800/50"
               :class="sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2'"
-              :title="sidebarCollapsed ? 'Search' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.search') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
               </svg>
-              <span v-if="!sidebarCollapsed" class="flex-1 text-left">Search</span>
+              <span v-if="!sidebarCollapsed" class="flex-1 text-left">{{ $t('shell.nav.search') }}</span>
               <kbd v-if="!sidebarCollapsed" class="text-[10px] font-mono text-slate-600">⌘K</kbd>
             </button>
           </div>
@@ -110,30 +110,30 @@
             <router-link v-if="hasOrg" :to="orgPath('/overview')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/overview')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Overview' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.overview') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Overview</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.overview') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/documents')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/documents')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Documents' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.documents') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Documents</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.documents') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/reviews')"
               class="relative flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/reviews')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Reviews' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.reviews') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
               </svg>
               <template v-if="!sidebarCollapsed">
-                <span class="flex-1">Reviews</span>
+                <span class="flex-1">{{ $t('shell.nav.reviews') }}</span>
                 <span v-if="openReviewCount > 0" class="min-w-[20px] h-5 px-1 bg-blue-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center flex-shrink-0">
                   {{ openReviewCount > 99 ? '99+' : openReviewCount }}
                 </span>
@@ -146,17 +146,17 @@
               <router-link :to="orgPath('/inbox')"
                 class="relative flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors flex-1"
                 :class="[route.path.startsWith(orgPath('/inbox')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-                :title="sidebarCollapsed ? 'Inbox' : undefined">
+                :title="sidebarCollapsed ? $t('shell.nav.inbox') : undefined">
                 <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 012.012 1.244l.256.512a2.25 2.25 0 002.013 1.244h3.218a2.25 2.25 0 002.013-1.244l.256-.512a2.25 2.25 0 012.013-1.244h3.859M12 3v8.25m0 0l-3-3m3 3l3-3" />
                 </svg>
-                <span v-if="!sidebarCollapsed" class="flex-1">Inbox</span>
+                <span v-if="!sidebarCollapsed" class="flex-1">{{ $t('shell.nav.inbox') }}</span>
                 <span v-if="!sidebarCollapsed && unreadCount > 0" class="w-5 h-5 bg-blue-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center flex-shrink-0">
                   {{ unreadCount > 9 ? '9+' : unreadCount }}
                 </span>
               </router-link>
               <button v-if="!sidebarCollapsed && unreadCount > 0" @click="markAllRead"
-                class="w-5 h-5 text-slate-600 hover:text-slate-300 transition-colors flex-shrink-0 ml-1" title="Mark all read">
+                class="w-5 h-5 text-slate-600 hover:text-slate-300 transition-colors flex-shrink-0 ml-1" :title="$t('shell.notifications.mark_all_read')">
                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                 </svg>
@@ -165,139 +165,139 @@
           </div>
 
           <!-- Divider + Group: Registers -->
-          <div v-if="!sidebarCollapsed" class="text-[10px] text-slate-600 uppercase tracking-wider font-medium px-2 pt-4 pb-1">Registers</div>
+          <div v-if="!sidebarCollapsed" class="text-[10px] text-slate-600 uppercase tracking-wider font-medium px-2 pt-4 pb-1">{{ $t('shell.nav.group_registers') }}</div>
           <div v-else class="border-t border-slate-800 my-2"></div>
           <div class="space-y-0.5">
             <router-link v-if="hasOrg" :to="orgPath('/risks')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/risks')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Risks' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.risks') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Risks</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.risks') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/assets')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/assets')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Assets' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.assets') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 17.25v-.228a4.5 4.5 0 00-.12-1.03l-2.268-9.64a3.375 3.375 0 00-3.285-2.602H7.923a3.375 3.375 0 00-3.285 2.602l-2.268 9.64a4.5 4.5 0 00-.12 1.03v.228m19.5 0a3 3 0 01-3 3H5.25a3 3 0 01-3-3m19.5 0a3 3 0 00-3-3H5.25a3 3 0 00-3 3m16.5 0h.008v.008h-.008v-.008zm-3 0h.008v.008h-.008v-.008z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Assets</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.assets') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/suppliers')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/suppliers')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Suppliers' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.suppliers') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0H6.375c-.621 0-1.125-.504-1.125-1.125V14.25m17.25 0V6.375c0-.621-.504-1.125-1.125-1.125H15.75m0 0v3.375c0 .621-.504 1.125-1.125 1.125H12m3.75-4.5V3.375c0-.621-.504-1.125-1.125-1.125H8.25m0 0v3.375c0 .621.504 1.125 1.125 1.125H12" />
               </svg>
-              <span v-if="!sidebarCollapsed">Suppliers</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.suppliers') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/legal')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/legal')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Legal' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.legal') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0012 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 01-2.031.352 5.988 5.988 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 01-2.031.352 5.989 5.989 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Legal</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.legal') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/systems')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/systems')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Systems' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.systems') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Systems</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.systems') }}</span>
             </router-link>
           </div>
 
           <!-- Divider + Group: Operations -->
-          <div v-if="!sidebarCollapsed" class="text-[10px] text-slate-600 uppercase tracking-wider font-medium px-2 pt-4 pb-1">Operations</div>
+          <div v-if="!sidebarCollapsed" class="text-[10px] text-slate-600 uppercase tracking-wider font-medium px-2 pt-4 pb-1">{{ $t('shell.nav.group_operations') }}</div>
           <div v-else class="border-t border-slate-800 my-2"></div>
           <div class="space-y-0.5">
             <router-link v-if="hasOrg" :to="orgPath('/objectives')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/objectives')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Objectives' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.objectives') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v1.5M3 21v-6m0 0l2.77-.693a9 9 0 016.208.682l.108.054a9 9 0 006.086.71l3.114-.732a48.524 48.524 0 01-.005-10.499l-3.11.732a9 9 0 01-6.085-.711l-.108-.054a9 9 0 00-6.208-.682L3 4.5M3 15V4.5" />
               </svg>
-              <span v-if="!sidebarCollapsed">Objectives</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.objectives') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/programs')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/programs')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Programs' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.programs') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
               </svg>
-              <span v-if="!sidebarCollapsed">Programs</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.programs') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/audit')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/audit')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Audit' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.audit') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15a2.25 2.25 0 011.65 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0118 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3l1.5 1.5 3-3.75" />
               </svg>
-              <span v-if="!sidebarCollapsed">Audit</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.audit') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/corrective-actions')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/corrective-actions')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Corrective Actions' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.corrective_actions') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17l-5.1-5.1m0 0L3.44 12.95m2.88-2.88L3.44 7.19m8.58 10.86l5.1-5.1m0 0l2.88 2.88m-2.88-2.88l2.88-2.88M3.75 7.5h16.5" />
               </svg>
-              <span v-if="!sidebarCollapsed">Corrective Actions</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.corrective_actions') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/incidents')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/incidents')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Incidents' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.incidents') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
               </svg>
-              <span v-if="!sidebarCollapsed">Incidents</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.incidents') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/changes')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/changes')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Change Management' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.changes') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
               </svg>
-              <span v-if="!sidebarCollapsed">Change Management</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.changes') }}</span>
             </router-link>
             <router-link v-if="hasOrg" :to="orgPath('/tasks')"
               class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
               :class="[route.path.startsWith(orgPath('/tasks')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-              :title="sidebarCollapsed ? 'Tasks' : undefined">
+              :title="sidebarCollapsed ? $t('shell.nav.tasks') : undefined">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
               </svg>
-              <span v-if="!sidebarCollapsed">Tasks</span>
+              <span v-if="!sidebarCollapsed">{{ $t('shell.nav.tasks') }}</span>
             </router-link>
           </div>
 
           <!-- Divider + Group: Admin (conditional) -->
           <template v-if="currentUserData?.role === 'admin'">
-            <div v-if="!sidebarCollapsed" class="text-[10px] text-slate-600 uppercase tracking-wider font-medium px-2 pt-4 pb-1">Admin</div>
+            <div v-if="!sidebarCollapsed" class="text-[10px] text-slate-600 uppercase tracking-wider font-medium px-2 pt-4 pb-1">{{ $t('shell.nav.admin') }}</div>
             <div v-else class="border-t border-slate-800 my-2"></div>
             <div class="space-y-0.5">
               <router-link v-if="hasOrg" :to="orgPath('/admin')"
                 class="flex items-center gap-2.5 py-1.5 text-sm rounded-lg transition-colors"
                 :class="[route.path.startsWith(orgPath('/admin')) ? 'bg-slate-800 text-white font-medium' : 'text-slate-400 hover:text-white hover:bg-slate-800/50', sidebarCollapsed ? 'px-2.5 justify-center' : 'px-2']"
-                :title="sidebarCollapsed ? 'Admin' : undefined">
+                :title="sidebarCollapsed ? $t('shell.nav.admin') : undefined">
                 <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
                   <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
-                <span v-if="!sidebarCollapsed">Admin</span>
+                <span v-if="!sidebarCollapsed">{{ $t('shell.nav.admin') }}</span>
               </router-link>
             </div>
           </template>
@@ -306,7 +306,7 @@
         <!-- Collapse/Expand button -->
         <button @click="sidebarCollapsed = !sidebarCollapsed"
           class="flex items-center justify-center py-3 border-t border-slate-800 text-slate-500 hover:text-slate-300 hover:bg-slate-800/50 transition-colors flex-shrink-0"
-          :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'">
+          :title="sidebarCollapsed ? $t('shell.sidebar.expand') : $t('shell.sidebar.collapse')">
           <svg class="w-4 h-4 transition-transform duration-200" :class="{ 'rotate-180': sidebarCollapsed }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18.75 19.5l-7.5-7.5 7.5-7.5m-6 15L5.25 12l7.5-7.5" />
           </svg>
@@ -319,18 +319,18 @@
         class="notifications-panel fixed right-4 top-14 w-80 max-w-[calc(100vw-2rem)] bg-slate-900 border border-slate-800 rounded-xl shadow-xl z-50 overflow-hidden"
       >
         <div class="flex items-center justify-between px-4 py-3 border-b border-slate-800">
-          <span class="text-sm font-semibold text-slate-200">Notifications</span>
+          <span class="text-sm font-semibold text-slate-200">{{ $t('shell.notifications.heading') }}</span>
           <button
             v-if="unreadCount > 0"
             @click="markAllRead"
             class="text-xs text-blue-400 hover:text-blue-300"
           >
-            Mark all read
+            {{ $t('shell.notifications.mark_all_read') }}
           </button>
         </div>
         <div class="max-h-72 overflow-y-auto divide-y divide-slate-800">
           <div v-if="notifications.length === 0" class="px-4 py-6 text-center text-xs text-slate-600">
-            No notifications
+            {{ $t('shell.notifications.empty') }}
           </div>
           <div
             v-for="n in notifications"
@@ -390,27 +390,27 @@
               <!-- Org dropdown -->
               <div v-if="showOrgMenu" @click.stop class="absolute right-0 top-full mt-2 w-72 bg-slate-900 border border-slate-700 rounded-xl shadow-xl z-50 py-1">
                 <div class="px-4 py-2.5 border-b border-slate-800">
-                  <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Current</div>
+                  <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ $t('shell.org.current_heading_short') }}</div>
                   <div class="text-sm font-medium text-white">{{ orgName }}</div>
                   <div class="text-xs text-slate-500">{{ currentUserData?.organization_slug }}</div>
                 </div>
                 <div v-if="currentUserData?.role === 'admin'" class="py-1 border-b border-slate-800">
                   <router-link :to="orgPath('/admin/settings')" @click="showOrgMenu = false" class="flex items-center gap-2 px-4 py-2 text-sm text-slate-300 hover:text-white hover:bg-slate-800/50 transition-colors">
                     <svg class="w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-                    Organization settings
+                    {{ $t('shell.org.settings') }}
                   </router-link>
                 </div>
                 <div v-if="otherOrgs.length > 0" class="py-1 border-b border-slate-800">
-                  <div class="px-4 py-1 text-[10px] text-slate-500 uppercase tracking-wider">Switch to</div>
+                  <div class="px-4 py-1 text-[10px] text-slate-500 uppercase tracking-wider">{{ $t('shell.org.switch_to') }}</div>
                   <button v-for="org in otherOrgs" :key="org.slug" @click="switchOrg(org)" class="w-full px-4 py-2 text-left text-sm text-slate-300 hover:text-white hover:bg-slate-800/50 transition-colors flex items-center justify-between">
                     <span>{{ org.name }}</span>
-                    <span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="org.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : 'bg-slate-500/20 text-slate-400'">{{ org.role }}</span>
+                    <span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="org.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : 'bg-slate-500/20 text-slate-400'">{{ roleLabel(org.role) }}</span>
                   </button>
                 </div>
                 <div v-if="!subdomainBound && otherOrgs.length > 0" class="border-t border-slate-800 py-1">
                   <router-link to="/organizations" @click="showOrgMenu = false" class="flex items-center gap-2 px-4 py-2 text-sm text-slate-400 hover:text-white hover:bg-slate-800/50 transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
-                    Switch organization
+                    {{ $t('shell.org.switch') }}
                   </router-link>
                 </div>
               </div>
@@ -430,16 +430,16 @@
                 <div class="px-4 py-2 border-b border-slate-800">
                   <div class="text-sm font-medium text-white">{{ displayName }}</div>
                   <div class="text-xs text-slate-500">{{ currentUserData?.email }}</div>
-                  <span v-if="hasOrg && currentUserData?.role" class="inline-block mt-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full" :class="roleBadgeClass(currentUserData.role)">{{ currentUserData.role }}</span>
+                  <span v-if="hasOrg && currentUserData?.role" class="inline-block mt-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full" :class="roleBadgeClass(currentUserData.role)">{{ roleLabel(currentUserData.role) }}</span>
                 </div>
                 <div class="py-1">
                   <router-link :to="orgSlug ? orgPath('/settings') : '/organizations'" @click="showUserMenu = false" class="flex items-center gap-2 px-4 py-2 text-sm text-slate-400 hover:text-white hover:bg-slate-800/50 transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-                    Settings
+                    {{ $t('shell.user.settings') }}
                   </router-link>
                   <button @click="logout" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-slate-400 hover:text-white hover:bg-slate-800/50 transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/></svg>
-                    Sign out
+                    {{ $t('shell.user.sign_out') }}
                   </button>
                 </div>
               </div>
@@ -456,11 +456,11 @@
 
         <!-- Footer -->
         <footer v-if="termsUrl || privacyUrl || showPoweredBy" class="px-8 py-4 text-center text-xs text-slate-600 border-t border-slate-800/50">
-          <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">Privacy Policy</a>
-          <span v-if="(termsUrl && privacyUrl)" class="mx-2">&middot;</span>
-          <a v-if="termsUrl" :href="termsUrl" target="_blank" class="hover:text-slate-400 transition-colors">Terms of Service</a>
-          <span v-if="showPoweredBy && (termsUrl || privacyUrl)" class="mx-2">&middot;</span>
-          <a v-if="showPoweredBy" href="https://isms.sh" target="_blank" rel="noopener" class="hover:text-slate-400 transition-colors">Powered by isms.sh</a>
+          <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.privacy') }}</a>
+          <span v-if="(termsUrl && privacyUrl)" class="mx-2">&middot;</span> <!-- i18n-ignore: typographic separator -->
+          <a v-if="termsUrl" :href="termsUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.terms') }}</a>
+          <span v-if="showPoweredBy && (termsUrl || privacyUrl)" class="mx-2">&middot;</span> <!-- i18n-ignore: typographic separator -->
+          <a v-if="showPoweredBy" href="https://isms.sh" target="_blank" rel="noopener" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.powered_by') }}</a>
         </footer>
       </div>
     </div>
@@ -470,15 +470,15 @@
   <Teleport to="body">
     <div class="fixed bottom-4 right-4 z-[100] space-y-2 max-w-sm">
       <transition-group name="toast">
-        <div v-for="t in toasts" :key="t.id"
+        <div v-for="toast in toasts" :key="toast.id"
           class="px-4 py-3 rounded-lg shadow-xl text-sm font-medium cursor-pointer backdrop-blur-sm border"
           :class="{
-            'bg-red-950/90 text-red-300 border-red-800': t.type === 'error',
-            'bg-emerald-950/90 text-emerald-300 border-emerald-800': t.type === 'success',
-            'bg-amber-950/90 text-amber-300 border-amber-800': t.type === 'warning',
+            'bg-red-950/90 text-red-300 border-red-800': toast.type === 'error',
+            'bg-emerald-950/90 text-emerald-300 border-emerald-800': toast.type === 'success',
+            'bg-amber-950/90 text-amber-300 border-amber-800': toast.type === 'warning',
           }"
-          @click="dismissToast(t.id)">
-          {{ t.message }}
+          @click="dismissToast(toast.id)">
+          {{ toast.message }}
         </div>
       </transition-group>
     </div>
@@ -516,6 +516,14 @@ import { useSession } from './composables/useSession'
 import { useNotifications } from './composables/useNotifications'
 import { notificationTitle } from './composables/useNotificationRender'
 import { useCurrentOrg, currentOrgPath, registerRouter, isSubdomainMode, subdomainRouting } from './composables/useCurrentOrg'
+import { useI18n } from 'vue-i18n'
+import { enumLabel } from './composables/useEnumLabel.js'
+
+const { t } = useI18n()
+
+// Wrapped rather than called inline: the enum group name is a literal, and the
+// raw-text scanner reads templates only.
+const roleLabel = (role) => enumLabel('role', role)
 
 const { toasts, dismiss: dismissToast } = useToast()
 
@@ -591,35 +599,6 @@ const isPublicRoute = computed(() =>
   route.path === '/' ||
   route.path === '/landing'
 )
-
-const nav = computed(() => {
-  if (!hasOrg.value) return []
-  const slug = currentUserData.value?.organization_slug
-  if (!slug) return []
-
-  const base = [
-    { path: orgPath('/overview'), label: 'Overview' },
-    { path: orgPath('/documents'), label: 'Documents' },
-    { path: orgPath('/inbox'), label: 'Inbox' },
-    { path: orgPath('/risks'), label: 'Risks' },
-    { path: orgPath('/suppliers'), label: 'Suppliers' },
-    { path: orgPath('/legal'), label: 'Legal' },
-    { path: orgPath('/assets'), label: 'Assets' },
-    { path: orgPath('/systems'), label: 'Systems' },
-    { path: orgPath('/objectives'), label: 'Objectives' },
-    { path: orgPath('/programs'), label: 'Programs' },
-    { path: orgPath('/audit'), label: 'Audit' },
-    { path: orgPath('/corrective-actions'), label: 'Corrective Actions' },
-    { path: orgPath('/incidents'), label: 'Incidents' },
-    { path: orgPath('/changes'), label: 'Change Management' },
-    { path: orgPath('/tasks'), label: 'Tasks' },
-    { path: orgPath('/reviews'), label: 'Reviews' },
-  ]
-  if (currentUserData.value?.role === 'admin') {
-    base.push({ path: orgPath('/admin'), label: 'Admin' })
-  }
-  return base
-})
 
 // Thin wrappers that wire composable calls to local context (router, orgSlug, showUserMenu)
 async function logout() {
@@ -743,9 +722,13 @@ onMounted(() => {
     if (!code) return
     const text = code.textContent || ''
     const confirm = () => {
+      // Restore the label the markdown renderer wrote, rather than hardcoding
+      // "Copy" back: the two live in different files, and a hardcoded reset
+      // would silently desync the moment the renderer's label is translated.
+      const idle = btn.textContent
       btn.classList.add('copied')
-      btn.textContent = 'Copied'
-      setTimeout(() => { btn.classList.remove('copied'); btn.textContent = 'Copy' }, 1500)
+      btn.textContent = t('common.state.copied')
+      setTimeout(() => { btn.classList.remove('copied'); btn.textContent = idle }, 1500)
     }
     // Clipboard API needs a secure context (https / localhost). Self-hosted
     // deployments on plain http (e.g. a LAN box) don't have it, so fall back

--- a/web/src/locales/en/auth.json
+++ b/web/src/locales/en/auth.json
@@ -1,5 +1,4 @@
 {
-  "product_name": "ISMS",
   "sign_in_to": "Sign in to {org}",
   "check_email": "Check your email",
   "back_to_sign_in": "← Back to sign in",
@@ -72,10 +71,5 @@
     "go_to_sign_in": "Go to sign in",
     "error_missing_link": "Missing or invalid confirmation link.",
     "error_failed": "This confirmation link is invalid or has expired."
-  },
-  "footer": {
-    "privacy": "Privacy Policy",
-    "terms": "Terms of Service",
-    "powered_by": "Powered by isms.sh"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -16,7 +16,8 @@
     "loading": "Loading…",
     "empty": "Nothing here yet",
     "error": "Something went wrong",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "copied": "Copied"
   },
   "validation": {
     "required": "This field is required"

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1,4 +1,7 @@
 {
+  "brand": {
+    "product_name": "ISMS"
+  },
   "action": {
     "save": "Save",
     "cancel": "Cancel",
@@ -265,5 +268,10 @@
     "eu": "EU",
     "eea": "EEA",
     "apac": "APAC"
+  },
+  "footer": {
+    "privacy": "Privacy Policy",
+    "terms": "Terms of Service",
+    "powered_by": "Powered by isms.sh"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -159,6 +159,12 @@
       "confidential": "Confidential",
       "restricted": "Restricted"
     },
+    "role": {
+      "admin": "Admin",
+      "manager": "Manager",
+      "contributor": "Contributor",
+      "reader": "Reader"
+    },
     "audit_result": {
       "not_assessed": "Not assessed",
       "conforming": "Conforming",

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -13,12 +13,14 @@
 // in the bundler and under `node --test`.
 import auth from './auth.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
+import landing from './landing.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
 
 export default {
   auth,
   common,
+  landing,
   notifications,
   organizations,
 }

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -16,6 +16,7 @@ import common from './common.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
+import shell from './shell.json' with { type: 'json' }
 
 export default {
   auth,
@@ -23,4 +24,5 @@ export default {
   landing,
   notifications,
   organizations,
+  shell,
 }

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -14,9 +14,11 @@
 import auth from './auth.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
+import organizations from './organizations.json' with { type: 'json' }
 
 export default {
   auth,
   common,
   notifications,
+  organizations,
 }

--- a/web/src/locales/en/landing.json
+++ b/web/src/locales/en/landing.json
@@ -1,0 +1,79 @@
+{
+  "nav": {
+    "docs": "Docs",
+    "sign_in": "Sign in"
+  },
+  "hero": {
+    "badge": "Open source · Apache 2.0",
+    "title_line1": "The Intelligent",
+    "title_line2": "Management System",
+    "subtitle": "Living documents, tracked reviews, and operational cadence in one auditable platform. Pick a framework or bring your own. AI helps with the work. Humans stay in control.",
+    "cta_cloud": "Start in cloud",
+    "cta_selfhost": "Self-host",
+    "cta_docs": "Read the docs"
+  },
+  "why": {
+    "heading": "Why another management system?",
+    "p1": "Because the ones we have are complex, opaque, and treated as a compliance exercise — relevant for the audit, irrelevant the day after. And the stakes keep rising: as AI adoption accelerates and threat surfaces widen, a management system that doesn't stay alive is worse than useless.",
+    "p2": "It doesn't have to work this way. Security done right starts at the root — genuinely understanding and managing your risks, not papering over them. Built AI-first, with real discipline in how it's designed and used, a management system should be a living part of how you operate, not a burden bolted on top.",
+    "p3": "That's why it's open source — built for organizations of every size, and finally a credible option for smaller ones, who've never had a management system that's simple, stays current, and doesn't fight them. We built this to change that."
+  },
+  "pillars": {
+    "documents_title": "Documents are operational assets",
+    "documents_desc": "Policies live in git as markdown. Every edit is a commit. Every version recoverable. Documents drive your ISMS, not sit in a folder.",
+    "reviews_title": "Reviews are tracked decisions",
+    "reviews_desc": "Round-based review with inline comments. Approve, request changes, or propose a revision. Every decision is an immutable record with a SHA-256 hash.",
+    "tasks_title": "Tasks run the year",
+    "tasks_desc": "Annual plan distributes reviews, audits, and risk assessments across the calendar. Dashboard shows what needs attention this month. Your ISMS never goes stale."
+  },
+  "how": {
+    "heading": "Five minutes, not five meetings",
+    "subtitle": "From event to updated policy to approved document. The platform handles the busywork.",
+    "step1_title": "Something happens",
+    "step1_desc": "An incident, a new supplier, a regulation change, an audit finding. Any event that affects your security posture.",
+    "step2_title": "Create or update",
+    "step2_desc": "Log it in the right register. AI can suggest risk updates, policy changes, and corrective actions. You review each suggestion.",
+    "step3_title": "Documents update on a branch",
+    "step3_desc": "Policy changes land on a review branch with full diff. No mystery edits. Five documents in five minutes.",
+    "step4_title": "Review rounds",
+    "step4_desc": "Reviewers get notified. Approve or request changes. After edits, resubmit as a new round. Each round shows only what changed since last feedback.",
+    "step5_title": "Publish",
+    "step5_desc": "Merge to main. Version incremented. Decision record created. Evidence stored. Done."
+  },
+  "features": {
+    "heading": "Built different",
+    "subtitle": "Not a document editor with compliance plugins. A purpose-built management system where everything connects.",
+    "git_title": "Git-native documents",
+    "git_desc": "Policies are markdown files in a git repo. Every change is a commit with full diff. Branch for review, merge to publish. No proprietary formats, no lock-in.",
+    "review_title": "Round-based review",
+    "review_desc": "Send a document for review. Reviewers approve, request changes, or propose a revision with inline comments. Resubmit as a new round — reviewers see only what changed.",
+    "registers_title": "Registers that connect",
+    "registers_desc": "Risks link to assets and controls. Incidents create corrective actions. Legal requirements link to policies. Change one thing, see the ripple everywhere.",
+    "ai_title": "AI suggests, you approve",
+    "ai_desc": "AI agents draft policies, assess risks, and propose register updates through the same review workflow. 22-tool MCP server. Full agent identity and audit trail. Not autopilot — a capable assistant.",
+    "cadence_title": "Annual plan and cadence",
+    "cadence_desc": "Dashboard shows what needs attention this month. Distribute reviews, audits, and risk assessments across the year. Tasks track execution. Your ISMS stays alive.",
+    "audit_title": "Auditor-ready from day one",
+    "audit_desc": "Every review approval and document publish creates an immutable decision record with SHA-256 content hash. Timestamped, attributable, cryptographically verifiable."
+  },
+  "frameworks": {
+    "heading": "Any framework. Your templates.",
+    "subtitle": "11 built-in frameworks. Or bring your own templates — a folder of markdown files is all it takes. Run multiple standards on the same platform."
+  },
+  "deploy": {
+    "cloud_title": "Managed cloud",
+    "cloud_desc": "Sign up, pick your framework, start working. We handle infrastructure, backups, and updates. Multi-tenant with row-level data isolation.",
+    "cloud_cta": "Start free",
+    "cloud_cta_signin": "Sign in",
+    "selfhost_title": "Self-hosted",
+    "selfhost_desc": "One Go binary. PostgreSQL and a data directory. Deploy anywhere — your infrastructure, your data. Apache 2.0, no artificial limits, no open-core tricks.",
+    "selfhost_cta": "View on GitHub"
+  },
+  "cta": {
+    "heading": "Your auditor will thank you",
+    "subtitle": "Full version history. Immutable approval records. Cryptographically verifiable decisions. Complete audit trail from day one."
+  },
+  "footer": {
+    "powered_by": "Powered by {link}"
+  }
+}

--- a/web/src/locales/en/organizations.json
+++ b/web/src/locales/en/organizations.json
@@ -1,0 +1,20 @@
+{
+  "title": "Your organizations",
+  "empty": "You're not a member of any organization yet.",
+  "create": "Create organization",
+  "form": {
+    "title": "New organization",
+    "name_label": "Name",
+    "name_placeholder": "Acme Corp",
+    "slug_label": "URL slug",
+    "slug_placeholder": "acme",
+    "template_label": "Template (optional)",
+    "template_none": "None — I'll set up documents manually",
+    "template_iso27001": "ISO 27001 — full document set",
+    "template_soc2": "SOC 2 — Trust Services Criteria",
+    "template_nis2": "NIS2 — EU directive requirements",
+    "template_hint": "Scaffolds document templates in git. Can add more templates later.",
+    "creating": "Creating…",
+    "error_create": "Failed to create organization"
+  }
+}

--- a/web/src/locales/en/shell.json
+++ b/web/src/locales/en/shell.json
@@ -1,0 +1,46 @@
+{
+  "nav": {
+    "search": "Search",
+    "overview": "Overview",
+    "documents": "Documents",
+    "reviews": "Reviews",
+    "inbox": "Inbox",
+    "group_registers": "Registers",
+    "risks": "Risks",
+    "assets": "Assets",
+    "suppliers": "Suppliers",
+    "legal": "Legal",
+    "systems": "Systems",
+    "group_operations": "Operations",
+    "objectives": "Objectives",
+    "programs": "Programs",
+    "audit": "Audit",
+    "corrective_actions": "Corrective Actions",
+    "incidents": "Incidents",
+    "changes": "Change Management",
+    "tasks": "Tasks",
+    "admin": "Admin"
+  },
+  "sidebar": {
+    "expand": "Expand sidebar",
+    "collapse": "Collapse sidebar"
+  },
+  "org": {
+    "none": "No org",
+    "current_heading": "Current organization",
+    "current_heading_short": "Current",
+    "settings": "Organization settings",
+    "switch_to": "Switch to",
+    "create": "Create new organization",
+    "switch": "Switch organization"
+  },
+  "notifications": {
+    "heading": "Notifications",
+    "mark_all_read": "Mark all read",
+    "empty": "No notifications"
+  },
+  "user": {
+    "settings": "Settings",
+    "sign_out": "Sign out"
+  }
+}

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -15,12 +15,13 @@
         <span class="text-xl font-bold tracking-tight">{{ brandName }}</span>
       </router-link>
       <div class="flex items-center gap-5">
-        <a href="/docs" class="text-sm text-slate-400 hover:text-white transition-colors">Docs</a>
+        <a href="/docs" class="text-sm text-slate-400 hover:text-white transition-colors">{{ t('landing.nav.docs') }}</a>
         <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener" class="text-sm text-slate-400 hover:text-white transition-colors flex items-center gap-1.5">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          <!-- i18n-ignore: brand name -->
           GitHub
         </a>
-        <router-link to="/login" class="px-5 py-2 text-sm font-medium bg-white/10 hover:bg-white/15 border border-white/10 rounded-lg transition-all hover:border-white/20">Sign in</router-link>
+        <router-link to="/login" class="px-5 py-2 text-sm font-medium bg-white/10 hover:bg-white/15 border border-white/10 rounded-lg transition-all hover:border-white/20">{{ t('landing.nav.sign_in') }}</router-link>
       </div>
     </nav>
 
@@ -28,39 +29,39 @@
     <section class="relative z-10 max-w-5xl mx-auto px-8 pt-20 pb-12 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 mb-8 text-xs font-medium text-slate-400 bg-slate-800/50 border border-slate-700/50 rounded-full">
         <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse"></span>
-        Open source &middot; Apache 2.0
+        {{ t('landing.hero.badge') }}
       </div>
       <h1 class="text-5xl sm:text-7xl font-extrabold tracking-tight leading-[1.1] mb-6">
-        <span class="bg-gradient-to-r from-white via-white to-slate-400 bg-clip-text text-transparent">The Intelligent</span><br>
-        <span class="hero-accent-gradient bg-clip-text text-transparent">Management System</span>
+        <span class="bg-gradient-to-r from-white via-white to-slate-400 bg-clip-text text-transparent">{{ t('landing.hero.title_line1') }}</span><br>
+        <span class="hero-accent-gradient bg-clip-text text-transparent">{{ t('landing.hero.title_line2') }}</span>
       </h1>
       <p class="text-lg sm:text-xl text-slate-400 max-w-2xl mx-auto mb-10 leading-relaxed">
-        Living documents, tracked reviews, and operational cadence in one auditable platform. Pick a framework or bring your own. AI helps with the work. Humans stay in control.
+        {{ t('landing.hero.subtitle') }}
       </p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
         <router-link v-if="signupEnabled" to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
-          Start in cloud
+          {{ t('landing.hero.cta_cloud') }}
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"/></svg>
         </router-link>
         <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener"
           class="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-slate-300 bg-slate-800/50 border border-slate-700 rounded-xl hover:bg-slate-800 hover:border-slate-600 transition-all">
-          Self-host
+          {{ t('landing.hero.cta_selfhost') }}
         </a>
         <a href="/docs"
           class="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-slate-400 hover:text-slate-200 transition-colors">
-          Read the docs
+          {{ t('landing.hero.cta_docs') }}
         </a>
       </div>
     </section>
 
     <!-- Why — lead with the conviction, not the feature list (#45) -->
     <section class="relative z-10 max-w-3xl mx-auto px-8 pt-8 pb-16">
-      <h2 class="text-3xl font-bold text-center mb-8">Why another management system?</h2>
+      <h2 class="text-3xl font-bold text-center mb-8">{{ t('landing.why.heading') }}</h2>
       <div class="space-y-5 text-slate-400 leading-relaxed text-lg">
-        <p>Because the ones we have are complex, opaque, and treated as a compliance exercise — relevant for the audit, irrelevant the day after. And the stakes keep rising: as AI adoption accelerates and threat surfaces widen, a management system that doesn't stay alive is worse than useless.</p>
-        <p class="text-slate-200">It doesn't have to work this way. Security done right starts at the root — genuinely understanding and managing your risks, not papering over them. Built AI-first, with real discipline in how it's designed and used, a management system should be a living part of how you operate, not a burden bolted on top.</p>
-        <p>That's why it's open source — built for organizations of every size, and finally a credible option for smaller ones, who've never had a management system that's simple, stays current, and doesn't fight them. We built this to change that.</p>
+        <p>{{ t('landing.why.p1') }}</p>
+        <p class="text-slate-200">{{ t('landing.why.p2') }}</p>
+        <p>{{ t('landing.why.p3') }}</p>
       </div>
     </section>
 
@@ -71,30 +72,30 @@
           <div class="w-12 h-12 rounded-xl bg-emerald-500/10 flex items-center justify-center mx-auto mb-4">
             <svg class="w-6 h-6 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg>
           </div>
-          <h3 class="text-lg font-semibold mb-2">Documents are operational assets</h3>
-          <p class="text-sm text-slate-400 leading-relaxed">Policies live in git as markdown. Every edit is a commit. Every version recoverable. Documents drive your ISMS, not sit in a folder.</p>
+          <h3 class="text-lg font-semibold mb-2">{{ t('landing.pillars.documents_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed">{{ t('landing.pillars.documents_desc') }}</p>
         </div>
         <div class="text-center">
           <div class="w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center mx-auto mb-4">
             <svg class="w-6 h-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.745 3.745 0 011.043 3.296A3.745 3.745 0 0121 12z" /></svg>
           </div>
-          <h3 class="text-lg font-semibold mb-2">Reviews are tracked decisions</h3>
-          <p class="text-sm text-slate-400 leading-relaxed">Round-based review with inline comments. Approve, request changes, or propose a revision. Every decision is an immutable record with a SHA-256 hash.</p>
+          <h3 class="text-lg font-semibold mb-2">{{ t('landing.pillars.reviews_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed">{{ t('landing.pillars.reviews_desc') }}</p>
         </div>
         <div class="text-center">
           <div class="w-12 h-12 rounded-xl bg-amber-500/10 flex items-center justify-center mx-auto mb-4">
             <svg class="w-6 h-6 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" /></svg>
           </div>
-          <h3 class="text-lg font-semibold mb-2">Tasks run the year</h3>
-          <p class="text-sm text-slate-400 leading-relaxed">Annual plan distributes reviews, audits, and risk assessments across the calendar. Dashboard shows what needs attention this month. Your ISMS never goes stale.</p>
+          <h3 class="text-lg font-semibold mb-2">{{ t('landing.pillars.tasks_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed">{{ t('landing.pillars.tasks_desc') }}</p>
         </div>
       </div>
     </section>
 
     <!-- How it works -->
     <section class="relative z-10 max-w-4xl mx-auto px-8 py-16">
-      <h2 class="text-3xl font-bold text-center mb-4">Five minutes, not five meetings</h2>
-      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">From event to updated policy to approved document. The platform handles the busywork.</p>
+      <h2 class="text-3xl font-bold text-center mb-4">{{ t('landing.how.heading') }}</h2>
+      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">{{ t('landing.how.subtitle') }}</p>
       <div class="space-y-4">
         <div v-for="(step, i) in steps" :key="i" class="flex gap-4 items-start p-5 bg-slate-900/30 border border-slate-800/30 rounded-xl">
           <div class="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-sm font-bold text-white" style="background-color: var(--brand-color)">{{ i + 1 }}</div>
@@ -108,8 +109,8 @@
 
     <!-- Features: why isms.sh -->
     <section class="relative z-10 max-w-6xl mx-auto px-8 py-16">
-      <h2 class="text-3xl font-bold text-center mb-4">Built different</h2>
-      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">Not a document editor with compliance plugins. A purpose-built management system where everything connects.</p>
+      <h2 class="text-3xl font-bold text-center mb-4">{{ t('landing.features.heading') }}</h2>
+      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">{{ t('landing.features.subtitle') }}</p>
       <div class="grid md:grid-cols-2 gap-6">
         <div v-for="f in features" :key="f.title" class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl backdrop-blur-sm hover:border-slate-700/50 transition-colors">
           <h3 class="text-base font-semibold mb-2">{{ f.title }}</h3>
@@ -120,8 +121,8 @@
 
     <!-- Frameworks -->
     <section class="relative z-10 max-w-4xl mx-auto px-8 py-16 text-center">
-      <h2 class="text-3xl font-bold mb-4">Any framework. Your templates.</h2>
-      <p class="text-slate-400 mb-10 max-w-2xl mx-auto">11 built-in frameworks. Or bring your own templates — a folder of markdown files is all it takes. Run multiple standards on the same platform.</p>
+      <h2 class="text-3xl font-bold mb-4">{{ t('landing.frameworks.heading') }}</h2>
+      <p class="text-slate-400 mb-10 max-w-2xl mx-auto">{{ t('landing.frameworks.subtitle') }}</p>
       <div class="flex flex-wrap justify-center gap-3">
         <span v-for="fw in frameworks" :key="fw" class="px-4 py-2 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-slate-300">{{ fw }}</span>
       </div>
@@ -131,31 +132,31 @@
     <section class="relative z-10 max-w-4xl mx-auto px-8 py-16">
       <div class="grid md:grid-cols-2 gap-6">
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
-          <h3 class="text-lg font-semibold mb-2">Managed cloud</h3>
-          <p class="text-sm text-slate-400 leading-relaxed mb-4">Sign up, pick your framework, start working. We handle infrastructure, backups, and updates. Multi-tenant with row-level data isolation.</p>
-          <router-link v-if="signupEnabled" to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Start free &rarr;</router-link>
-          <router-link v-else to="/login" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">Sign in &rarr;</router-link>
+          <h3 class="text-lg font-semibold mb-2">{{ t('landing.deploy.cloud_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed mb-4">{{ t('landing.deploy.cloud_desc') }}</p>
+          <router-link v-if="signupEnabled" to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">{{ t('landing.deploy.cloud_cta') }} &rarr;</router-link> <!-- i18n-ignore: typographic arrow -->
+          <router-link v-else to="/login" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">{{ t('landing.deploy.cloud_cta_signin') }} &rarr;</router-link> <!-- i18n-ignore: typographic arrow -->
         </div>
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
-          <h3 class="text-lg font-semibold mb-2">Self-hosted</h3>
-          <p class="text-sm text-slate-400 leading-relaxed mb-4">One Go binary. PostgreSQL and a data directory. Deploy anywhere — your infrastructure, your data. Apache 2.0, no artificial limits, no open-core tricks.</p>
-          <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener" class="text-sm font-medium text-slate-400 hover:text-white hover:underline">View on GitHub &rarr;</a>
+          <h3 class="text-lg font-semibold mb-2">{{ t('landing.deploy.selfhost_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed mb-4">{{ t('landing.deploy.selfhost_desc') }}</p>
+          <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener" class="text-sm font-medium text-slate-400 hover:text-white hover:underline">{{ t('landing.deploy.selfhost_cta') }} &rarr;</a> <!-- i18n-ignore: typographic arrow -->
         </div>
       </div>
     </section>
 
     <!-- CTA -->
     <section class="relative z-10 max-w-3xl mx-auto px-8 py-20 text-center">
-      <h2 class="text-4xl font-bold mb-4">Your auditor will thank you</h2>
-      <p class="text-slate-400 mb-8">Full version history. Immutable approval records. Cryptographically verifiable decisions. Complete audit trail from day one.</p>
+      <h2 class="text-4xl font-bold mb-4">{{ t('landing.cta.heading') }}</h2>
+      <p class="text-slate-400 mb-8">{{ t('landing.cta.subtitle') }}</p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
         <router-link v-if="signupEnabled" to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
-          Start in cloud
+          {{ t('landing.hero.cta_cloud') }}
         </router-link>
         <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener"
           class="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-slate-300 bg-slate-800/50 border border-slate-700 rounded-xl hover:bg-slate-800 hover:border-slate-600 transition-all">
-          Self-host
+          {{ t('landing.hero.cta_selfhost') }}
         </a>
       </div>
     </section>
@@ -168,9 +169,12 @@
           <!-- Pre-login, so the choice is local only: there is no account to save
                it against yet. -->
           <LocalePicker :persist="false" compact class="shrink-0" />
-          <span v-if="showPoweredBy">
-            Powered by <a href="https://isms.sh" target="_blank" rel="noopener" class="text-slate-400 hover:text-white transition-colors">isms.sh</a>
-          </span>
+          <i18n-t v-if="showPoweredBy" keypath="landing.footer.powered_by" tag="span" scope="global">
+            <template #link>
+              <!-- i18n-ignore: product domain -->
+              <a href="https://isms.sh" target="_blank" rel="noopener" class="text-slate-400 hover:text-white transition-colors">isms.sh</a>
+            </template>
+          </i18n-t>
         </div>
       </div>
     </footer>
@@ -178,10 +182,13 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import api from '../api'
 import { applyConfigLocales } from '../composables/useLocale'
 import LocalePicker from '../components/LocalePicker.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 // Neutral seed so a self-hosted deployment doesn't flash "isms.sh" in the
 // top-left while /api/v1/config resolves the branded name — same fallback
@@ -193,22 +200,25 @@ const logoError = ref(false)
 const showPoweredBy = ref(true)
 const signupEnabled = ref(false)
 
-const features = [
-  { title: 'Git-native documents', desc: 'Policies are markdown files in a git repo. Every change is a commit with full diff. Branch for review, merge to publish. No proprietary formats, no lock-in.' },
-  { title: 'Round-based review', desc: 'Send a document for review. Reviewers approve, request changes, or propose a revision with inline comments. Resubmit as a new round — reviewers see only what changed.' },
-  { title: 'Registers that connect', desc: 'Risks link to assets and controls. Incidents create corrective actions. Legal requirements link to policies. Change one thing, see the ripple everywhere.' },
-  { title: 'AI suggests, you approve', desc: 'AI agents draft policies, assess risks, and propose register updates through the same review workflow. 22-tool MCP server. Full agent identity and audit trail. Not autopilot — a capable assistant.' },
-  { title: 'Annual plan and cadence', desc: 'Dashboard shows what needs attention this month. Distribute reviews, audits, and risk assessments across the year. Tasks track execution. Your ISMS stays alive.' },
-  { title: 'Auditor-ready from day one', desc: 'Every review approval and document publish creates an immutable decision record with SHA-256 content hash. Timestamped, attributable, cryptographically verifiable.' },
-]
+// computed, not a plain array: the footer carries a LocalePicker, so the locale
+// can change while this page is mounted. A literal array would be built once
+// against the boot locale and never re-render.
+const features = computed(() => [
+  { title: t('landing.features.git_title'), desc: t('landing.features.git_desc') },
+  { title: t('landing.features.review_title'), desc: t('landing.features.review_desc') },
+  { title: t('landing.features.registers_title'), desc: t('landing.features.registers_desc') },
+  { title: t('landing.features.ai_title'), desc: t('landing.features.ai_desc') },
+  { title: t('landing.features.cadence_title'), desc: t('landing.features.cadence_desc') },
+  { title: t('landing.features.audit_title'), desc: t('landing.features.audit_desc') },
+])
 
-const steps = [
-  { title: 'Something happens', desc: 'An incident, a new supplier, a regulation change, an audit finding. Any event that affects your security posture.' },
-  { title: 'Create or update', desc: 'Log it in the right register. AI can suggest risk updates, policy changes, and corrective actions. You review each suggestion.' },
-  { title: 'Documents update on a branch', desc: 'Policy changes land on a review branch with full diff. No mystery edits. Five documents in five minutes.' },
-  { title: 'Review rounds', desc: 'Reviewers get notified. Approve or request changes. After edits, resubmit as a new round. Each round shows only what changed since last feedback.' },
-  { title: 'Publish', desc: 'Merge to main. Version incremented. Decision record created. Evidence stored. Done.' },
-]
+const steps = computed(() => [
+  { title: t('landing.how.step1_title'), desc: t('landing.how.step1_desc') },
+  { title: t('landing.how.step2_title'), desc: t('landing.how.step2_desc') },
+  { title: t('landing.how.step3_title'), desc: t('landing.how.step3_desc') },
+  { title: t('landing.how.step4_title'), desc: t('landing.how.step4_desc') },
+  { title: t('landing.how.step5_title'), desc: t('landing.how.step5_desc') },
+])
 
 const frameworks = [
   'ISO 27001', 'ISO 9001', 'ISO 14001', 'ISO 42001', 'SOC 2',

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -15,13 +15,13 @@
         <span class="text-xl font-bold tracking-tight">{{ brandName }}</span>
       </router-link>
       <div class="flex items-center gap-5">
-        <a href="/docs" class="text-sm text-slate-400 hover:text-white transition-colors">{{ t('landing.nav.docs') }}</a>
+        <a href="/docs" class="text-sm text-slate-400 hover:text-white transition-colors">{{ $t('landing.nav.docs') }}</a>
         <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener" class="text-sm text-slate-400 hover:text-white transition-colors flex items-center gap-1.5">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
           <!-- i18n-ignore: brand name -->
           GitHub
         </a>
-        <router-link to="/login" class="px-5 py-2 text-sm font-medium bg-white/10 hover:bg-white/15 border border-white/10 rounded-lg transition-all hover:border-white/20">{{ t('landing.nav.sign_in') }}</router-link>
+        <router-link to="/login" class="px-5 py-2 text-sm font-medium bg-white/10 hover:bg-white/15 border border-white/10 rounded-lg transition-all hover:border-white/20">{{ $t('landing.nav.sign_in') }}</router-link>
       </div>
     </nav>
 
@@ -29,39 +29,39 @@
     <section class="relative z-10 max-w-5xl mx-auto px-8 pt-20 pb-12 text-center">
       <div class="inline-flex items-center gap-2 px-4 py-1.5 mb-8 text-xs font-medium text-slate-400 bg-slate-800/50 border border-slate-700/50 rounded-full">
         <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse"></span>
-        {{ t('landing.hero.badge') }}
+        {{ $t('landing.hero.badge') }}
       </div>
       <h1 class="text-5xl sm:text-7xl font-extrabold tracking-tight leading-[1.1] mb-6">
-        <span class="bg-gradient-to-r from-white via-white to-slate-400 bg-clip-text text-transparent">{{ t('landing.hero.title_line1') }}</span><br>
-        <span class="hero-accent-gradient bg-clip-text text-transparent">{{ t('landing.hero.title_line2') }}</span>
+        <span class="bg-gradient-to-r from-white via-white to-slate-400 bg-clip-text text-transparent">{{ $t('landing.hero.title_line1') }}</span><br>
+        <span class="hero-accent-gradient bg-clip-text text-transparent">{{ $t('landing.hero.title_line2') }}</span>
       </h1>
       <p class="text-lg sm:text-xl text-slate-400 max-w-2xl mx-auto mb-10 leading-relaxed">
-        {{ t('landing.hero.subtitle') }}
+        {{ $t('landing.hero.subtitle') }}
       </p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
         <router-link v-if="signupEnabled" to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
-          {{ t('landing.hero.cta_cloud') }}
+          {{ $t('landing.hero.cta_cloud') }}
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"/></svg>
         </router-link>
         <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener"
           class="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-slate-300 bg-slate-800/50 border border-slate-700 rounded-xl hover:bg-slate-800 hover:border-slate-600 transition-all">
-          {{ t('landing.hero.cta_selfhost') }}
+          {{ $t('landing.hero.cta_selfhost') }}
         </a>
         <a href="/docs"
           class="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-slate-400 hover:text-slate-200 transition-colors">
-          {{ t('landing.hero.cta_docs') }}
+          {{ $t('landing.hero.cta_docs') }}
         </a>
       </div>
     </section>
 
     <!-- Why — lead with the conviction, not the feature list (#45) -->
     <section class="relative z-10 max-w-3xl mx-auto px-8 pt-8 pb-16">
-      <h2 class="text-3xl font-bold text-center mb-8">{{ t('landing.why.heading') }}</h2>
+      <h2 class="text-3xl font-bold text-center mb-8">{{ $t('landing.why.heading') }}</h2>
       <div class="space-y-5 text-slate-400 leading-relaxed text-lg">
-        <p>{{ t('landing.why.p1') }}</p>
-        <p class="text-slate-200">{{ t('landing.why.p2') }}</p>
-        <p>{{ t('landing.why.p3') }}</p>
+        <p>{{ $t('landing.why.p1') }}</p>
+        <p class="text-slate-200">{{ $t('landing.why.p2') }}</p>
+        <p>{{ $t('landing.why.p3') }}</p>
       </div>
     </section>
 
@@ -72,30 +72,30 @@
           <div class="w-12 h-12 rounded-xl bg-emerald-500/10 flex items-center justify-center mx-auto mb-4">
             <svg class="w-6 h-6 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg>
           </div>
-          <h3 class="text-lg font-semibold mb-2">{{ t('landing.pillars.documents_title') }}</h3>
-          <p class="text-sm text-slate-400 leading-relaxed">{{ t('landing.pillars.documents_desc') }}</p>
+          <h3 class="text-lg font-semibold mb-2">{{ $t('landing.pillars.documents_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed">{{ $t('landing.pillars.documents_desc') }}</p>
         </div>
         <div class="text-center">
           <div class="w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center mx-auto mb-4">
             <svg class="w-6 h-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.745 3.745 0 011.043 3.296A3.745 3.745 0 0121 12z" /></svg>
           </div>
-          <h3 class="text-lg font-semibold mb-2">{{ t('landing.pillars.reviews_title') }}</h3>
-          <p class="text-sm text-slate-400 leading-relaxed">{{ t('landing.pillars.reviews_desc') }}</p>
+          <h3 class="text-lg font-semibold mb-2">{{ $t('landing.pillars.reviews_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed">{{ $t('landing.pillars.reviews_desc') }}</p>
         </div>
         <div class="text-center">
           <div class="w-12 h-12 rounded-xl bg-amber-500/10 flex items-center justify-center mx-auto mb-4">
             <svg class="w-6 h-6 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" /></svg>
           </div>
-          <h3 class="text-lg font-semibold mb-2">{{ t('landing.pillars.tasks_title') }}</h3>
-          <p class="text-sm text-slate-400 leading-relaxed">{{ t('landing.pillars.tasks_desc') }}</p>
+          <h3 class="text-lg font-semibold mb-2">{{ $t('landing.pillars.tasks_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed">{{ $t('landing.pillars.tasks_desc') }}</p>
         </div>
       </div>
     </section>
 
     <!-- How it works -->
     <section class="relative z-10 max-w-4xl mx-auto px-8 py-16">
-      <h2 class="text-3xl font-bold text-center mb-4">{{ t('landing.how.heading') }}</h2>
-      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">{{ t('landing.how.subtitle') }}</p>
+      <h2 class="text-3xl font-bold text-center mb-4">{{ $t('landing.how.heading') }}</h2>
+      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">{{ $t('landing.how.subtitle') }}</p>
       <div class="space-y-4">
         <div v-for="(step, i) in steps" :key="i" class="flex gap-4 items-start p-5 bg-slate-900/30 border border-slate-800/30 rounded-xl">
           <div class="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-sm font-bold text-white" style="background-color: var(--brand-color)">{{ i + 1 }}</div>
@@ -109,8 +109,8 @@
 
     <!-- Features: why isms.sh -->
     <section class="relative z-10 max-w-6xl mx-auto px-8 py-16">
-      <h2 class="text-3xl font-bold text-center mb-4">{{ t('landing.features.heading') }}</h2>
-      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">{{ t('landing.features.subtitle') }}</p>
+      <h2 class="text-3xl font-bold text-center mb-4">{{ $t('landing.features.heading') }}</h2>
+      <p class="text-slate-400 text-center mb-12 max-w-2xl mx-auto">{{ $t('landing.features.subtitle') }}</p>
       <div class="grid md:grid-cols-2 gap-6">
         <div v-for="f in features" :key="f.title" class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl backdrop-blur-sm hover:border-slate-700/50 transition-colors">
           <h3 class="text-base font-semibold mb-2">{{ f.title }}</h3>
@@ -121,8 +121,8 @@
 
     <!-- Frameworks -->
     <section class="relative z-10 max-w-4xl mx-auto px-8 py-16 text-center">
-      <h2 class="text-3xl font-bold mb-4">{{ t('landing.frameworks.heading') }}</h2>
-      <p class="text-slate-400 mb-10 max-w-2xl mx-auto">{{ t('landing.frameworks.subtitle') }}</p>
+      <h2 class="text-3xl font-bold mb-4">{{ $t('landing.frameworks.heading') }}</h2>
+      <p class="text-slate-400 mb-10 max-w-2xl mx-auto">{{ $t('landing.frameworks.subtitle') }}</p>
       <div class="flex flex-wrap justify-center gap-3">
         <span v-for="fw in frameworks" :key="fw" class="px-4 py-2 bg-slate-800/50 border border-slate-700/50 rounded-lg text-sm text-slate-300">{{ fw }}</span>
       </div>
@@ -132,31 +132,31 @@
     <section class="relative z-10 max-w-4xl mx-auto px-8 py-16">
       <div class="grid md:grid-cols-2 gap-6">
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
-          <h3 class="text-lg font-semibold mb-2">{{ t('landing.deploy.cloud_title') }}</h3>
-          <p class="text-sm text-slate-400 leading-relaxed mb-4">{{ t('landing.deploy.cloud_desc') }}</p>
-          <router-link v-if="signupEnabled" to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">{{ t('landing.deploy.cloud_cta') }} &rarr;</router-link> <!-- i18n-ignore: typographic arrow -->
-          <router-link v-else to="/login" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">{{ t('landing.deploy.cloud_cta_signin') }} &rarr;</router-link> <!-- i18n-ignore: typographic arrow -->
+          <h3 class="text-lg font-semibold mb-2">{{ $t('landing.deploy.cloud_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed mb-4">{{ $t('landing.deploy.cloud_desc') }}</p>
+          <router-link v-if="signupEnabled" to="/signup" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">{{ $t('landing.deploy.cloud_cta') }} &rarr;</router-link> <!-- i18n-ignore: typographic arrow -->
+          <router-link v-else to="/login" class="text-sm font-medium hover:underline" style="color: var(--brand-color)">{{ $t('landing.deploy.cloud_cta_signin') }} &rarr;</router-link> <!-- i18n-ignore: typographic arrow -->
         </div>
         <div class="p-6 bg-slate-900/50 border border-slate-800/50 rounded-2xl">
-          <h3 class="text-lg font-semibold mb-2">{{ t('landing.deploy.selfhost_title') }}</h3>
-          <p class="text-sm text-slate-400 leading-relaxed mb-4">{{ t('landing.deploy.selfhost_desc') }}</p>
-          <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener" class="text-sm font-medium text-slate-400 hover:text-white hover:underline">{{ t('landing.deploy.selfhost_cta') }} &rarr;</a> <!-- i18n-ignore: typographic arrow -->
+          <h3 class="text-lg font-semibold mb-2">{{ $t('landing.deploy.selfhost_title') }}</h3>
+          <p class="text-sm text-slate-400 leading-relaxed mb-4">{{ $t('landing.deploy.selfhost_desc') }}</p>
+          <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener" class="text-sm font-medium text-slate-400 hover:text-white hover:underline">{{ $t('landing.deploy.selfhost_cta') }} &rarr;</a> <!-- i18n-ignore: typographic arrow -->
         </div>
       </div>
     </section>
 
     <!-- CTA -->
     <section class="relative z-10 max-w-3xl mx-auto px-8 py-20 text-center">
-      <h2 class="text-4xl font-bold mb-4">{{ t('landing.cta.heading') }}</h2>
-      <p class="text-slate-400 mb-8">{{ t('landing.cta.subtitle') }}</p>
+      <h2 class="text-4xl font-bold mb-4">{{ $t('landing.cta.heading') }}</h2>
+      <p class="text-slate-400 mb-8">{{ $t('landing.cta.subtitle') }}</p>
       <div class="flex items-center justify-center gap-4 flex-wrap">
         <router-link v-if="signupEnabled" to="/signup"
           class="brand-cta-btn inline-flex items-center gap-2 px-7 py-3 text-white font-semibold rounded-xl transition-all hover:-translate-y-0.5">
-          {{ t('landing.hero.cta_cloud') }}
+          {{ $t('landing.hero.cta_cloud') }}
         </router-link>
         <a href="https://github.com/unidoc/isms" target="_blank" rel="noopener"
           class="inline-flex items-center gap-2 px-6 py-3 text-sm font-medium text-slate-300 bg-slate-800/50 border border-slate-700 rounded-xl hover:bg-slate-800 hover:border-slate-600 transition-all">
-          {{ t('landing.hero.cta_selfhost') }}
+          {{ $t('landing.hero.cta_selfhost') }}
         </a>
       </div>
     </section>

--- a/web/src/views/Landing.vue
+++ b/web/src/views/Landing.vue
@@ -193,7 +193,7 @@ const { t } = useI18n()
 // Neutral seed so a self-hosted deployment doesn't flash "isms.sh" in the
 // top-left while /api/v1/config resolves the branded name — same fallback
 // App.vue's sidebar already uses for orgName.
-const brandName = ref('ISMS')
+const brandName = ref(t('common.brand.product_name'))
 const brandFooter = ref('')
 const logoUrl = ref(null)
 const logoError = ref(false)

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -11,7 +11,7 @@
             </svg>
           </div>
         </router-link>
-        <h1 class="text-xl font-bold text-white mb-1">{{ $t('auth.sign_in_to', { org: $t('auth.product_name') }) }}</h1>
+        <h1 class="text-xl font-bold text-white mb-1">{{ $t('auth.sign_in_to', { org: $t('common.brand.product_name') }) }}</h1>
         <p class="text-sm text-slate-500 mb-6">{{ $t('auth.org_discovery.subtitle') }}</p>
         <form @submit.prevent="goToOrg" class="space-y-3">
           <input
@@ -49,7 +49,7 @@
             </svg>
           </div>
         </router-link>
-        <h1 class="text-xl font-bold text-white">{{ $t('auth.sign_in_to', { org: orgName || $t('auth.product_name') }) }}</h1>
+        <h1 class="text-xl font-bold text-white">{{ $t('auth.sign_in_to', { org: orgName || $t('common.brand.product_name') }) }}</h1>
         <p v-if="orgSlug" class="text-sm text-slate-500 mt-1">{{ orgSlug }}</p>
       </div>
 
@@ -204,11 +204,11 @@
       </div>
     </div>
     <div class="fixed bottom-4 left-0 right-0 text-center text-xs text-slate-600">
-      <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('auth.footer.privacy') }}</a>
+      <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.privacy') }}</a>
       <span v-if="termsUrl && privacyUrl" class="mx-2">&middot;</span> <!-- i18n-ignore: typographic separator -->
-      <a v-if="termsUrl" :href="termsUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('auth.footer.terms') }}</a>
+      <a v-if="termsUrl" :href="termsUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.terms') }}</a>
       <span v-if="showPoweredBy && (termsUrl || privacyUrl)" class="mx-2">&middot;</span> <!-- i18n-ignore: typographic separator -->
-      <a v-if="showPoweredBy" href="https://isms.sh" target="_blank" rel="noopener" class="hover:text-slate-400 transition-colors">{{ $t('auth.footer.powered_by') }}</a>
+      <a v-if="showPoweredBy" href="https://isms.sh" target="_blank" rel="noopener" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.powered_by') }}</a>
     </div>
   </div>
 </template>

--- a/web/src/views/Organizations.vue
+++ b/web/src/views/Organizations.vue
@@ -8,11 +8,11 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
           </svg>
         </div>
-        <h1 class="text-2xl font-bold text-white">Your organizations</h1>
+        <h1 class="text-2xl font-bold text-white">{{ t('organizations.title') }}</h1>
       </div>
 
       <!-- Loading -->
-      <div v-if="loading" class="text-center text-slate-500 text-sm py-8">Loading...</div>
+      <div v-if="loading" class="text-center text-slate-500 text-sm py-8">{{ t('common.state.loading') }}</div>
 
       <!-- Org list -->
       <div v-else>
@@ -26,7 +26,7 @@
             <div class="flex items-center gap-3">
               <span class="text-[10px] px-2 py-0.5 rounded-full font-medium"
                 :class="org.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : org.role === 'manager' ? 'bg-blue-500/20 text-blue-300' : 'bg-slate-500/20 text-slate-400'">
-                {{ org.role }}
+                {{ roleLabel(org.role) }}
               </span>
               <svg class="w-4 h-4 text-slate-600 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
@@ -36,7 +36,7 @@
         </div>
 
         <div v-else class="text-center py-8 mb-6">
-          <p class="text-slate-400 text-sm">You're not a member of any organization yet.</p>
+          <p class="text-slate-400 text-sm">{{ t('organizations.empty') }}</p>
         </div>
 
         <!-- Create new -->
@@ -44,43 +44,43 @@
           <button @click="showCreate = true"
             class="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-xl transition-colors">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
-            Create organization
+            {{ t('organizations.create') }}
           </button>
         </div>
 
         <!-- Create form -->
         <form v-else @submit.prevent="createOrg" class="bg-slate-900 border border-slate-800 rounded-xl p-5 space-y-3">
-          <h3 class="text-sm font-semibold text-white mb-3">New organization</h3>
+          <h3 class="text-sm font-semibold text-white mb-3">{{ t('organizations.form.title') }}</h3>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Name</label>
-            <input v-model="newOrg.name" @input="onNameInput" type="text" placeholder="Acme Corp" required autofocus
+            <label class="block text-xs text-slate-500 mb-1">{{ t('organizations.form.name_label') }}</label>
+            <input v-model="newOrg.name" @input="onNameInput" type="text" :placeholder="t('organizations.form.name_placeholder')" required autofocus
               class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500" />
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">URL slug</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('organizations.form.slug_label') }}</label>
             <div class="flex items-center">
               <span class="px-3 py-2 bg-slate-950 border border-r-0 border-slate-700 rounded-l-lg text-sm text-slate-500">{{ baseDomain }}/</span>
-              <input v-model="newOrg.slug" @input="onSlugInput" type="text" placeholder="acme" required
+              <input v-model="newOrg.slug" @input="onSlugInput" type="text" :placeholder="t('organizations.form.slug_placeholder')" required
                 class="flex-1 px-3 py-2 bg-slate-800 border border-slate-700 rounded-r-lg text-sm text-white focus:outline-none focus:border-blue-500" />
             </div>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Template (optional)</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('organizations.form.template_label') }}</label>
             <select v-model="newOrg.template"
               class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500">
-              <option value="">None — I'll set up documents manually</option>
-              <option value="iso27001">ISO 27001 — full document set</option>
-              <option value="soc2">SOC 2 — Trust Services Criteria</option>
-              <option value="nis2">NIS2 — EU directive requirements</option>
+              <option value="">{{ t('organizations.form.template_none') }}</option>
+              <option value="iso27001">{{ t('organizations.form.template_iso27001') }}</option>
+              <option value="soc2">{{ t('organizations.form.template_soc2') }}</option>
+              <option value="nis2">{{ t('organizations.form.template_nis2') }}</option>
             </select>
-            <div class="text-[10px] text-slate-600 mt-1">Scaffolds document templates in git. Can add more templates later.</div>
+            <div class="text-[10px] text-slate-600 mt-1">{{ t('organizations.form.template_hint') }}</div>
           </div>
           <div class="flex gap-2 pt-1">
             <button type="submit" :disabled="creating || !newOrg.name.trim() || !newOrg.slug.trim()"
               class="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50">
-              {{ creating ? 'Creating...' : 'Create' }}
+              {{ creating ? t('organizations.form.creating') : t('common.action.create') }}
             </button>
-            <button type="button" @click="showCreate = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">Cancel</button>
+            <button type="button" @click="showCreate = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">{{ t('common.action.cancel') }}</button>
           </div>
           <div v-if="error" class="text-xs text-red-400">{{ error }}</div>
         </form>
@@ -95,6 +95,16 @@ import { useRouter } from 'vue-router'
 import api, { setApiToken } from '../api'
 import { orgEntryURL, ensureConfigLoaded } from '../composables/useCurrentOrg'
 import { useSession } from '../composables/useSession'
+import { useI18n } from 'vue-i18n'
+import { enumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
+
+const { t } = useI18n()
+
+// Wrapped rather than called inline: the enum group name is a literal, and the
+// raw-text scanner reads templates only, so keeping it in script keeps the
+// template free of string literals that look like copy.
+const roleLabel = (role) => enumLabel('role', role)
 
 const router = useRouter()
 
@@ -173,7 +183,7 @@ async function createOrg() {
       showCreate.value = false
     }
   } catch (e) {
-    error.value = e.message || 'Failed to create organization'
+    error.value = renderApiError(e) || t('organizations.form.error_create')
   } finally {
     creating.value = false
   }

--- a/web/src/views/Organizations.vue
+++ b/web/src/views/Organizations.vue
@@ -8,11 +8,11 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
           </svg>
         </div>
-        <h1 class="text-2xl font-bold text-white">{{ t('organizations.title') }}</h1>
+        <h1 class="text-2xl font-bold text-white">{{ $t('organizations.title') }}</h1>
       </div>
 
       <!-- Loading -->
-      <div v-if="loading" class="text-center text-slate-500 text-sm py-8">{{ t('common.state.loading') }}</div>
+      <div v-if="loading" class="text-center text-slate-500 text-sm py-8">{{ $t('common.state.loading') }}</div>
 
       <!-- Org list -->
       <div v-else>
@@ -36,7 +36,7 @@
         </div>
 
         <div v-else class="text-center py-8 mb-6">
-          <p class="text-slate-400 text-sm">{{ t('organizations.empty') }}</p>
+          <p class="text-slate-400 text-sm">{{ $t('organizations.empty') }}</p>
         </div>
 
         <!-- Create new -->
@@ -44,43 +44,43 @@
           <button @click="showCreate = true"
             class="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-xl transition-colors">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
-            {{ t('organizations.create') }}
+            {{ $t('organizations.create') }}
           </button>
         </div>
 
         <!-- Create form -->
         <form v-else @submit.prevent="createOrg" class="bg-slate-900 border border-slate-800 rounded-xl p-5 space-y-3">
-          <h3 class="text-sm font-semibold text-white mb-3">{{ t('organizations.form.title') }}</h3>
+          <h3 class="text-sm font-semibold text-white mb-3">{{ $t('organizations.form.title') }}</h3>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">{{ t('organizations.form.name_label') }}</label>
-            <input v-model="newOrg.name" @input="onNameInput" type="text" :placeholder="t('organizations.form.name_placeholder')" required autofocus
+            <label class="block text-xs text-slate-500 mb-1">{{ $t('organizations.form.name_label') }}</label>
+            <input v-model="newOrg.name" @input="onNameInput" type="text" :placeholder="$t('organizations.form.name_placeholder')" required autofocus
               class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500" />
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">{{ t('organizations.form.slug_label') }}</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ $t('organizations.form.slug_label') }}</label>
             <div class="flex items-center">
               <span class="px-3 py-2 bg-slate-950 border border-r-0 border-slate-700 rounded-l-lg text-sm text-slate-500">{{ baseDomain }}/</span>
-              <input v-model="newOrg.slug" @input="onSlugInput" type="text" :placeholder="t('organizations.form.slug_placeholder')" required
+              <input v-model="newOrg.slug" @input="onSlugInput" type="text" :placeholder="$t('organizations.form.slug_placeholder')" required
                 class="flex-1 px-3 py-2 bg-slate-800 border border-slate-700 rounded-r-lg text-sm text-white focus:outline-none focus:border-blue-500" />
             </div>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">{{ t('organizations.form.template_label') }}</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ $t('organizations.form.template_label') }}</label>
             <select v-model="newOrg.template"
               class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500">
-              <option value="">{{ t('organizations.form.template_none') }}</option>
-              <option value="iso27001">{{ t('organizations.form.template_iso27001') }}</option>
-              <option value="soc2">{{ t('organizations.form.template_soc2') }}</option>
-              <option value="nis2">{{ t('organizations.form.template_nis2') }}</option>
+              <option value="">{{ $t('organizations.form.template_none') }}</option>
+              <option value="iso27001">{{ $t('organizations.form.template_iso27001') }}</option>
+              <option value="soc2">{{ $t('organizations.form.template_soc2') }}</option>
+              <option value="nis2">{{ $t('organizations.form.template_nis2') }}</option>
             </select>
-            <div class="text-[10px] text-slate-600 mt-1">{{ t('organizations.form.template_hint') }}</div>
+            <div class="text-[10px] text-slate-600 mt-1">{{ $t('organizations.form.template_hint') }}</div>
           </div>
           <div class="flex gap-2 pt-1">
             <button type="submit" :disabled="creating || !newOrg.name.trim() || !newOrg.slug.trim()"
               class="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50">
-              {{ creating ? t('organizations.form.creating') : t('common.action.create') }}
+              {{ creating ? $t('organizations.form.creating') : $t('common.action.create') }}
             </button>
-            <button type="button" @click="showCreate = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">{{ t('common.action.cancel') }}</button>
+            <button type="button" @click="showCreate = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">{{ $t('common.action.cancel') }}</button>
           </div>
           <div v-if="error" class="text-xs text-red-400">{{ error }}</div>
         </form>

--- a/web/src/views/Signup.vue
+++ b/web/src/views/Signup.vue
@@ -12,7 +12,7 @@
           </div>
         </router-link>
         <h1 class="text-xl font-bold text-white">{{ $t('auth.signup.title') }}</h1>
-        <p class="text-sm text-slate-500 mt-1">{{ $t('auth.signup.join', { org: orgName || $t('auth.product_name') }) }}</p>
+        <p class="text-sm text-slate-500 mt-1">{{ $t('auth.signup.join', { org: orgName || $t('common.brand.product_name') }) }}</p>
       </div>
 
       <!-- Success state -->
@@ -49,11 +49,11 @@
       </form>
     </div>
     <div class="fixed bottom-4 left-0 right-0 text-center text-xs text-slate-600">
-      <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('auth.footer.privacy') }}</a>
+      <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.privacy') }}</a>
       <span v-if="termsUrl && privacyUrl" class="mx-2">&middot;</span> <!-- i18n-ignore: typographic separator -->
-      <a v-if="termsUrl" :href="termsUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('auth.footer.terms') }}</a>
+      <a v-if="termsUrl" :href="termsUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.terms') }}</a>
       <span v-if="showPoweredBy && (termsUrl || privacyUrl)" class="mx-2">&middot;</span> <!-- i18n-ignore: typographic separator -->
-      <a v-if="showPoweredBy" href="https://isms.sh" target="_blank" rel="noopener" class="hover:text-slate-400 transition-colors">{{ $t('auth.footer.powered_by') }}</a>
+      <a v-if="showPoweredBy" href="https://isms.sh" target="_blank" rel="noopener" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.powered_by') }}</a>
     </div>
   </div>
 </template>

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -17,7 +17,6 @@
   "views/Incidents.vue": 9,
   "views/Legal.vue": 6,
   "views/Objectives.vue": 12,
-  "views/Organizations.vue": 1,
   "views/Programs.vue": 5,
   "views/Reviews.vue": 12,
   "views/Risks.vue": 9,

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,5 +1,4 @@
 {
-  "App.vue": 63,
   "components/CodeBlockView.vue": 4,
   "components/ColorPicker.vue": 2,
   "components/CommentSidebar.vue": 14,

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -38,7 +38,6 @@
   "views/Landing.vue": 39,
   "views/Legal.vue": 90,
   "views/Objectives.vue": 98,
-  "views/Organizations.vue": 18,
   "views/Programs.vue": 36,
   "views/Reviews.vue": 146,
   "views/Risks.vue": 167,

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -35,7 +35,6 @@
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
   "views/Incidents.vue": 120,
-  "views/Landing.vue": 39,
   "views/Legal.vue": 90,
   "views/Objectives.vue": 98,
   "views/Programs.vue": 36,


### PR DESCRIPTION
## What this does

Continues making the web UI translatable. Three screens move from hardcoded English to the translation catalogue: the **application shell** (the sidebar, header and footer that wrap every signed-in page), the **public landing page**, and the **organizations picker** a new cloud user lands on after verifying their email.

Before this, a reader on another language would have seen a translated page inside an untranslated frame. Nothing changes for an English reader.

Progress on the overall effort: 2415 untranslated strings remaining before, 2295 after. All 120 in these three screens are now done.

## ⚠️ Please merge with a merge commit, not a squash

Each screen is its own commit. Squashing collapses them into one, which loses the ability to revert a single screen if something turns out wrong, and makes `git blame` point at the batch instead of the screen. Same request as #254.

## A real bug this found

The landing page builds its six feature cards and five workflow steps from a list in code. That list was built once when the page loaded, **before** the language had been decided — so with a non-English language active, the page headings translated correctly while those eleven items silently stayed in English.

This is the kind of failure that no automated check can catch: every string exists, every lookup succeeds, the tests pass. I confirmed it by putting the bug back and watching it happen in a browser, then confirmed the fix the same way.

Worth flagging because the same pattern (a list of display text built in code) appears throughout the screens still to be converted, so it is now on the checklist.

## Visible changes for an English reader

Three, all cosmetic, all intentional:

- `Loading...` → `Loading…` and `Creating...` → `Creating…` — these now use the shared wording the rest of the app already uses.
- Role badges read **Admin** instead of **admin**. They were printing the raw database value, which is why they were lower-case; they now go through the same shared list every other status label uses. This was visible in four places across two screens.

## Also in here

- **Deleted dead code.** The shell carried a hidden list of 17 navigation labels that nothing has displayed since the sidebar became fixed markup. Converting it would have added 17 entries to the catalogue that nothing can ever show.
- **Moved shared wording to the shared file.** The legal footer and the product name were filed under "login screens" because those screens needed them first. The shell and landing page show the same footer, so they now live in the shared file. Done now specifically because it is free today and stops being free the moment an outside contributor starts translating — renaming an entry invalidates their in-flight work. This is why two login screens appear in the diff.
- **Fixed a label that could have desynced.** The copy button on code blocks reset its own text to a hardcoded "Copy" that has to match what a different file wrote. It now restores whatever that file actually put there, so translating the two independently can't leave the button flipping between languages.
- Settled a small consistency question (which of two equivalent ways to look up a translation to use in page markup) while it affects 6 screens rather than 26. This is the `style` commit.

## Not fixed here, found while testing

Creating an organization with a name already in use returns a **500** with the raw database error text (`duplicate key value violates unique constraint …`) shown to the browser. It should be a 409 with a friendly message, and it leaks a schema detail. Pre-existing, unrelated to this change, and it deserves its own issue — noting it so it isn't lost.

## What was checked in a real browser

Automated checks cannot see a screen that renders in the wrong language, so each screen was loaded against a running server and compared against the original text.

| Screenshot | What it confirms |
|---|---|
| 1 — landing hero | Headline, badge, subtitle, all three calls to action |
| 2 — landing pillars and steps | The eleven items that were previously stuck in one language |
| 3 — shell sidebar | All 20 navigation labels and both section headings |
| 4 — organization switcher | The switcher rows, plus the corrected role badge |
| 5 — organizations create form | Every field, both placeholders, all four template options |

Also checked, not pictured: all 18 sidebar tooltips in collapsed mode, the notification panel, the user menu, the shell footer, the live language switch through the landing page's language picker (in both directions), and the error message shown when creating an organization fails.

## Verification

- `npm test` — 148 pass
- `npm run build`
- Both automated string checks report zero remaining for all three screens
- Every entry added to the catalogue is actually used, and every lookup in the code resolves to a real entry (219 checked)
- `tests/test_e2e_routing.py` still passes: it looks for the text "Switch organization", and English output is unchanged

## Notes for review

No Indonesian counterparts were added for the new entries. A missing entry falls back to English by design, and that language is switched off for the next release. Flagging it because two earlier changes did add them — happy to fill in the ~9 values if you would rather keep them in step.

Relates to #212. Frontend only; no schema or migration.