### PR TITLE
feat(i18n): extract the six register views (#212)

### DIFF
--- a/internal/isms/i18n/release_gate_test.go
+++ b/internal/isms/i18n/release_gate_test.go
@@ -18,11 +18,12 @@ const rawTextBaseline = "../../../web/test/rawText.baseline.json"
 // punctuation, and attribute values it cannot distinguish from copy — so a
 // fully extracted tree still carries a residue, and 100 is an estimate of it.
 //
-// For scale: that is about 25x below where the tree sits today (2415) and about
-// 25x below where it started (2488). Those two numbers are nearly identical,
-// which is the honest summary of how far extraction has got. The estimate wants
-// revisiting once a mostly-extracted tree shows what the residue actually is —
-// the threshold is a judgement, and says so. The coupling it enforces is not.
+// For scale: the tree started at 2488 and sits at 1075 now that the auth,
+// shell, component, admin and register surfaces are extracted — so roughly 10x
+// above the threshold, with the workflow and document views left. The estimate
+// still wants revisiting once a fully extracted tree shows what the residue
+// actually is; the threshold is a judgement, and says so. The coupling it
+// enforces is not.
 const extractionGateThreshold = 100
 
 // TestSecondLocaleRequiresExtraction is a release gate, not a unit test.

--- a/web/src/locales/en/assets.json
+++ b/web/src/locales/en/assets.json
@@ -1,0 +1,76 @@
+{
+  "title": "Asset Register",
+  "subtitle": "Information assets, classification, and ownership",
+  "error": {
+    "save": "Failed to save: {message}",
+    "create": "Failed to create asset: {message}",
+    "delete": "Failed to delete: {message}"
+  },
+  "action": {
+    "add": "Add Asset"
+  },
+  "create": {
+    "heading": "Add Asset",
+    "name_label": "Name *",
+    "name_placeholder": "e.g. Production Database, Customer Portal",
+    "type_label": "Type",
+    "deselect_hint": "Click to deselect",
+    "fill_in_later": "You can add CIA classification, owner, and more after creating.",
+    "submit": "Add"
+  },
+  "filter": {
+    "empty": "No assets found"
+  },
+  "stat": {
+    "severe": "Severe (CIA = 5)"
+  },
+  "table": {
+    "header": {
+      "asset": "Asset",
+      "type": "Type",
+      "cia": "C/I/A",
+      "status": "Status",
+      "owner": "Owner"
+    },
+    "cia_title": {
+      "confidentiality": "Confidentiality: {level}",
+      "integrity": "Integrity: {level}",
+      "availability": "Availability: {level}"
+    }
+  },
+  "field": {
+    "name": "Name",
+    "description": "Description",
+    "type": "Type",
+    "status": "Status",
+    "owner": "Owner",
+    "primary_location": "Primary Location",
+    "next_review": "Next Review",
+    "created": "Created",
+    "created_by": "Created by"
+  },
+  "placeholder": {
+    "description": "Describe the asset...",
+    "primary_location": "e.g. Reykjavík DC, AWS eu-west-1",
+    "notes": "Additional notes... Type /doc to link a document"
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes"
+  },
+  "assessment": {
+    "confidentiality": "Confidentiality",
+    "integrity": "Integrity",
+    "availability": "Availability"
+  },
+  "danger": {
+    "warning": "Deleting this asset is permanent and cannot be undone. History, comments, and linked references will be lost.",
+    "delete": "Delete asset",
+    "confirm": "Delete this asset? This cannot be undone."
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
+  }
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -232,6 +232,75 @@
       "read-write": "Read & Write",
       "read": "Read only",
       "write": "Write only"
+    },
+    "treatment": {
+      "mitigate": "Mitigate",
+      "accept": "Accept",
+      "transfer": "Transfer",
+      "avoid": "Avoid"
+    },
+    "risk_type": {
+      "threat": "Threat",
+      "opportunity": "Opportunity"
+    },
+    "origin": {
+      "internal": "Internal",
+      "external": "External",
+      "internal and external": "Internal & external"
+    },
+    "incident_type": {
+      "incident": "Incident",
+      "event": "Event",
+      "weakness": "Weakness"
+    },
+    "gdpr_role": {
+      "controller": "Controller",
+      "processor": "Processor"
+    },
+    "notification_status": {
+      "not_required": "Not required",
+      "pending": "Pending",
+      "notified": "Notified"
+    },
+    "supplier_type": {
+      "cloud": "Cloud",
+      "saas": "SaaS",
+      "consulting": "Consulting",
+      "hosting": "Hosting",
+      "infrastructure": "Infrastructure",
+      "software": "Software",
+      "contractor": "Contractor",
+      "other": "Other"
+    },
+    "asset_type": {
+      "infrastructure": "Infrastructure",
+      "processing_devices": "Processing devices",
+      "software": "Software",
+      "system": "System",
+      "network": "Network",
+      "service": "Service",
+      "financial_info": "Financial info",
+      "personal_data": "Personal data",
+      "ipr": "Intellectual property",
+      "sales_marketing": "Sales & marketing",
+      "processing_facility": "Processing facility",
+      "products_services": "Products & services",
+      "supply_chain": "Supply chain",
+      "other": "Other"
+    },
+    "legal_category": {
+      "privacy": "Privacy",
+      "security": "Security",
+      "sector": "Sector",
+      "contractual": "Contractual",
+      "other": "Other",
+      "data_protection": "Data protection",
+      "employment": "Employment law",
+      "regulatory": "Regulatory compliance",
+      "intellectual_property": "Intellectual property",
+      "financial": "Financial regulation",
+      "environmental": "Environmental",
+      "corporate": "Corporate governance"
     }
   },
   "enum_inline": {
@@ -319,5 +388,31 @@
   },
   "placeholder": {
     "search": "Search..."
+  },
+  "tab": {
+    "overview": "Overview",
+    "treatment": "Treatment",
+    "assessment": "Assessment",
+    "notes": "Notes",
+    "links": "Links",
+    "actions": "Actions",
+    "suggestions": "Suggestions",
+    "comments": "Comments",
+    "history": "History"
+  },
+  "filter": {
+    "all_statuses": "All statuses",
+    "all_types": "All types",
+    "all_levels": "All levels",
+    "all_criticality": "All criticality",
+    "all_categories": "All categories",
+    "all_severities": "All severities"
+  },
+  "option": {
+    "none": "None",
+    "not_decided": "Not decided"
+  },
+  "stat": {
+    "total": "Total"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -433,6 +433,11 @@
     "next": "Next review: {date}",
     "overdue_since": "Review overdue since {date}"
   },
+  "cia_abbr": {
+    "c": "C",
+    "i": "I",
+    "a": "A"
+  },
   "cia": {
     "not_assessed": "Not assessed",
     "insignificant": "Insignificant",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -29,6 +29,7 @@
     "outdated_inline": "outdated",
     "resolved": "Resolved",
     "copied": "Copied",
+    "saved": "Saved",
     "overdue": "OVERDUE",
     "no_notes": "No notes yet."
   },

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -13,6 +13,7 @@
     "delete": "Delete",
     "copy": "Copy",
     "search": "Search",
+    "clear": "Clear",
     "add_comment": "Add comment",
     "comment": "Comment",
     "reply": "Reply",
@@ -27,7 +28,9 @@
     "outdated": "Outdated",
     "outdated_inline": "outdated",
     "resolved": "Resolved",
-    "copied": "Copied"
+    "copied": "Copied",
+    "overdue": "OVERDUE",
+    "no_notes": "No notes yet."
   },
   "validation": {
     "required": "This field is required"
@@ -383,11 +386,13 @@
     "powered_by": "Powered by isms.sh"
   },
   "count": {
+    "total": "{count} total",
     "comments": "{count} comment | {count} comments",
     "outdated_comments": "{count} outdated comment | {count} outdated comments"
   },
   "placeholder": {
-    "search": "Search..."
+    "search": "Search...",
+    "select_owner": "Select owner..."
   },
   "tab": {
     "overview": "Overview",
@@ -414,5 +419,26 @@
   },
   "stat": {
     "total": "Total"
+  },
+  "heading": {
+    "quick_actions": "Quick actions",
+    "danger_zone": "Danger zone"
+  },
+  "read_only": {
+    "actions": "Read-only — actions require manager or admin role."
+  },
+  "review": {
+    "last": "Last review: {date}",
+    "next": "Next review: {date}",
+    "overdue_since": "Review overdue since {date}"
+  },
+  "cia": {
+    "not_assessed": "Not assessed",
+    "insignificant": "Insignificant",
+    "minor": "Minor",
+    "moderate": "Moderate",
+    "major": "Major",
+    "severe": "Severe",
+    "na": "N/A"
   }
 }

--- a/web/src/locales/en/incidents.json
+++ b/web/src/locales/en/incidents.json
@@ -1,0 +1,98 @@
+{
+  "title": "Incident Management",
+  "subtitle": "Track, respond to, and learn from security incidents",
+  "error": {
+    "create": "Failed to create incident: {message}",
+    "save": "Failed to save: {message}",
+    "delete": "Failed to delete incident: {message}"
+  },
+  "action": {
+    "add": "Add Incident"
+  },
+  "create": {
+    "heading": "Add Incident",
+    "title_label": "Title *",
+    "title_placeholder": "Brief incident title",
+    "severity_label": "Severity",
+    "type_label": "Type",
+    "fill_in_later": "You can add description, classification, origin, assignee, GDPR details and notes after creating.",
+    "submit": "Add"
+  },
+  "filter": {
+    "empty": "No incidents found"
+  },
+  "list": {
+    "source": "Source: {value}",
+    "reporter": "Reporter: {name}",
+    "assignee": "Assignee: {name}"
+  },
+  "cia_abbr": {
+    "c": "C",
+    "i": "I",
+    "a": "A"
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "severity": "Severity",
+    "type": "Type",
+    "origin": "Origin",
+    "classification": "Classification",
+    "status": "Status",
+    "assignee": "Assignee",
+    "reporter": "Reporter",
+    "root_cause": "Root Cause",
+    "lessons_learned": "Lessons Learned",
+    "created": "Created",
+    "created_by": "Created by"
+  },
+  "placeholder": {
+    "description": "Describe the incident...",
+    "root_cause": "Root cause analysis...",
+    "lessons_learned": "What can we improve?",
+    "assignee": "Select assignee...",
+    "notes": "Add notes..."
+  },
+  "classification": {
+    "confidentiality": "Confidentiality",
+    "integrity": "Integrity",
+    "availability": "Availability"
+  },
+  "data_breach_checkbox": "This is a personal data breach (GDPR)",
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes"
+  },
+  "tab": {
+    "data_breach": "Data Breach"
+  },
+  "timeline": {
+    "heading": "Timeline",
+    "detected": "Detected:",
+    "contained": "Contained:",
+    "resolved": "Resolved:",
+    "closed": "Closed:"
+  },
+  "actions": {
+    "create_ca": "Create Corrective Action",
+    "create_ca_desc": "Spawn a corrective action linked back to this incident."
+  },
+  "breach": {
+    "heading": "Personal Data Breach (GDPR)",
+    "gdpr_role": "GDPR Role",
+    "authority_notification": "Authority Notification",
+    "subjects_notification": "Data Subjects Notification",
+    "authority": "Authority",
+    "subjects": "Data Subjects"
+  },
+  "danger": {
+    "warning": "Deleting this incident is permanent and cannot be undone.",
+    "delete": "Delete incident",
+    "confirm": "Delete incident \"{title}\"? This cannot be undone."
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
+  }
+}

--- a/web/src/locales/en/incidents.json
+++ b/web/src/locales/en/incidents.json
@@ -26,11 +26,6 @@
     "reporter": "Reporter: {name}",
     "assignee": "Assignee: {name}"
   },
-  "cia_abbr": {
-    "c": "C",
-    "i": "I",
-    "a": "A"
-  },
   "field": {
     "title": "Title",
     "description": "Description",

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -19,6 +19,7 @@ import components from './components.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
+import risks from './risks.json' with { type: 'json' }
 import settings from './settings.json' with { type: 'json' }
 import shell from './shell.json' with { type: 'json' }
 
@@ -31,6 +32,7 @@ export default {
   landing,
   notifications,
   organizations,
+  risks,
   settings,
   shell,
 }

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -12,6 +12,7 @@
 // modules, and understood by Vite/Rollup — the same file therefore loads both
 // in the bundler and under `node --test`.
 import admin from './admin.json' with { type: 'json' }
+import assets from './assets.json' with { type: 'json' }
 import auth from './auth.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
@@ -29,6 +30,7 @@ import systems from './systems.json' with { type: 'json' }
 
 export default {
   admin,
+  assets,
   auth,
   common,
   components,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -17,6 +17,7 @@ import common from './common.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
 import components from './components.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
+import legal from './legal.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
 import risks from './risks.json' with { type: 'json' }
@@ -30,6 +31,7 @@ export default {
   components,
   dashboard,
   landing,
+  legal,
   notifications,
   organizations,
   risks,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -23,6 +23,7 @@ import organizations from './organizations.json' with { type: 'json' }
 import risks from './risks.json' with { type: 'json' }
 import settings from './settings.json' with { type: 'json' }
 import shell from './shell.json' with { type: 'json' }
+import systems from './systems.json' with { type: 'json' }
 
 export default {
   admin,
@@ -37,4 +38,5 @@ export default {
   risks,
   settings,
   shell,
+  systems,
 }

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -23,6 +23,7 @@ import organizations from './organizations.json' with { type: 'json' }
 import risks from './risks.json' with { type: 'json' }
 import settings from './settings.json' with { type: 'json' }
 import shell from './shell.json' with { type: 'json' }
+import suppliers from './suppliers.json' with { type: 'json' }
 import systems from './systems.json' with { type: 'json' }
 
 export default {
@@ -38,5 +39,6 @@ export default {
   risks,
   settings,
   shell,
+  suppliers,
   systems,
 }

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -16,6 +16,7 @@ import auth from './auth.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
 import components from './components.json' with { type: 'json' }
+import incidents from './incidents.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
 import legal from './legal.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
@@ -32,6 +33,7 @@ export default {
   common,
   components,
   dashboard,
+  incidents,
   landing,
   legal,
   notifications,

--- a/web/src/locales/en/legal.json
+++ b/web/src/locales/en/legal.json
@@ -1,0 +1,79 @@
+{
+  "title": "Legal Register",
+  "subtitle": "Applicable legislation and regulatory risk assessment",
+  "error": {
+    "save": "Failed to save: {message}",
+    "create": "Failed to create legal requirement: {message}",
+    "delete": "Failed to delete: {message}"
+  },
+  "action": {
+    "add": "Add Legal Requirement"
+  },
+  "create": {
+    "heading": "Add Legal Requirement",
+    "title_label": "Title *",
+    "title_placeholder": "e.g. GDPR, NIS2 Directive",
+    "category_label": "Category",
+    "deselect_hint": "Click to deselect",
+    "fill_in_later": "You can add jurisdiction, owner, treatment and more after creating.",
+    "submit": "Add"
+  },
+  "map": {
+    "summary": "Risk Map",
+    "heading": "Compliance Risk Map"
+  },
+  "filter": {
+    "empty": "No legal requirements found"
+  },
+  "table": {
+    "header": {
+      "title": "Title",
+      "jurisdiction": "Jurisdiction",
+      "score": "Score",
+      "treatment": "Treatment",
+      "status": "Status",
+      "owner": "Owner"
+    }
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "jurisdiction": "Jurisdiction",
+    "category": "Category",
+    "status": "Status",
+    "owner": "Owner",
+    "reference": "Reference",
+    "reference_label": "Reference (article/section)",
+    "url": "URL",
+    "treatment": "Treatment",
+    "treatment_plan": "Treatment Plan",
+    "created": "Created",
+    "created_by": "Created by"
+  },
+  "placeholder": {
+    "description": "Describe the requirement...",
+    "jurisdiction": "Type to search...",
+    "reference": "e.g. Article 32, Section 4.2",
+    "url": "https://...",
+    "treatment_plan": "How are we addressing this requirement? (controls, policies, actions...)",
+    "notes": "Additional notes, observations, interpretations... Type /doc to link a document"
+  },
+  "detail": {
+    "overview": "Overview",
+    "treatment": "Treatment",
+    "notes": "Notes"
+  },
+  "assessment": {
+    "current": "Current"
+  },
+  "danger": {
+    "warning": "Deleting this legal requirement is permanent and cannot be undone. History, comments, and linked references will be lost.",
+    "delete": "Delete requirement",
+    "confirm": "Delete this legal requirement? This cannot be undone."
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
+  }
+}

--- a/web/src/locales/en/risks.json
+++ b/web/src/locales/en/risks.json
@@ -1,0 +1,98 @@
+{
+  "title": "Risk Register",
+  "subtitle": "Information security risk assessment and treatment",
+  "error": {
+    "load": "Failed to load risks. {message}",
+    "save": "Failed to save: {message}",
+    "create": "Failed to create risk: {message}",
+    "delete": "Failed to delete risk: {message}"
+  },
+  "action": {
+    "add": "Add Risk",
+    "cancel": "Cancel"
+  },
+  "create": {
+    "heading": "Add Risk",
+    "title_label": "Title *",
+    "title_placeholder": "e.g. Ransomware attack on production systems",
+    "category_label": "Category",
+    "deselect_hint": "Click to deselect",
+    "fill_in_later": "You can add description, consequences, treatment, owner and more after creating.",
+    "submit": "Add"
+  },
+  "map": {
+    "heading": "Risk Map"
+  },
+  "stat": {
+    "total": "Total Risks"
+  },
+  "filter": {
+    "empty": "No risks match your filter.",
+    "none_yet": "No risks yet — click Add to create your first one."
+  },
+  "table": {
+    "header": {
+      "risk": "Risk",
+      "type": "Type",
+      "score": "Score",
+      "cia": "C/I/A",
+      "owner": "Owner",
+      "treatment": "Treatment",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "was_score": "was {score}",
+    "cia_title": {
+      "confidentiality": "Confidentiality: {level}",
+      "integrity": "Integrity: {level}",
+      "availability": "Availability: {level}"
+    },
+    "advisory_badge": "Review",
+    "advisory_title": "CIA mismatch with linked assets — reassessment needed"
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "status": "Status",
+    "owner": "Owner",
+    "category": "Category",
+    "risk_type": "Risk Type",
+    "origin": "Origin",
+    "treatment": "Treatment",
+    "treatment_plan": "Treatment Plan",
+    "created": "Created",
+    "created_by": "Created by",
+    "notes": "Notes"
+  },
+  "placeholder": {
+    "description": "Describe the risk...",
+    "treatment_plan": "How are we addressing this risk?",
+    "notes": "Add notes, observations, meeting minutes, references..."
+  },
+  "detail": {
+    "overview": "Overview",
+    "treatment": "Treatment",
+    "notes": "Notes"
+  },
+  "assessment": {
+    "inherent": "Inherent",
+    "current": "Current"
+  },
+  "links": {
+    "linked_assets": "Linked Assets"
+  },
+  "actions": {
+    "create_task": "Create Implementation Task",
+    "create_task_desc": "Spawn a task to action the treatment plan; auto-linked back to this risk."
+  },
+  "danger": {
+    "warning": "Deleting this risk is permanent and cannot be undone. History, comments, and linked references will be lost.",
+    "delete": "Delete risk",
+    "confirm": "Delete this risk? This cannot be undone."
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
+  }
+}

--- a/web/src/locales/en/suppliers.json
+++ b/web/src/locales/en/suppliers.json
@@ -1,0 +1,88 @@
+{
+  "title": "Supplier Register",
+  "subtitle": "Third-party suppliers, criticality, and assessment",
+  "error": {
+    "save": "Failed to save: {message}",
+    "create": "Failed to create supplier: {message}",
+    "delete": "Failed to delete: {message}"
+  },
+  "action": {
+    "add": "Add Supplier"
+  },
+  "create": {
+    "heading": "Add Supplier",
+    "name_label": "Name *",
+    "name_placeholder": "e.g. AWS, Office 365",
+    "type_label": "Type",
+    "criticality_label": "Criticality",
+    "fill_in_later": "You can add CIA classification, owner, contract details after creating.",
+    "submit": "Add"
+  },
+  "filter": {
+    "empty": "No suppliers found"
+  },
+  "table": {
+    "header": {
+      "supplier": "Supplier",
+      "type": "Type",
+      "criticality": "Criticality",
+      "cia": "C/I/A",
+      "status": "Status",
+      "owner": "Owner",
+      "next_review": "Next Review"
+    },
+    "cia_title": {
+      "confidentiality": "Confidentiality: {level}",
+      "integrity": "Integrity: {level}",
+      "availability": "Availability: {level}"
+    }
+  },
+  "field": {
+    "name": "Name",
+    "type": "Type",
+    "criticality": "Criticality",
+    "status": "Status",
+    "owner": "Owner",
+    "contact": "Contact",
+    "contract_ref": "Contract Reference",
+    "contract_expiry": "Contract Expiry",
+    "data_access": "Data Access",
+    "created": "Created",
+    "created_by": "Created by"
+  },
+  "placeholder": {
+    "contact": "contact{'@'}supplier.com",
+    "contract_ref": "DPA / contract URL",
+    "notes": "Additional notes... Type /doc to link a document"
+  },
+  "data_access": {
+    "checkbox": "Supplier has access to our data",
+    "yes": "Yes",
+    "no": "No"
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes"
+  },
+  "tab": {
+    "reviews": "Reviews"
+  },
+  "assessment": {
+    "confidentiality": "Confidentiality",
+    "integrity": "Integrity",
+    "availability": "Availability"
+  },
+  "linked_systems": {
+    "heading": "no linked systems | Linked system ({count}) | Linked systems ({count})"
+  },
+  "danger": {
+    "warning": "Deleting this supplier is permanent and cannot be undone. History, comments, reviews and linked references will be lost.",
+    "delete": "Delete supplier",
+    "confirm": "Delete this supplier? This cannot be undone."
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
+  }
+}

--- a/web/src/locales/en/systems.json
+++ b/web/src/locales/en/systems.json
@@ -1,0 +1,106 @@
+{
+  "title": "Systems Register",
+  "subtitle": "IT systems, recovery objectives, access control, and supplier links",
+  "error": {
+    "save": "Failed to save: {message}",
+    "create": "Failed to create system: {message}",
+    "delete": "Failed to delete: {message}",
+    "record_review": "Failed to record review: {message}"
+  },
+  "action": {
+    "add": "Add System"
+  },
+  "create": {
+    "heading": "Add System",
+    "name_label": "Name *",
+    "name_placeholder": "e.g. Production ERP",
+    "classification_label": "Classification",
+    "criticality_label": "Criticality",
+    "supplier_label": "Supplier",
+    "fill_in_later": "You can add CIA classification, RPO/RTO, and owner after creating.",
+    "submit": "Add"
+  },
+  "filter": {
+    "empty": "No systems found"
+  },
+  "option": {
+    "no_supplier": "— None —"
+  },
+  "table": {
+    "header": {
+      "system": "System",
+      "classification": "Classification",
+      "criticality": "Criticality",
+      "cia": "C/I/A",
+      "rpo": "RPO",
+      "rto": "RTO",
+      "status": "Status",
+      "owner": "Owner",
+      "next_review": "Next Review"
+    },
+    "cia_title": {
+      "confidentiality": "Confidentiality: {level}",
+      "integrity": "Integrity: {level}",
+      "availability": "Availability: {level}"
+    },
+    "hours": "{count}h"
+  },
+  "field": {
+    "name": "Name",
+    "description": "Description",
+    "classification": "Classification",
+    "criticality": "Criticality",
+    "status": "Status",
+    "owner": "Owner",
+    "department": "Department",
+    "supplier": "Supplier",
+    "rpo": "RPO (hours)",
+    "rto": "RTO (hours)",
+    "rpo_rto": "RPO / RTO",
+    "created": "Created",
+    "created_by": "Created by"
+  },
+  "hint": {
+    "rpo": "Max acceptable data loss (hours)",
+    "rto": "Max acceptable downtime (hours)"
+  },
+  "placeholder": {
+    "description": "Describe the system...",
+    "department": "IT, Engineering, Marketing...",
+    "notes": "Additional notes... Type /doc to link a document"
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes"
+  },
+  "tab": {
+    "reviews": "Access Reviews"
+  },
+  "assessment": {
+    "confidentiality": "Confidentiality",
+    "integrity": "Integrity",
+    "availability": "Availability"
+  },
+  "reviews": {
+    "heading": "Access Reviews",
+    "add": "+ Record review",
+    "users_added": "Users Added",
+    "users_removed": "Users Removed",
+    "notes_label": "Notes",
+    "notes_placeholder": "Removed former employees...",
+    "submit": "Record Review",
+    "reviewed_by": "{name} {reviewed}",
+    "reviewed": "reviewed",
+    "empty": "No access reviews recorded."
+  },
+  "danger": {
+    "warning": "Deleting this system is permanent and cannot be undone. History, comments, access reviews and linked references will be lost.",
+    "delete": "Delete system",
+    "confirm": "Delete this system? This cannot be undone."
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
+  }
+}

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -19,15 +19,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Asset Register</h1>
-          <p class="text-sm text-slate-500 mt-1">Information assets, classification, and ownership</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('assets.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('assets.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite" @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ showCreateForm ? 'Cancel' : 'Add Asset' }}
+            {{ showCreateForm ? t('common.action.cancel') : t('assets.action.add') }}
           </button>
-          <SuggestNewButton entityType="asset" typeLabel="Asset" />
+          <SuggestNewButton entityType="asset" :typeLabel="entityLabel('asset')" />
         </div>
       </div>
 
@@ -38,7 +38,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
           <div class="flex items-center justify-between mb-2">
-            <h2 class="text-sm font-semibold text-slate-200">Add Asset</h2>
+            <h2 class="text-sm font-semibold text-slate-200">{{ t('assets.create.heading') }}</h2>
             <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -47,27 +47,27 @@
           </div>
           <div class="space-y-3">
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Name *</label>
-              <input v-model="newItem.name" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. Production Database, Customer Portal" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.create.name_label') }}</label>
+              <input v-model="newItem.name" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('assets.create.name_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.create.type_label') }}</label>
               <div class="flex flex-wrap gap-1.5">
-                <button v-for="t in assetTypes" :key="t.key"
-                  @click="newItem.asset_type = newItem.asset_type === t.key ? '' : t.key"
+                <button v-for="o in typeOptions" :key="o.value"
+                  @click="newItem.asset_type = newItem.asset_type === o.value ? '' : o.value"
                   class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
-                  :class="newItem.asset_type === t.key ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'"
-                  :title="newItem.asset_type === t.key ? 'Click to deselect' : ''">
-                  {{ t.label }}
+                  :class="newItem.asset_type === o.value ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'"
+                  :title="newItem.asset_type === o.value ? t('assets.create.deselect_hint') : ''">
+                  {{ o.label }}
                 </button>
               </div>
             </div>
           </div>
-          <div class="text-[10px] text-slate-600 mt-1">You can add CIA classification, owner, and more after creating.</div>
+          <div class="text-[10px] text-slate-600 mt-1">{{ t('assets.create.fill_in_later') }}</div>
           <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
             <button @click="createItem" :disabled="!newItem.name" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-              Add
+              {{ t('assets.create.submit') }}
             </button>
           </div>
         </div>
@@ -86,33 +86,31 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="searchQuery" type="text" placeholder="Search..."
+            <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="filterType" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All types</option>
-            <option v-for="t in assetTypes" :key="t.key" :value="t.key">{{ t.label }}</option>
+            <option value="">{{ t('common.filter.all_types') }}</option>
+            <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="draft">Draft</option>
-            <option value="open">Open</option>
-            <option value="archived">Archived</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <button v-if="filterType || filterStatus || searchQuery"
             @click="filterType = ''; filterStatus = ''; searchQuery = ''"
             class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-            Clear
+            {{ t('common.action.clear') }}
           </button>
           <div class="ml-auto text-xs text-slate-500 tabular-nums">
-            {{ total }} total
+            {{ t('common.count.total', { count: total }) }}
           </div>
         </div>
       </div>
 
       <!-- Empty state -->
       <div v-if="assets.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-        <div class="text-sm text-slate-500">No assets found</div>
+        <div class="text-sm text-slate-500">{{ t('assets.filter.empty') }}</div>
       </div>
 
       <!-- Table -->
@@ -120,11 +118,11 @@
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Asset</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Type</th>
-              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">C/I/A</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('assets.table.header.asset') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('assets.table.header.type') }}</th>
+              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('assets.table.header.cia') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('assets.table.header.status') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('assets.table.header.owner') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-800/50">
@@ -135,12 +133,12 @@
                 <div class="text-sm font-medium text-slate-200">{{ asset.name }}</div>
                 <div v-if="asset.description" class="text-xs text-slate-500 mt-0.5 truncate max-w-xs">{{ asset.description }}</div>
               </td>
-              <td class="px-5 py-3.5 text-sm text-slate-400 capitalize">{{ formatLabel(asset.asset_type) }}</td>
+              <td class="px-5 py-3.5 text-sm text-slate-400">{{ typeLabel(asset.asset_type) || '—' }}</td>
               <td class="px-5 py-3.5 text-center">
                 <div class="flex gap-0.5 justify-center">
-                  <span v-if="asset.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.confidentiality)" :title="'Confidentiality: ' + ciaLabel(asset.confidentiality)">C{{ asset.confidentiality }}</span>
-                  <span v-if="asset.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.integrity)" :title="'Integrity: ' + ciaLabel(asset.integrity)">I{{ asset.integrity }}</span>
-                  <span v-if="asset.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.availability)" :title="'Availability: ' + ciaLabel(asset.availability)">A{{ asset.availability }}</span>
+                  <span v-if="asset.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.confidentiality)" :title="t('assets.table.cia_title.confidentiality', { level: ciaLabel(asset.confidentiality) })">C{{ asset.confidentiality }}</span>
+                  <span v-if="asset.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.integrity)" :title="t('assets.table.cia_title.integrity', { level: ciaLabel(asset.integrity) })">I{{ asset.integrity }}</span>
+                  <span v-if="asset.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.availability)" :title="t('assets.table.cia_title.availability', { level: ciaLabel(asset.availability) })">A{{ asset.availability }}</span>
                   <span v-if="!asset.confidentiality && !asset.integrity && !asset.availability" class="text-slate-600 text-xs">-</span>
                 </div>
               </td>
@@ -182,10 +180,10 @@
             <!-- Left nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -197,84 +195,82 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('assets.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Name</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.field.name') }}</label>
                         <input v-model="editForm.name" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'asset'" :self-id="selectedItem?.identifier || ''" :rows="3" placeholder="Describe the asset..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'asset'" :self-id="selectedItem?.identifier || ''" :rows="3" :placeholder="t('assets.placeholder.description')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.field.type') }}</label>
                         <select v-model="editForm.asset_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="">None</option>
-                          <option v-for="t in assetTypes" :key="t.key" :value="t.key">{{ t.label }}</option>
+                          <option value="">{{ t('common.option.none') }}</option>
+                          <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="draft">Draft</option>
-                          <option value="open">Open</option>
-                          <option value="archived">Archived</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                        <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.field.owner') }}</label>
+                        <MemberPicker v-model="editForm.owner" :members="orgMembers" :placeholder="t('common.placeholder.select_owner')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Primary Location</label>
-                        <input v-model="editForm.primary_location" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. Reykjavík DC, AWS eu-west-1" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('assets.field.primary_location') }}</label>
+                        <input v-model="editForm.primary_location" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('assets.placeholder.primary_location')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Name</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('assets.field.name') }}</div>
                         <div class="text-sm text-slate-200 font-medium">{{ selectedItem.name }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('assets.field.description') }}</div>
                         <div v-if="selectedItem.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedItem.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.status') }}</div>
                           <StatusBadge :status="selectedItem.status" />
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ formatLabel(selectedItem.asset_type) }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.type') }}</div>
+                          <div class="text-sm text-slate-300">{{ typeLabel(selectedItem.asset_type) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.owner') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.owner) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Primary Location</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.primary_location') }}</div>
                           <div class="text-sm text-slate-300">{{ selectedItem.primary_location || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Next Review</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.next_review') }}</div>
                           <div class="text-sm" :class="isOverdue(selectedItem.next_review) ? 'text-red-400' : 'text-slate-300'">
                             {{ formatDay(selectedItem.next_review) || '—' }}
                           </div>
                         </div>
                         <div v-if="selectedItem.created_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedItem.created_at) }}</div>
                         </div>
                         <div v-if="selectedItem.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('assets.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.created_by) }}</div>
                         </div>
                       </div>
@@ -290,25 +286,25 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDay(selectedItem.next_review) }}
+                    {{ t('common.review.overdue_since', { date: formatDay(selectedItem.next_review) }) }}
                   </div>
 
                   <!-- CIA scores -->
                   <div class="grid grid-cols-3 gap-4">
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Confidentiality</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('assets.assessment.confidentiality') }}</div>
                       <div v-if="selectedItem.confidentiality" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.confidentiality)">{{ selectedItem.confidentiality }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.confidentiality" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.confidentiality) }}</div>
                     </div>
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Integrity</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('assets.assessment.integrity') }}</div>
                       <div v-if="selectedItem.integrity" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.integrity)">{{ selectedItem.integrity }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.integrity" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.integrity) }}</div>
                     </div>
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Availability</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('assets.assessment.availability') }}</div>
                       <div v-if="selectedItem.availability" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.availability)">{{ selectedItem.availability }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.availability" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.availability) }}</div>
@@ -316,8 +312,8 @@
                   </div>
 
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">{{ t('common.review.last', { date: formatDay(selectedItem.last_review) }) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">{{ t('common.review.next', { date: formatDay(selectedItem.next_review) }) }}</span>
                   </div>
 
                   <!-- Readings -->
@@ -333,15 +329,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('assets.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'asset'" :self-id="selectedItem?.identifier || ''" :rows="12" placeholder="Additional notes... Type /doc to link a document" />
+                    <MarkdownField v-model="editForm.notes" :self-type="'asset'" :self-id="selectedItem?.identifier || ''" :rows="12" :placeholder="t('assets.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedItem.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedItem.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -372,10 +368,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="asset" :entityId="String(selectedItem.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this asset is permanent and cannot be undone. History, comments, and linked references will be lost.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('assets.danger.warning') }}</div>
                     <button @click="deleteSelectedItem" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete asset
+                      {{ t('assets.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -386,8 +382,8 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -402,6 +398,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -424,7 +421,11 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate, formatDay } from '../composables/useFormat.js'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
+const { t } = useI18n()
+const { enumLabel, entityLabel } = useEnumLabel()
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
 
@@ -445,7 +446,7 @@ async function reload() {
   try {
     await loadAssets()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -456,11 +457,13 @@ const orgMembers = ref([])
 const saving = ref(false)
 const stats = ref({ total: 0, draft: 0, open: 0, archived: 0, critical: 0 })
 const statusStats = computed(() => [
-  { key: '', label: 'Total', count: stats.value.total, color: 'text-slate-100' },
-  { key: 'draft', label: 'Draft', count: stats.value.draft || 0, color: 'text-amber-400' },
-  { key: 'open', label: 'Open', count: stats.value.open, color: 'text-blue-400' },
-  { key: 'archived', label: 'Archived', count: stats.value.archived, color: 'text-slate-400' },
-  { key: 'critical', label: 'Severe (CIA = 5)', count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: '', label: t('common.stat.total'), count: stats.value.total, color: 'text-slate-100' },
+  { key: 'draft', label: statusLabel('draft'), count: stats.value.draft || 0, color: 'text-amber-400' },
+  { key: 'open', label: statusLabel('open'), count: stats.value.open, color: 'text-blue-400' },
+  { key: 'archived', label: statusLabel('archived'), count: stats.value.archived, color: 'text-slate-400' },
+  // Not a status and not an enum member: this chip counts assets whose highest
+  // CIA rating is 5, so its label is this view's own copy.
+  { key: 'critical', label: t('assets.stat.severe'), count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
 ])
 
 const selectedItem = ref(null)
@@ -481,32 +484,38 @@ const page = ref(1)
 const pageSize = ref(50)
 const total = ref(0)
 
-const assetTypes = [
-  { key: 'infrastructure', label: 'Infrastructure' },
-  { key: 'processing_devices', label: 'Processing Devices' },
-  { key: 'software', label: 'Software' },
-  { key: 'system', label: 'System' },
-  { key: 'network', label: 'Network' },
-  { key: 'service', label: 'Service' },
-  { key: 'financial_info', label: 'Financial Info' },
-  { key: 'personal_data', label: 'Personal Data' },
-  { key: 'ipr', label: 'Intellectual Property' },
-  { key: 'sales_marketing', label: 'Sales & Marketing' },
-  { key: 'processing_facility', label: 'Processing Facility' },
-  { key: 'products_services', label: 'Products & Services' },
-  { key: 'supply_chain', label: 'Supply Chain' },
-  { key: 'other', label: 'Other' },
+// The members each picker offers, matching the asset_type CHECK in
+// migrations/20260327000000_initial_schema.sql. Only the label comes from the
+// shared catalogue.
+const ASSET_TYPES = [
+  'infrastructure', 'processing_devices', 'software', 'system', 'network',
+  'service', 'financial_info', 'personal_data', 'ipr', 'sales_marketing',
+  'processing_facility', 'products_services', 'supply_chain', 'other',
 ]
+const STATUSES = ['draft', 'open', 'archived']
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'assessment', label: 'Assessment' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Message keys, not labels: a module-scope array of translated strings freezes
+// the tab bar in whichever locale was active when this module first evaluated.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'assessment', label: 'common.tab.assessment' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
+
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+const statusLabel = (v) => enumLabel('status', v)
+const typeLabel = (v) => enumLabel('asset_type', v)
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const typeOptions = options(ASSET_TYPES, typeLabel)
 
 useModalEscape(showCreateForm)
 useModalEscape(computed(() => !!selectedItem.value), closeDetail)
@@ -522,7 +531,17 @@ watch([filterType, filterStatus], () => {
 })
 watch([page, pageSize], () => loadAssets())
 
-const ciaLabel = (v) => ['Not Assessed','Insignificant','Minor','Moderate','Major','Severe'][v] || 'N/A'
+// Keys written out rather than built from the index: a runtime-composed key
+// defeats keyset extraction, which is why the convention forbids it.
+const CIA_KEYS = [
+  'common.cia.not_assessed',
+  'common.cia.insignificant',
+  'common.cia.minor',
+  'common.cia.moderate',
+  'common.cia.major',
+  'common.cia.severe',
+]
+const ciaLabel = (v) => (CIA_KEYS[v] ? t(CIA_KEYS[v]) : t('common.cia.na'))
 
 function ciaColor(v) {
   switch (v) {
@@ -544,10 +563,6 @@ function ciaColorText(v) {
     case 1: return 'text-slate-400'
     default: return 'text-slate-500'
   }
-}
-
-function formatLabel(s) {
-  return (s || '').replace(/_/g, ' ')
 }
 
 function isOverdue(dateStr) {
@@ -575,7 +590,7 @@ async function loadAssets() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -625,9 +640,9 @@ async function saveSection() {
     await api.putJSON(`/api/v1/assets/${selectedItem.value.id}`, { ...editForm.value })
     await refreshSelectedItem()
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('assets.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
@@ -655,9 +670,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('assets.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('assets.dirty.discard'),
     })
     if (!ok) return
   }
@@ -668,9 +683,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('assets.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('assets.dirty.discard'),
     })
     if (!ok) return
   }
@@ -699,20 +714,20 @@ async function createItem() {
       router.push(orgPath(`/assets/${fresh.id}`))
     }
   } catch (e) {
-    showError('Failed to create asset: ' + e.message)
+    showError(t('assets.error.create', { message: renderApiError(e) }))
   }
 }
 
 async function deleteSelectedItem() {
   if (!selectedItem.value) return
-  const ok = await confirmDialog({ message: 'Delete this asset? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({ message: t('assets.danger.confirm'), variant: 'danger', confirmLabel: t('common.action.delete') })
   if (!ok) return
   try {
     await api.deleteJSON(`/api/v1/assets/${selectedItem.value.id}`)
     closeDetail()
     await loadAssets()
   } catch (e) {
-    showError('Failed to delete: ' + e.message)
+    showError(t('assets.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -725,7 +740,7 @@ onMounted(async () => {
     ])
     orgMembers.value = users || []
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -136,9 +136,9 @@
               <td class="px-5 py-3.5 text-sm text-slate-400">{{ typeLabel(asset.asset_type) || '—' }}</td>
               <td class="px-5 py-3.5 text-center">
                 <div class="flex gap-0.5 justify-center">
-                  <span v-if="asset.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.confidentiality)" :title="t('assets.table.cia_title.confidentiality', { level: ciaLabel(asset.confidentiality) })">C{{ asset.confidentiality }}</span>
-                  <span v-if="asset.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.integrity)" :title="t('assets.table.cia_title.integrity', { level: ciaLabel(asset.integrity) })">I{{ asset.integrity }}</span>
-                  <span v-if="asset.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.availability)" :title="t('assets.table.cia_title.availability', { level: ciaLabel(asset.availability) })">A{{ asset.availability }}</span>
+                  <span v-if="asset.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.confidentiality)" :title="t('assets.table.cia_title.confidentiality', { level: ciaLabel(asset.confidentiality) })">{{ t('common.cia_abbr.c') }}{{ asset.confidentiality }}</span>
+                  <span v-if="asset.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.integrity)" :title="t('assets.table.cia_title.integrity', { level: ciaLabel(asset.integrity) })">{{ t('common.cia_abbr.i') }}{{ asset.integrity }}</span>
+                  <span v-if="asset.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(asset.availability)" :title="t('assets.table.cia_title.availability', { level: ciaLabel(asset.availability) })">{{ t('common.cia_abbr.a') }}{{ asset.availability }}</span>
                   <span v-if="!asset.confidentiality && !asset.integrity && !asset.availability" class="text-slate-600 text-xs">-</span>
                 </div>
               </td>

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -276,9 +276,9 @@
                         <div>
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.classification') }}</div>
                           <div class="flex items-center gap-1.5">
-                            <span v-if="selectedIncident.affects_c" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-900/40 text-blue-300 border border-blue-800">{{ t('incidents.cia_abbr.c') }}</span>
-                            <span v-if="selectedIncident.affects_i" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-900/40 text-purple-300 border border-purple-800">{{ t('incidents.cia_abbr.i') }}</span>
-                            <span v-if="selectedIncident.affects_a" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-900/40 text-emerald-300 border border-emerald-800">{{ t('incidents.cia_abbr.a') }}</span>
+                            <span v-if="selectedIncident.affects_c" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-900/40 text-blue-300 border border-blue-800">{{ t('common.cia_abbr.c') }}</span>
+                            <span v-if="selectedIncident.affects_i" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-900/40 text-purple-300 border border-purple-800">{{ t('common.cia_abbr.i') }}</span>
+                            <span v-if="selectedIncident.affects_a" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-900/40 text-emerald-300 border border-emerald-800">{{ t('common.cia_abbr.a') }}</span>
                             <span v-if="!selectedIncident.affects_c && !selectedIncident.affects_i && !selectedIncident.affects_a" class="text-sm text-slate-600">—</span>
                           </div>
                         </div>
@@ -856,11 +856,15 @@ async function closeDetail() {
   router.push(orgPath('/incidents'))
 }
 
+// The initials are copy: which letters abbreviate confidentiality, integrity
+// and availability is a property of the language, not of the data. Invisible to
+// both scanners — the raw-text one never reads script, and a lone capital in a
+// template fails its has-a-word test.
 function classificationLabel(inc) {
   const parts = []
-  if (inc.affects_c) parts.push('C')
-  if (inc.affects_i) parts.push('I')
-  if (inc.affects_a) parts.push('A')
+  if (inc.affects_c) parts.push(t('common.cia_abbr.c'))
+  if (inc.affects_i) parts.push(t('common.cia_abbr.i'))
+  if (inc.affects_a) parts.push(t('common.cia_abbr.a'))
   return parts.length ? parts.join('/') : ''
 }
 

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -18,16 +18,16 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Incident Management</h1>
-          <p class="text-sm text-slate-500 mt-1">Track, respond to, and learn from security incidents</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('incidents.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('incidents.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canReport"
             @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Incident
+            {{ t('incidents.action.add') }}
           </button>
-          <SuggestNewButton entityType="incident" typeLabel="Incident" />
+          <SuggestNewButton entityType="incident" :typeLabel="entityLabel('incident')" />
         </div>
       </div>
 
@@ -41,26 +41,18 @@
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
           </svg>
-          <input v-model="searchQuery" type="text" placeholder="Search..."
+          <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
             class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
         </div>
         <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All statuses</option>
-          <option value="draft">Draft</option>
-          <option value="open">Open</option>
-          <option value="investigating">Investigating</option>
-          <option value="contained">Contained</option>
-          <option value="resolved">Resolved</option>
-          <option value="closed">Closed</option>
+          <option value="">{{ t('common.filter.all_statuses') }}</option>
+          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select v-model="filterSeverity" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All severities</option>
-          <option value="critical">Critical</option>
-          <option value="high">High</option>
-          <option value="medium">Medium</option>
-          <option value="low">Low</option>
+          <option value="">{{ t('common.filter.all_severities') }}</option>
+          <option v-for="o in severityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
-        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ total }} total</div>
+        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: total }) }}</div>
       </div>
 
       <!-- Create form -->
@@ -70,7 +62,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Incident</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('incidents.create.heading') }}</h2>
           <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -79,32 +71,27 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="sm:col-span-2">
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newIncident.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Brief incident title" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.create.title_label') }}</label>
+            <input v-model="newIncident.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('incidents.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Severity</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.create.severity_label') }}</label>
             <select v-model="newIncident.severity" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option value="critical">Critical</option>
-              <option value="high">High</option>
-              <option value="medium">Medium</option>
-              <option value="low">Low</option>
+              <option v-for="o in severityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.create.type_label') }}</label>
             <select v-model="newIncident.incident_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option value="incident">Incident</option>
-              <option value="event">Event</option>
-              <option value="weakness">Weakness</option>
+              <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, classification, origin, assignee, GDPR details and notes after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('incidents.create.fill_in_later') }}</div>
         <div class="flex justify-end gap-3 pt-2">
-          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createIncident" :disabled="!newIncident.title" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            Add
+            {{ t('incidents.create.submit') }}
           </button>
         </div>
         </div>
@@ -114,7 +101,7 @@
 
       <!-- Incident list -->
       <div v-if="incidents.length === 0" class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
-        <div class="text-slate-500 text-sm">No incidents found</div>
+        <div class="text-slate-500 text-sm">{{ t('incidents.filter.empty') }}</div>
       </div>
 
       <div v-else class="space-y-2">
@@ -124,11 +111,11 @@
           <div class="flex items-center gap-3">
             <span class="inline-flex items-center px-2 py-0.5 text-[11px] font-semibold rounded-full uppercase tracking-wider"
               :class="severityClass(inc.severity)">
-              {{ inc.severity }}
+              {{ severityLabel(inc.severity) }}
             </span>
             <span class="inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-full"
               :class="typeClass(inc.incident_type)">
-              {{ inc.incident_type }}
+              {{ typeLabel(inc.incident_type) }}
             </span>
             <StatusBadge :status="inc.status" />
             <span class="text-sm font-medium text-slate-200 flex-1 truncate">{{ inc.title }}</span>
@@ -137,9 +124,9 @@
           </div>
           <div class="mt-1.5 flex items-center gap-3 text-xs text-slate-500">
             <span v-if="classificationLabel(inc)">{{ classificationLabel(inc) }}</span>
-            <span>Source: {{ inc.source }}</span>
-            <span>Reporter: {{ resolveUserName(inc.reporter) }}</span>
-            <span v-if="inc.assignee">Assignee: {{ resolveUserName(inc.assignee) }}</span>
+            <span>{{ t('incidents.list.source', { value: originLabel(inc.source) }) }}</span>
+            <span>{{ t('incidents.list.reporter', { name: resolveUserName(inc.reporter) }) }}</span>
+            <span v-if="inc.assignee">{{ t('incidents.list.assignee', { name: resolveUserName(inc.assignee) }) }}</span>
           </div>
         </div>
         <Pagination :page="page" :pageSize="pageSize" :total="total" @update:page="page = $event" @update:pageSize="pageSize = $event" />
@@ -161,7 +148,7 @@
               <CopyLinkButton />
               <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full uppercase tracking-wider"
                 :class="severityClass(selectedIncident.severity)">
-                {{ selectedIncident.severity }}
+                {{ severityLabel(selectedIncident.severity) }}
               </span>
               <StatusBadge :status="selectedIncident.status" />
               <button @click="closeDetail" class="p-1 rounded-lg text-slate-600 hover:text-slate-300 hover:bg-slate-800 transition-colors">
@@ -176,10 +163,10 @@
           <div class="flex flex-1 min-h-0">
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -190,88 +177,76 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('incidents.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.title') }}</label>
                         <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="3" placeholder="Describe the incident..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="3" :placeholder="t('incidents.placeholder.description')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Severity</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.severity') }}</label>
                         <select v-model="editForm.severity" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="critical">Critical</option>
-                          <option value="high">High</option>
-                          <option value="medium">Medium</option>
-                          <option value="low">Low</option>
+                          <option v-for="o in severityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.type') }}</label>
                         <select v-model="editForm.incident_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="incident">Incident</option>
-                          <option value="event">Event</option>
-                          <option value="weakness">Weakness</option>
+                          <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Origin</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.origin') }}</label>
                         <select v-model="editForm.source" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="internal">Internal</option>
-                          <option value="external">External</option>
-                          <option value="internal and external">Internal &amp; External</option>
+                          <option v-for="o in originOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Classification</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.classification') }}</label>
                         <div class="flex flex-wrap gap-4 mt-1">
                           <label class="flex items-center gap-2 cursor-pointer">
                             <input type="checkbox" v-model="editForm.affects_c" class="rounded bg-slate-800 border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0" />
-                            <span class="text-xs text-slate-300">Confidentiality</span>
+                            <span class="text-xs text-slate-300">{{ t('incidents.classification.confidentiality') }}</span>
                           </label>
                           <label class="flex items-center gap-2 cursor-pointer">
                             <input type="checkbox" v-model="editForm.affects_i" class="rounded bg-slate-800 border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0" />
-                            <span class="text-xs text-slate-300">Integrity</span>
+                            <span class="text-xs text-slate-300">{{ t('incidents.classification.integrity') }}</span>
                           </label>
                           <label class="flex items-center gap-2 cursor-pointer">
                             <input type="checkbox" v-model="editForm.affects_a" class="rounded bg-slate-800 border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0" />
-                            <span class="text-xs text-slate-300">Availability</span>
+                            <span class="text-xs text-slate-300">{{ t('incidents.classification.availability') }}</span>
                           </label>
                         </div>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="draft">Draft</option>
-                          <option value="open">Open</option>
-                          <option value="investigating">Investigating</option>
-                          <option value="contained">Contained</option>
-                          <option value="resolved">Resolved</option>
-                          <option value="closed">Closed</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Assignee</label>
-                        <MemberPicker v-model="editForm.assignee" :members="orgMembers" placeholder="Select assignee..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.assignee') }}</label>
+                        <MemberPicker v-model="editForm.assignee" :members="orgMembers" :placeholder="t('incidents.placeholder.assignee')" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Root Cause</label>
-                        <MarkdownField v-model="editForm.root_cause" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="3" placeholder="Root cause analysis..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.root_cause') }}</label>
+                        <MarkdownField v-model="editForm.root_cause" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="3" :placeholder="t('incidents.placeholder.root_cause')" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Lessons Learned</label>
-                        <MarkdownField v-model="editForm.lessons_learned" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="3" placeholder="What can we improve?" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.field.lessons_learned') }}</label>
+                        <MarkdownField v-model="editForm.lessons_learned" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="3" :placeholder="t('incidents.placeholder.lessons_learned')" />
                       </div>
                       <div class="sm:col-span-2">
                         <label class="flex items-center gap-2 cursor-pointer">
                           <input type="checkbox" v-model="editForm.data_breach" class="rounded bg-slate-800 border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0" />
-                          <span class="text-xs font-medium text-slate-400">This is a personal data breach (GDPR)</span>
+                          <span class="text-xs font-medium text-slate-400">{{ t('incidents.data_breach_checkbox') }}</span>
                         </label>
                       </div>
                     </div>
@@ -279,48 +254,48 @@
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('incidents.field.description') }}</div>
                         <div v-if="selectedIncident.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedIncident.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
 
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Severity</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.severity') }}</div>
                           <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full uppercase tracking-wider"
-                            :class="severityClass(selectedIncident.severity)">{{ selectedIncident.severity }}</span>
+                            :class="severityClass(selectedIncident.severity)">{{ severityLabel(selectedIncident.severity) }}</span>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ selectedIncident.incident_type }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.type') }}</div>
+                          <div class="text-sm text-slate-300">{{ typeLabel(selectedIncident.incident_type) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Origin</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ selectedIncident.source }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.origin') }}</div>
+                          <div class="text-sm text-slate-300">{{ originLabel(selectedIncident.source) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Classification</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.classification') }}</div>
                           <div class="flex items-center gap-1.5">
-                            <span v-if="selectedIncident.affects_c" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-900/40 text-blue-300 border border-blue-800">C</span>
-                            <span v-if="selectedIncident.affects_i" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-900/40 text-purple-300 border border-purple-800">I</span>
-                            <span v-if="selectedIncident.affects_a" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-900/40 text-emerald-300 border border-emerald-800">A</span>
+                            <span v-if="selectedIncident.affects_c" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-blue-900/40 text-blue-300 border border-blue-800">{{ t('incidents.cia_abbr.c') }}</span>
+                            <span v-if="selectedIncident.affects_i" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-900/40 text-purple-300 border border-purple-800">{{ t('incidents.cia_abbr.i') }}</span>
+                            <span v-if="selectedIncident.affects_a" class="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-emerald-900/40 text-emerald-300 border border-emerald-800">{{ t('incidents.cia_abbr.a') }}</span>
                             <span v-if="!selectedIncident.affects_c && !selectedIncident.affects_i && !selectedIncident.affects_a" class="text-sm text-slate-600">—</span>
                           </div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Reporter</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.reporter') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedIncident.reporter) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Assignee</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.assignee') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedIncident.assignee) }}</div>
                         </div>
                         <div v-if="selectedIncident.created_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedIncident.created_at) }}</div>
                         </div>
                         <div v-if="selectedIncident.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('incidents.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedIncident.created_by) }}</div>
                         </div>
                       </div>
@@ -328,12 +303,12 @@
                       <!-- Investigation/resolution fields -->
                       <div class="border-t border-slate-800 pt-4 space-y-3">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Root Cause</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('incidents.field.root_cause') }}</div>
                           <div v-if="selectedIncident.root_cause" class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedIncident.root_cause)"></div>
                           <div v-else class="text-sm text-slate-600">—</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Lessons Learned</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('incidents.field.lessons_learned') }}</div>
                           <div v-if="selectedIncident.lessons_learned" class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedIncident.lessons_learned)"></div>
                           <div v-else class="text-sm text-slate-600">—</div>
                         </div>
@@ -341,22 +316,22 @@
 
                       <!-- Timeline -->
                       <div class="border-t border-slate-800 pt-4">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-3">Timeline</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-3">{{ t('incidents.timeline.heading') }}</div>
                         <div class="grid grid-cols-2 gap-3 text-xs">
                           <div>
-                            <span class="text-slate-500">Detected:</span>
+                            <span class="text-slate-500">{{ t('incidents.timeline.detected') }}</span>
                             <span class="text-slate-300 ml-1">{{ formatDateTime(selectedIncident.detected_at) }}</span>
                           </div>
                           <div v-if="selectedIncident.contained_at">
-                            <span class="text-slate-500">Contained:</span>
+                            <span class="text-slate-500">{{ t('incidents.timeline.contained') }}</span>
                             <span class="text-slate-300 ml-1">{{ formatDateTime(selectedIncident.contained_at) }}</span>
                           </div>
                           <div v-if="selectedIncident.resolved_at">
-                            <span class="text-slate-500">Resolved:</span>
+                            <span class="text-slate-500">{{ t('incidents.timeline.resolved') }}</span>
                             <span class="text-slate-300 ml-1">{{ formatDateTime(selectedIncident.resolved_at) }}</span>
                           </div>
                           <div v-if="selectedIncident.closed_at">
-                            <span class="text-slate-500">Closed:</span>
+                            <span class="text-slate-500">{{ t('incidents.timeline.closed') }}</span>
                             <span class="text-slate-300 ml-1">{{ formatDateTime(selectedIncident.closed_at) }}</span>
                           </div>
                         </div>
@@ -370,14 +345,14 @@
               <!-- ═══ ACTIONS ═══ -->
               <template v-if="detailTab === 'actions'">
                 <div class="px-6 py-5 space-y-4">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Quick actions</div>
-                  <div v-if="!canWrite" class="text-xs text-slate-600 italic">Read-only — actions require manager or admin role.</div>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('common.heading.quick_actions') }}</div>
+                  <div v-if="!canWrite" class="text-xs text-slate-600 italic">{{ t('common.read_only.actions') }}</div>
                   <div v-else class="flex flex-col gap-3 max-w-md">
                     <button @click="createLinkedCA"
                       class="flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-slate-900 hover:bg-slate-800 border border-slate-700 hover:border-slate-600 transition-colors text-left">
                       <div>
-                        <div class="text-sm font-medium text-slate-200">Create Corrective Action</div>
-                        <div class="text-xs text-slate-500 mt-0.5">Spawn a corrective action linked back to this incident.</div>
+                        <div class="text-sm font-medium text-slate-200">{{ t('incidents.actions.create_ca') }}</div>
+                        <div class="text-xs text-slate-500 mt-0.5">{{ t('incidents.actions.create_ca_desc') }}</div>
                       </div>
                       <span class="text-slate-500 text-lg">→</span>
                     </button>
@@ -389,32 +364,27 @@
               <template v-if="detailTab === 'data_breach' && selectedIncident.data_breach">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Personal Data Breach (GDPR)</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('data_breach')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('incidents.breach.heading') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('data_breach')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'data_breach'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">GDPR Role</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.breach.gdpr_role') }}</label>
                         <select v-model="editForm.gdpr_role" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="controller">Controller</option>
-                          <option value="processor">Processor</option>
+                          <option v-for="o in gdprRoleOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Authority Notification</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.breach.authority_notification') }}</label>
                         <select v-model="editForm.authority_notified" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="not_required">Not Required</option>
-                          <option value="pending">Pending</option>
-                          <option value="notified">Notified</option>
+                          <option v-for="o in notificationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Data Subjects Notification</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('incidents.breach.subjects_notification') }}</label>
                         <select v-model="editForm.subjects_notified" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="not_required">Not Required</option>
-                          <option value="pending">Pending</option>
-                          <option value="notified">Notified</option>
+                          <option v-for="o in notificationOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                     </div>
@@ -423,22 +393,22 @@
                     <div class="bg-red-950/30 border border-red-900/40 rounded-lg p-4 space-y-3">
                       <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-xs">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">GDPR Role</div>
-                          <div class="text-slate-300 capitalize">{{ selectedIncident.gdpr_role || '—' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('incidents.breach.gdpr_role') }}</div>
+                          <div class="text-slate-300">{{ gdprRoleLabel(selectedIncident.gdpr_role) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Authority</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('incidents.breach.authority') }}</div>
                           <span class="px-1.5 py-0.5 rounded text-[10px] font-medium"
                             :class="selectedIncident.authority_notified === 'notified' ? 'bg-emerald-900/40 text-emerald-400' : selectedIncident.authority_notified === 'pending' ? 'bg-amber-900/40 text-amber-400' : 'bg-slate-800 text-slate-500'">
-                            {{ (selectedIncident.authority_notified || 'not_required').replace(/_/g, ' ') }}
+                            {{ notificationLabel(selectedIncident.authority_notified) }}
                           </span>
                           <div v-if="selectedIncident.authority_notified_at" class="text-slate-600 mt-1">{{ formatDateTime(selectedIncident.authority_notified_at) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Data Subjects</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('incidents.breach.subjects') }}</div>
                           <span class="px-1.5 py-0.5 rounded text-[10px] font-medium"
                             :class="selectedIncident.subjects_notified === 'notified' ? 'bg-emerald-900/40 text-emerald-400' : selectedIncident.subjects_notified === 'pending' ? 'bg-amber-900/40 text-amber-400' : 'bg-slate-800 text-slate-500'">
-                            {{ (selectedIncident.subjects_notified || 'not_required').replace(/_/g, ' ') }}
+                            {{ notificationLabel(selectedIncident.subjects_notified) }}
                           </span>
                           <div v-if="selectedIncident.subjects_notified_at" class="text-slate-600 mt-1">{{ formatDateTime(selectedIncident.subjects_notified_at) }}</div>
                         </div>
@@ -452,15 +422,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('incidents.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="12" placeholder="Add notes..." />
+                    <MarkdownField v-model="editForm.notes" :self-type="'incident'" :self-id="selectedIncident ? String(selectedIncident.id) : ''" :rows="12" :placeholder="t('incidents.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedIncident.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedIncident.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -491,10 +461,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="incident" :entityId="String(selectedIncident.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this incident is permanent and cannot be undone.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('incidents.danger.warning') }}</div>
                     <button @click="deleteSelectedIncident" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete incident
+                      {{ t('incidents.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -505,8 +475,8 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -519,6 +489,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import api from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -540,10 +511,14 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate } from '../composables/useFormat.js'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
 const route = useRoute()
 const router = useRouter()
 const { orgSlug, orgPath } = useCurrentOrg()
+const { t } = useI18n()
+const { enumLabel, entityLabel } = useEnumLabel()
 const { success: showSaved, error: showError } = useToast()
 const { confirm: confirmDialog } = useConfirm()
 
@@ -562,7 +537,7 @@ async function reload() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -571,12 +546,12 @@ const error = ref(null)
 const incidents = ref([])
 const stats = ref({})
 const statusStats = computed(() => [
-  { key: '', label: 'Total', count: stats.value.total || total.value || 0, color: 'text-slate-100' },
-  { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-red-400' },
-  { key: 'investigating', label: 'Investigating', count: stats.value.investigating || 0, color: 'text-amber-400' },
-  { key: 'contained', label: 'Contained', count: stats.value.contained || 0, color: 'text-blue-400' },
-  { key: 'resolved', label: 'Resolved', count: stats.value.resolved || 0, color: 'text-emerald-400' },
-  { key: 'closed', label: 'Closed', count: stats.value.closed || 0, color: 'text-slate-400' },
+  { key: '', label: t('common.stat.total'), count: stats.value.total || total.value || 0, color: 'text-slate-100' },
+  { key: 'open', label: statusLabel('open'), count: stats.value.open || 0, color: 'text-red-400' },
+  { key: 'investigating', label: statusLabel('investigating'), count: stats.value.investigating || 0, color: 'text-amber-400' },
+  { key: 'contained', label: statusLabel('contained'), count: stats.value.contained || 0, color: 'text-blue-400' },
+  { key: 'resolved', label: statusLabel('resolved'), count: stats.value.resolved || 0, color: 'text-emerald-400' },
+  { key: 'closed', label: statusLabel('closed'), count: stats.value.closed || 0, color: 'text-slate-400' },
 ])
 const selectedIncident = ref(null)
 const showCreateForm = ref(false)
@@ -596,17 +571,51 @@ const saving = ref(false)
 
 // orgPath is provided by useCurrentOrg() above.
 
+// The members each <select> offers. The set is this view's own choice; only the
+// label comes from the shared catalogue.
+const STATUSES = ['draft', 'open', 'investigating', 'contained', 'resolved', 'closed']
+const SEVERITIES = ['critical', 'high', 'medium', 'low']
+const INCIDENT_TYPES = ['incident', 'event', 'weakness']
+const ORIGINS = ['internal', 'external', 'internal and external']
+const GDPR_ROLES = ['controller', 'processor']
+const NOTIFICATION_STATES = ['not_required', 'pending', 'notified']
+
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+const statusLabel = (v) => enumLabel('status', v)
+const severityLabel = (v) => enumLabel('severity', v)
+const typeLabel = (v) => enumLabel('incident_type', v)
+// incidents.source shares its value set with risks.origin, so it shares the
+// group — `source` is reserved for corrective_actions.source, a different set.
+const originLabel = (v) => enumLabel('origin', v)
+const gdprRoleLabel = (v) => enumLabel('gdpr_role', v)
+// Defaults to the column default rather than taking it from the call site: a
+// bare stored value in a mustache is what the raw-text scanner counts, and
+// correctly so.
+const notificationLabel = (v) => enumLabel('notification_status', v || 'not_required')
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const severityOptions = options(SEVERITIES, severityLabel)
+const typeOptions = options(INCIDENT_TYPES, typeLabel)
+const originOptions = options(ORIGINS, originLabel)
+const gdprRoleOptions = options(GDPR_ROLES, gdprRoleLabel)
+const notificationOptions = options(NOTIFICATION_STATES, notificationLabel)
+
+// The tab bar was already a computed, so it was reactive — but its labels were
+// English literals, so it was reactive to the wrong thing. It holds keys now.
 const detailTabs = computed(() => {
-  const base = [{ key: 'overview', label: 'Overview' }]
+  const base = [{ key: 'overview', label: t('common.tab.overview') }]
   if (selectedIncident.value?.data_breach) {
-    base.push({ key: 'data_breach', label: 'Data Breach' })
+    base.push({ key: 'data_breach', label: t('incidents.tab.data_breach') })
   }
-  base.push({ key: 'notes', label: 'Notes' })
-  base.push({ key: 'links', label: 'Links' })
-  base.push({ key: 'actions', label: 'Actions' })
-  base.push({ key: 'suggestions', label: 'Suggestions' })
-  base.push({ key: 'comments', label: 'Comments' })
-  base.push({ key: 'history', label: 'History' })
+  base.push({ key: 'notes', label: t('common.tab.notes') })
+  base.push({ key: 'links', label: t('common.tab.links') })
+  base.push({ key: 'actions', label: t('common.tab.actions') })
+  base.push({ key: 'suggestions', label: t('common.tab.suggestions') })
+  base.push({ key: 'comments', label: t('common.tab.comments') })
+  base.push({ key: 'history', label: t('common.tab.history') })
   return base
 })
 
@@ -654,7 +663,7 @@ async function loadAll() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }
@@ -679,7 +688,7 @@ async function loadIncidents() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -725,21 +734,8 @@ async function createIncident() {
       router.push(orgPath(`/incidents/${fresh.id}`))
     }
   } catch (e) {
-    error.value = e.message
-    showError('Failed to create incident: ' + (e.message || 'unknown error'))
-  }
-}
-
-async function changeStatus(inc, status) {
-  try {
-    await api.updateIncidentStatus(inc.id, status)
-    inc.status = status
-    if (selectedIncident.value?.id === inc.id) {
-      selectedIncident.value = { ...inc, status }
-    }
-    await loadStats()
-  } catch (e) {
-    showError(e.message || 'Status change failed')
+    error.value = renderApiError(e)
+    showError(t('incidents.error.create', { message: renderApiError(e) }))
   }
 }
 
@@ -757,14 +753,14 @@ function createLinkedCA() {
 
 async function deleteSelectedIncident() {
   if (!selectedIncident.value) return
-  if (!await confirmDialog({ message: `Delete incident "${selectedIncident.value.title}"? This cannot be undone.`, confirmLabel: 'Delete', variant: 'danger' })) return
+  if (!await confirmDialog({ message: t('incidents.danger.confirm', { title: selectedIncident.value.title }), confirmLabel: t('common.action.delete'), variant: 'danger' })) return
   try {
     await api.deleteIncident(selectedIncident.value.id)
     closeDetail()
     await loadIncidents()
   } catch (e) {
-    error.value = e.message
-    showError('Failed to delete incident: ' + (e.message || 'unknown error'))
+    error.value = renderApiError(e)
+    showError(t('incidents.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -819,9 +815,9 @@ async function saveSection() {
       } catch {}
     }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('incidents.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
@@ -838,9 +834,9 @@ async function selectIncident(inc) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('incidents.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('incidents.dirty.discard'),
     })
     if (!ok) return
   }
@@ -851,9 +847,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('incidents.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('incidents.dirty.discard'),
     })
     if (!ok) return
   }

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -19,15 +19,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Legal Register</h1>
-          <p class="text-sm text-slate-500 mt-1">Applicable legislation and regulatory risk assessment</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('legal.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('legal.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite" @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ showCreateForm ? 'Cancel' : 'Add Legal Requirement' }}
+            {{ showCreateForm ? t('common.action.cancel') : t('legal.action.add') }}
           </button>
-          <SuggestNewButton entityType="legal_requirement" typeLabel="Legal Requirement" />
+          <SuggestNewButton entityType="legal_requirement" :typeLabel="entityLabel('legal_requirement')" />
         </div>
       </div>
 
@@ -38,7 +38,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Legal Requirement</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('legal.create.heading') }}</h2>
           <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -47,29 +47,29 @@
         </div>
         <div class="space-y-3">
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newItem.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. GDPR, NIS2 Directive" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.create.title_label') }}</label>
+            <input v-model="newItem.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('legal.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.create.category_label') }}</label>
             <div class="flex flex-wrap gap-1.5">
               <button v-for="cat in legalCategories" :key="cat.key"
                 @click="newItem.category = newItem.category === cat.key ? '' : cat.key"
                 class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
                 :class="newItem.category === cat.key ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'"
-                :title="newItem.category === cat.key ? 'Click to deselect' : ''">
+                :title="newItem.category === cat.key ? t('legal.create.deselect_hint') : ''">
                 {{ cat.label }}
               </button>
             </div>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add jurisdiction, owner, treatment and more after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('legal.create.fill_in_later') }}</div>
 
         <!-- Footer -->
         <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createItem" :disabled="!newItem.title" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            Add
+            {{ t('legal.create.submit') }}
           </button>
         </div>
       </div>
@@ -86,10 +86,10 @@
           <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
           </svg>
-          Risk Map
+          {{ t('legal.map.summary') }}
         </summary>
         <div class="mt-3">
-          <HeatMap :items="heatMapItems" title="Compliance Risk Map" />
+          <HeatMap :items="heatMapItems" :title="t('legal.map.heading')" />
         </div>
       </details>
 
@@ -101,40 +101,35 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="searchQuery" type="text" placeholder="Search..."
+            <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="filterLevel" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All levels</option>
-            <option value="critical">Critical</option>
-            <option value="high">High</option>
-            <option value="medium">Medium</option>
-            <option value="low">Low</option>
+            <option value="">{{ t('common.filter.all_levels') }}</option>
+            <option v-for="o in levelOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <select v-model="filterCategory" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All categories</option>
+            <option value="">{{ t('common.filter.all_categories') }}</option>
             <option v-for="cat in legalCategories" :key="cat.key" :value="cat.key">{{ cat.label }}</option>
           </select>
           <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="draft">Draft</option>
-            <option value="open">Open</option>
-            <option value="closed">Closed</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <button v-if="filterLevel || filterCategory || filterStatus || searchQuery"
             @click="filterLevel = ''; filterCategory = ''; filterStatus = ''; searchQuery = ''"
             class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-            Clear
+            {{ t('common.action.clear') }}
           </button>
           <div class="ml-auto text-xs text-slate-500 tabular-nums">
-            {{ total }} total
+            {{ t('common.count.total', { count: total }) }}
           </div>
         </div>
       </div>
 
       <!-- Empty state -->
       <div v-if="items.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-        <div class="text-sm text-slate-500">No legal requirements found</div>
+        <div class="text-sm text-slate-500">{{ t('legal.filter.empty') }}</div>
       </div>
 
       <!-- Table -->
@@ -142,12 +137,12 @@
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Jurisdiction</th>
-              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Score</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Treatment</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('legal.table.header.title') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('legal.table.header.jurisdiction') }}</th>
+              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('legal.table.header.score') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('legal.table.header.treatment') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('legal.table.header.status') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('legal.table.header.owner') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-800/50">
@@ -157,7 +152,7 @@
               <td class="px-5 py-3.5">
                 <div class="flex items-center gap-2">
                   <span class="text-sm font-medium text-slate-200">{{ item.title }}</span>
-                  <span v-if="isOverdue(item.next_review)" class="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-900/50 text-red-400">OVERDUE</span>
+                  <span v-if="isOverdue(item.next_review)" class="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-900/50 text-red-400">{{ t('common.state.overdue') }}</span>
                 </div>
                 <div v-if="item.reference" class="text-xs text-slate-500 mt-0.5">{{ item.reference }}</div>
               </td>
@@ -172,7 +167,7 @@
                 </span>
                 <span v-else class="text-slate-600 text-xs">-</span>
               </td>
-              <td class="px-5 py-3.5 text-sm text-slate-400 capitalize">{{ (item.treatment || '-').replace(/_/g, ' ') }}</td>
+              <td class="px-5 py-3.5 text-sm text-slate-400">{{ treatmentLabel(item.treatment) || '-' }}</td>
               <td class="px-5 py-3.5">
                 <StatusBadge :status="item.status" />
               </td>
@@ -211,10 +206,10 @@
             <!-- Left nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -226,21 +221,21 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('legal.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.title') }}</label>
                         <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'legal'" :self-id="selectedItem?.identifier || ''" :rows="3" placeholder="Describe the requirement..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'legal'" :self-id="selectedItem?.identifier || ''" :rows="3" :placeholder="t('legal.placeholder.description')" />
                       </div>
                       <div class="relative">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Jurisdiction</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.jurisdiction') }}</label>
                         <input v-model="editForm.jurisdiction"
                           @focus="showJurisdictionPicker = true"
                           @input="showJurisdictionPicker = true"
@@ -251,7 +246,7 @@
                           @keydown.enter.prevent="filteredJurisdictions.length && (editForm.jurisdiction = filteredJurisdictions[jurisdictionIdx], showJurisdictionPicker = false)"
                           @keydown.escape="showJurisdictionPicker = false"
                           class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                          placeholder="Type to search..." />
+                          :placeholder="t('legal.placeholder.jurisdiction')" />
                         <div v-if="showJurisdictionPicker && filteredJurisdictions.length > 0"
                           class="absolute z-50 left-0 right-0 mt-1 bg-slate-900 border border-slate-700 rounded-lg shadow-xl max-h-48 overflow-y-auto">
                           <button v-for="(j, i) in filteredJurisdictions" :key="j"
@@ -263,77 +258,75 @@
                         </div>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.category') }}</label>
                         <select v-model="editForm.category" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="">None</option>
+                          <option value="">{{ t('common.option.none') }}</option>
                           <option v-for="cat in legalCategories" :key="cat.key" :value="cat.key">{{ cat.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="draft">Draft</option>
-                          <option value="open">Open</option>
-                          <option value="closed">Closed</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                        <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.owner') }}</label>
+                        <MemberPicker v-model="editForm.owner" :members="orgMembers" :placeholder="t('common.placeholder.select_owner')" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Reference (article/section)</label>
-                        <input v-model="editForm.reference" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. Article 32, Section 4.2" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.reference_label') }}</label>
+                        <input v-model="editForm.reference" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('legal.placeholder.reference')" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">URL</label>
-                        <input v-model="editForm.url" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="https://..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.url') }}</label>
+                        <input v-model="editForm.url" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('legal.placeholder.url')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Title</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('legal.field.title') }}</div>
                         <div class="text-sm text-slate-200 font-medium">{{ selectedItem.title }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('legal.field.description') }}</div>
                         <div v-if="selectedItem.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedItem.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('legal.field.status') }}</div>
                           <StatusBadge :status="selectedItem.status" />
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('legal.field.owner') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.owner) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Jurisdiction</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('legal.field.jurisdiction') }}</div>
                           <div class="text-sm text-slate-300">{{ selectedItem.jurisdiction || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Category</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ formatLabel(selectedItem.category) || '—' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('legal.field.category') }}</div>
+                          <div class="text-sm text-slate-300">{{ categoryLabel(selectedItem.category) || '—' }}</div>
                         </div>
                         <div v-if="selectedItem.created_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('legal.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedItem.created_at) }}</div>
                         </div>
                         <div v-if="selectedItem.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('legal.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.created_by) }}</div>
                         </div>
                       </div>
                       <div class="pt-1">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Reference</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('legal.field.reference') }}</div>
                         <div class="text-sm text-slate-300">{{ selectedItem.reference || '—' }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">URL</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('legal.field.url') }}</div>
                         <a v-if="selectedItem.url" :href="selectedItem.url" target="_blank" rel="noopener" class="text-sm text-blue-400 hover:text-blue-300 break-all">{{ selectedItem.url }}</a>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
@@ -346,31 +339,32 @@
               <template v-if="detailTab === 'treatment'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Treatment</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('treatment')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('legal.detail.treatment') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('treatment')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'treatment'">
                     <div class="space-y-4">
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Treatment</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.treatment') }}</label>
                         <select v-model="editForm.treatment" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="">Not decided</option><option value="mitigate">Mitigate</option><option value="accept">Accept</option><option value="transfer">Transfer</option><option value="avoid">Avoid</option>
+                          <option value="">{{ t('common.option.not_decided') }}</option>
+                          <option v-for="o in treatmentOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Treatment Plan</label>
-                        <MarkdownField v-model="editForm.treatment_plan" :self-type="'legal'" :self-id="selectedItem?.identifier || ''" :rows="4" placeholder="How are we addressing this requirement? (controls, policies, actions...)" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('legal.field.treatment_plan') }}</label>
+                        <MarkdownField v-model="editForm.treatment_plan" :self-type="'legal'" :self-id="selectedItem?.identifier || ''" :rows="4" :placeholder="t('legal.placeholder.treatment_plan')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Treatment</div>
-                        <div class="text-sm text-slate-300 capitalize">{{ selectedItem.treatment || '—' }}</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('legal.field.treatment') }}</div>
+                        <div class="text-sm text-slate-300">{{ treatmentLabel(selectedItem.treatment) || '—' }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Treatment Plan</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('legal.field.treatment_plan') }}</div>
                         <div v-if="selectedItem.treatment_plan" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedItem.treatment_plan)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
@@ -386,20 +380,20 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDay(selectedItem.next_review) }}
+                    {{ t('common.review.overdue_since', { date: formatDay(selectedItem.next_review) }) }}
                   </div>
                   <div class="flex items-center gap-4">
                     <div class="flex gap-3 flex-1">
                       <div class="bg-slate-800/60 border border-slate-600/50 rounded-lg px-5 py-3 text-center min-w-[90px] ring-1 ring-slate-600/20">
-                        <div class="text-[9px] text-slate-400 uppercase tracking-wider">Current</div>
+                        <div class="text-[9px] text-slate-400 uppercase tracking-wider">{{ t('legal.assessment.current') }}</div>
                         <div v-if="selectedItem.current_score" class="text-xl font-bold tabular-nums mt-1" :class="scoreColor(selectedItem.current_score)">{{ selectedItem.current_score }}</div>
                         <div v-else class="text-xl text-slate-700 mt-1">—</div>
                       </div>
                     </div>
                   </div>
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">{{ t('common.review.last', { date: formatDay(selectedItem.last_review) }) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">{{ t('common.review.next', { date: formatDay(selectedItem.next_review) }) }}</span>
                   </div>
                   <div class="border-t border-slate-800 pt-4">
                     <ReadingsPanel entityType="legal_requirement" :entityId="selectedItem.id" :identifier="selectedItem.identifier || ('LEGAL-' + selectedItem.id)" :canWrite="canWrite"
@@ -413,15 +407,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('legal.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'legal'" :self-id="selectedItem?.identifier || ''" :rows="12" placeholder="Additional notes, observations, interpretations... Type /doc to link a document" />
+                    <MarkdownField v-model="editForm.notes" :self-type="'legal'" :self-id="selectedItem?.identifier || ''" :rows="12" :placeholder="t('legal.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedItem.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedItem.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -452,10 +446,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="legal_requirement" :entityId="String(selectedItem.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this legal requirement is permanent and cannot be undone. History, comments, and linked references will be lost.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('legal.danger.warning') }}</div>
                     <button @click="deleteSelectedItem" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete requirement
+                      {{ t('legal.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -466,8 +460,8 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -482,6 +476,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -506,7 +501,11 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate, formatDay } from '../composables/useFormat.js'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
+const { t } = useI18n()
+const { enumLabel, entityLabel } = useEnumLabel()
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
 
@@ -527,7 +526,7 @@ async function reload() {
   try {
     await loadItems()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -566,27 +565,49 @@ const filteredJurisdictions = computed(() => {
 watch(() => editForm.value.jurisdiction, () => { jurisdictionIdx.value = 0 })
 function hideJurisdictionPicker() { setTimeout(() => { showJurisdictionPicker.value = false }, 200) }
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'treatment', label: 'Treatment' },
-  { key: 'assessment', label: 'Assessment' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Message keys, not labels: a module-scope array of translated strings freezes
+// the tab bar in whichever locale was active when this module first evaluated.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'treatment', label: 'common.tab.treatment' },
+  { key: 'assessment', label: 'common.tab.assessment' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
+]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
+
+// The members each <select> offers. The set is this view's own choice; only the
+// label comes from the shared catalogue.
+const STATUSES = ['draft', 'open', 'closed']
+const LEVELS = ['critical', 'high', 'medium', 'low']
+const TREATMENTS = ['mitigate', 'accept', 'transfer', 'avoid']
+
+// The category list this view has always offered. It does NOT match
+// db.LegalCategories — six of these eight are rejected on save, which is #269
+// and not an extraction's to fix. Unchanged here; only the labels moved to the
+// catalogue, which carries the server's five as well so a value stored through
+// the API or CLI also renders.
+const CATEGORY_KEYS = [
+  'data_protection', 'employment', 'contractual', 'regulatory',
+  'intellectual_property', 'financial', 'environmental', 'corporate',
 ]
 
-const legalCategories = [
-  { key: 'data_protection', label: 'Data Protection' },
-  { key: 'employment', label: 'Employment Law' },
-  { key: 'contractual', label: 'Contractual' },
-  { key: 'regulatory', label: 'Regulatory Compliance' },
-  { key: 'intellectual_property', label: 'Intellectual Property' },
-  { key: 'financial', label: 'Financial Regulation' },
-  { key: 'environmental', label: 'Environmental' },
-  { key: 'corporate', label: 'Corporate Governance' },
-]
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+const statusLabel = (v) => enumLabel('status', v)
+const levelLabel = (v) => enumLabel('severity', v)
+const treatmentLabel = (v) => enumLabel('treatment', v)
+const categoryLabel = (v) => enumLabel('legal_category', v)
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const levelOptions = options(LEVELS, levelLabel)
+const treatmentOptions = options(TREATMENTS, treatmentLabel)
+const legalCategories = computed(() => CATEGORY_KEYS.map((key) => ({ key, label: categoryLabel(key) })))
 
 useModalEscape(showCreateForm)
 useModalEscape(computed(() => !!selectedItem.value), closeDetail)
@@ -595,12 +616,12 @@ const stats = ref({ total: 0, critical: 0, high: 0, medium: 0, low: 0, not_asses
 const criticalCount = computed(() => stats.value.critical)
 const highCount = computed(() => stats.value.high)
 const statusStats = computed(() => [
-  { key: '', label: 'Total', count: stats.value.total || items.value.length, color: 'text-slate-100' },
-  { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-blue-400' },
-  { key: 'draft', label: 'Draft', count: stats.value.draft || 0, color: 'text-amber-400' },
-  { key: 'closed', label: 'Closed', count: stats.value.closed || 0, color: 'text-slate-400' },
-  { key: 'critical', label: 'Critical', count: criticalCount.value, color: criticalCount.value > 0 ? 'text-red-400' : 'text-slate-100', static: true },
-  { key: 'high', label: 'High', count: highCount.value, color: highCount.value > 0 ? 'text-orange-400' : 'text-slate-100', static: true },
+  { key: '', label: t('common.stat.total'), count: stats.value.total || items.value.length, color: 'text-slate-100' },
+  { key: 'open', label: statusLabel('open'), count: stats.value.open || 0, color: 'text-blue-400' },
+  { key: 'draft', label: statusLabel('draft'), count: stats.value.draft || 0, color: 'text-amber-400' },
+  { key: 'closed', label: statusLabel('closed'), count: stats.value.closed || 0, color: 'text-slate-400' },
+  { key: 'critical', label: levelLabel('critical'), count: criticalCount.value, color: criticalCount.value > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: 'high', label: levelLabel('high'), count: highCount.value, color: highCount.value > 0 ? 'text-orange-400' : 'text-slate-100', static: true },
 ])
 const notAssessedCount = computed(() => stats.value.not_assessed)
 
@@ -630,8 +651,6 @@ function scoreColor(score) {
   return 'bg-emerald-900/60 text-emerald-300'
 }
 
-function formatLabel(s) { return (s || '').replace(/_/g, ' ') }
-
 function isOverdue(dateStr) {
   if (!dateStr) return false
   const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
@@ -658,7 +677,7 @@ async function loadItems() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -708,9 +727,9 @@ async function saveSection() {
     const fresh = items.value.find(i => i.id === selectedItem.value.id)
     if (fresh) { selectedItem.value = fresh; startEdit(fresh) }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('legal.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
@@ -739,9 +758,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('legal.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('legal.dirty.discard'),
     })
     if (!ok) return
   }
@@ -752,9 +771,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('legal.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('legal.dirty.discard'),
     })
     if (!ok) return
   }
@@ -784,20 +803,20 @@ async function createItem() {
       router.push(orgPath(`/legal/${fresh.id}`))
     }
   } catch (e) {
-    showError('Failed to create legal requirement: ' + e.message)
+    showError(t('legal.error.create', { message: renderApiError(e) }))
   }
 }
 
 async function deleteSelectedItem() {
   if (!selectedItem.value) return
-  const ok = await confirmDialog({ message: 'Delete this legal requirement? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({ message: t('legal.danger.confirm'), variant: 'danger', confirmLabel: t('common.action.delete') })
   if (!ok) return
   try {
     await api.deleteJSON(`/api/v1/legal/${selectedItem.value.id}`)
     closeDetail()
     await loadItems()
   } catch (e) {
-    showError('Failed to delete: ' + e.message)
+    showError(t('legal.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -810,7 +829,7 @@ onMounted(async () => {
     ])
     orgMembers.value = users || []
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -9,7 +9,7 @@
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
       <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
-        <span>Failed to load risks. {{ error }}</span>
+        <span>{{ t('risks.error.load', { message: error }) }}</span>
         <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
@@ -19,17 +19,17 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Risk Register</h1>
-          <p class="text-sm text-slate-500 mt-1">Information security risk assessment and treatment</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('risks.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('risks.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite"
             @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
           >
-            {{ showCreateForm ? 'Cancel' : 'Add Risk' }}
+            {{ showCreateForm ? t('common.action.cancel') : t('risks.action.add') }}
           </button>
-          <SuggestNewButton entityType="risk" typeLabel="Risk" />
+          <SuggestNewButton entityType="risk" :typeLabel="entityLabel('risk')" />
         </div>
       </div>
 
@@ -40,7 +40,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Risk</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('risks.create.heading') }}</h2>
           <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -49,29 +49,29 @@
         </div>
         <div class="space-y-3">
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newRisk.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. Ransomware attack on production systems" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.create.title_label') }}</label>
+            <input v-model="newRisk.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('risks.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.create.category_label') }}</label>
             <div class="flex flex-wrap gap-1.5">
               <button v-for="cat in riskCategories" :key="cat.key"
                 @click="newRisk.category = newRisk.category === cat.key ? '' : cat.key"
                 class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
                 :class="newRisk.category === cat.key ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'"
-                :title="newRisk.category === cat.key ? 'Click to deselect' : ''">
+                :title="newRisk.category === cat.key ? t('risks.create.deselect_hint') : ''">
                 {{ cat.label }}
               </button>
             </div>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, consequences, treatment, owner and more after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('risks.create.fill_in_later') }}</div>
 
         <!-- Footer -->
         <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createRisk" :disabled="!newRisk.title" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            Add
+            {{ t('risks.create.submit') }}
           </button>
         </div>
       </div>
@@ -89,10 +89,10 @@
           <svg class="w-4 h-4 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
           </svg>
-          Risk Map
+          {{ t('risks.map.heading') }}
         </summary>
         <div class="mt-3">
-          <HeatMap :items="allRisksForMap" title="Risk Map" @cell-click="onHeatMapClick" />
+          <HeatMap :items="allRisksForMap" :title="t('risks.map.heading')" @cell-click="onHeatMapClick" />
         </div>
       </details>
 
@@ -104,33 +104,28 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="searchQuery" type="text" placeholder="Search..."
+            <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="filterLevel" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All levels</option>
-            <option value="critical">Critical</option>
-            <option value="high">High</option>
-            <option value="medium">Medium</option>
-            <option value="low">Low</option>
+            <option value="">{{ t('common.filter.all_levels') }}</option>
+            <option v-for="o in levelOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <select v-model="filterCategory" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All categories</option>
+            <option value="">{{ t('common.filter.all_categories') }}</option>
             <option v-for="cat in riskCategories" :key="cat.key" :value="cat.key">{{ cat.label }}</option>
           </select>
           <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="draft">Draft</option>
-            <option value="open">Open</option>
-            <option value="closed">Closed</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <button v-if="filterLevel || filterCategory || filterStatus || searchQuery"
             @click="filterLevel = ''; filterCategory = ''; filterStatus = ''; searchQuery = ''"
             class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-            Clear
+            {{ t('common.action.clear') }}
           </button>
           <div class="ml-auto text-xs text-slate-500 tabular-nums">
-            {{ total }} total
+            {{ t('common.count.total', { count: total }) }}
           </div>
         </div>
       </div>
@@ -138,10 +133,10 @@
       <!-- Empty state -->
       <div v-if="risks.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
         <div v-if="filterLevel || filterCategory || filterStatus || searchQuery" class="text-sm text-slate-500">
-          No risks match your filter.
+          {{ t('risks.filter.empty') }}
         </div>
         <div v-else class="text-sm text-slate-500">
-          No risks yet — click Add to create your first one.
+          {{ t('risks.filter.none_yet') }}
         </div>
       </div>
 
@@ -150,14 +145,14 @@
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Risk</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Type</th>
-              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Score</th>
-              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">C/I/A</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Treatment</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-              <th class="text-right px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Actions</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.risk') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.type') }}</th>
+              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.score') }}</th>
+              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.cia') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.owner') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.treatment') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.status') }}</th>
+              <th class="text-right px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('risks.table.header.actions') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-800/50">
@@ -169,7 +164,7 @@
                 <td class="px-5 py-3.5">
                   <div class="flex items-center gap-2">
                     <span class="text-sm font-medium text-slate-200">{{ risk.title || risk.risk_id }}</span>
-                    <span v-if="isOverdue(risk.next_review)" class="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-900/50 text-red-400">OVERDUE</span>
+                    <span v-if="isOverdue(risk.next_review)" class="px-1.5 py-0.5 rounded text-[9px] font-semibold bg-red-900/50 text-red-400">{{ t('common.state.overdue') }}</span>
                   </div>
                   <div v-if="risk.category" class="text-[10px] text-slate-600 mt-0.5">{{ categoryLabel(risk.category) }}</div>
                   <div v-if="risk.description" class="text-xs text-slate-500 mt-0.5 truncate max-w-xs">{{ stripMd(risk.description) }}</div>
@@ -177,7 +172,7 @@
                 <td class="px-5 py-3.5">
                   <span v-if="risk.risk_type" class="inline-block px-2 py-0.5 rounded text-xs font-medium"
                     :class="risk.risk_type === 'opportunity' ? 'bg-emerald-900/40 text-emerald-400' : 'bg-red-900/40 text-red-400'">
-                    {{ risk.risk_type }}
+                    {{ riskTypeLabel(risk.risk_type) }}
                   </span>
                   <span v-else class="text-slate-600 text-xs">-</span>
                 </td>
@@ -189,29 +184,29 @@
                     >
                       {{ risk.current_score ?? '-' }}
                     </span>
-                    <span v-if="risk.inherent_score" class="text-[9px] text-slate-600">was {{ risk.inherent_score }}</span>
+                    <span v-if="risk.inherent_score" class="text-[9px] text-slate-600">{{ t('risks.table.was_score', { score: risk.inherent_score }) }}</span>
                   </div>
                 </td>
                 <td class="px-5 py-3.5 text-center">
                   <div class="flex gap-0.5 justify-center">
-                    <span v-if="risk.confidentiality_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.confidentiality_impact)" :title="'Confidentiality: ' + ciaLabel(risk.confidentiality_impact)">C{{ risk.confidentiality_impact }}</span>
-                    <span v-if="risk.integrity_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.integrity_impact)" :title="'Integrity: ' + ciaLabel(risk.integrity_impact)">I{{ risk.integrity_impact }}</span>
-                    <span v-if="risk.availability_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.availability_impact)" :title="'Availability: ' + ciaLabel(risk.availability_impact)">A{{ risk.availability_impact }}</span>
+                    <span v-if="risk.confidentiality_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.confidentiality_impact)" :title="t('risks.table.cia_title.confidentiality', { level: ciaLabel(risk.confidentiality_impact) })">C{{ risk.confidentiality_impact }}</span>
+                    <span v-if="risk.integrity_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.integrity_impact)" :title="t('risks.table.cia_title.integrity', { level: ciaLabel(risk.integrity_impact) })">I{{ risk.integrity_impact }}</span>
+                    <span v-if="risk.availability_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.availability_impact)" :title="t('risks.table.cia_title.availability', { level: ciaLabel(risk.availability_impact) })">A{{ risk.availability_impact }}</span>
                     <span v-if="!risk.confidentiality_impact && !risk.integrity_impact && !risk.availability_impact" class="text-slate-600 text-xs">-</span>
                   </div>
                 </td>
                 <td class="px-5 py-3.5 text-sm text-slate-400">{{ resolveUserName(risk.owner) }}</td>
-                <td class="px-5 py-3.5 text-sm text-slate-400 capitalize">{{ (risk.treatment || '-').replace(/_/g, ' ') }}</td>
+                <td class="px-5 py-3.5 text-sm text-slate-400">{{ treatmentLabel(risk.treatment) || '-' }}</td>
                 <td class="px-5 py-3.5">
                   <StatusBadge :status="risk.status" />
                 </td>
                 <td class="px-5 py-3.5 text-right">
                   <div class="flex items-center justify-end gap-2">
-                    <span v-if="riskAdvisories[risk.id]?.length" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-medium bg-amber-900/40 text-amber-400 border border-amber-800/40" title="CIA mismatch with linked assets — reassessment needed">
+                    <span v-if="riskAdvisories[risk.id]?.length" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-medium bg-amber-900/40 text-amber-400 border border-amber-800/40" :title="t('risks.table.advisory_title')">
                       <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                       </svg>
-                      Review
+                      {{ t('risks.table.advisory_badge') }}
                     </span>
                   </div>
                 </td>
@@ -251,10 +246,10 @@
             <!-- Primary nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -266,48 +261,48 @@
                 <div class="px-6 py-5 space-y-5">
                   <!-- Section header -->
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('risks.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <!-- Edit mode -->
                     <div class="space-y-4">
                       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         <div class="sm:col-span-2">
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.title') }}</label>
                           <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                         </div>
                         <div class="sm:col-span-2">
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                          <MarkdownField v-model="editForm.description" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="3" placeholder="Describe the risk..." />
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.description') }}</label>
+                          <MarkdownField v-model="editForm.description" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="3" :placeholder="t('risks.placeholder.description')" />
                         </div>
                         <div>
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.status') }}</label>
                           <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                            <option value="draft">Draft</option><option value="open">Open</option><option value="closed">Closed</option>
+                            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                           </select>
                         </div>
                         <div>
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                          <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.owner') }}</label>
+                          <MemberPicker v-model="editForm.owner" :members="orgMembers" :placeholder="t('common.placeholder.select_owner')" />
                         </div>
                         <div>
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.category') }}</label>
                           <select v-model="editForm.category" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                            <option value="">None</option>
+                            <option value="">{{ t('common.option.none') }}</option>
                             <option v-for="cat in riskCategories" :key="cat.key" :value="cat.key">{{ cat.label }}</option>
                           </select>
                         </div>
                         <div>
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Risk Type</label>
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.risk_type') }}</label>
                           <select v-model="editForm.risk_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                            <option value="threat">Threat</option><option value="opportunity">Opportunity</option>
+                            <option v-for="o in riskTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                           </select>
                         </div>
                         <div>
-                          <label class="block text-xs font-medium text-slate-500 mb-1">Origin</label>
+                          <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.origin') }}</label>
                           <select v-model="editForm.origin" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                            <option value="internal">Internal</option><option value="external">External</option><option value="internal and external">Internal &amp; External</option>
+                            <option v-for="o in originOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                           </select>
                         </div>
                       </div>
@@ -318,13 +313,13 @@
                     <div class="space-y-4">
                       <!-- Title -->
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Title</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('risks.field.title') }}</div>
                         <div class="text-sm text-slate-200 font-medium">{{ selectedRisk.title }}</div>
                       </div>
 
                       <!-- Description -->
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('risks.field.description') }}</div>
                         <div v-if="selectedRisk.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedRisk.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
@@ -332,31 +327,31 @@
                       <!-- 2-column metadata -->
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.status') }}</div>
                           <StatusBadge :status="selectedRisk.status" />
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.owner') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedRisk.owner) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Category</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.category') }}</div>
                           <div class="text-sm text-slate-300">{{ categoryLabel(selectedRisk.category) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Risk Type</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ selectedRisk.risk_type || '—' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.risk_type') }}</div>
+                          <div class="text-sm text-slate-300">{{ riskTypeLabel(selectedRisk.risk_type) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Origin</div>
-                          <div class="text-sm text-slate-300">{{ formatOrigin(selectedRisk.origin) || '—' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.origin') }}</div>
+                          <div class="text-sm text-slate-300">{{ originLabel(selectedRisk.origin) || '—' }}</div>
                         </div>
                         <div v-if="selectedRisk.created_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedRisk.created_at) }}</div>
                         </div>
                         <div v-if="selectedRisk.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('risks.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedRisk.created_by) }}</div>
                         </div>
                       </div>
@@ -370,32 +365,33 @@
               <template v-if="detailTab === 'treatment'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Treatment</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('treatment')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('risks.detail.treatment') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('treatment')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'treatment'">
                     <div class="space-y-4">
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Treatment</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.treatment') }}</label>
                         <select v-model="editForm.treatment" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="">Not decided</option><option value="mitigate">Mitigate</option><option value="accept">Accept</option><option value="transfer">Transfer</option><option value="avoid">Avoid</option>
+                          <option value="">{{ t('common.option.not_decided') }}</option>
+                          <option v-for="o in treatmentOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Treatment Plan</label>
-                        <MarkdownField v-model="editForm.treatment_plan" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="4" placeholder="How are we addressing this risk?" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('risks.field.treatment_plan') }}</label>
+                        <MarkdownField v-model="editForm.treatment_plan" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="4" :placeholder="t('risks.placeholder.treatment_plan')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Treatment</div>
-                        <div class="text-sm text-slate-300 capitalize">{{ selectedRisk.treatment || '—' }}</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('risks.field.treatment') }}</div>
+                        <div class="text-sm text-slate-300">{{ treatmentLabel(selectedRisk.treatment) || '—' }}</div>
                       </div>
 
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Treatment Plan</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('risks.field.treatment_plan') }}</div>
                         <div v-if="selectedRisk.treatment_plan" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedRisk.treatment_plan)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
@@ -407,155 +403,16 @@
               <!-- ═══ ACTIONS ═══ -->
               <template v-if="detailTab === 'actions'">
                 <div class="px-6 py-5 space-y-4">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Quick actions</div>
-                  <div v-if="!canWrite" class="text-xs text-slate-600 italic">Read-only — actions require manager or admin role.</div>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('common.heading.quick_actions') }}</div>
+                  <div v-if="!canWrite" class="text-xs text-slate-600 italic">{{ t('common.read_only.actions') }}</div>
                   <div v-else class="flex flex-col gap-3 max-w-md">
                     <button @click="createLinkedTask"
                       class="flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-slate-900 hover:bg-slate-800 border border-slate-700 hover:border-slate-600 transition-colors text-left">
                       <div>
-                        <div class="text-sm font-medium text-slate-200">Create Implementation Task</div>
-                        <div class="text-xs text-slate-500 mt-0.5">Spawn a task to action the treatment plan; auto-linked back to this risk.</div>
+                        <div class="text-sm font-medium text-slate-200">{{ t('risks.actions.create_task') }}</div>
+                        <div class="text-xs text-slate-500 mt-0.5">{{ t('risks.actions.create_task_desc') }}</div>
                       </div>
                       <span class="text-slate-500 text-lg">→</span>
-                    </button>
-                  </div>
-                </div>
-              </template>
-
-              <!-- ═══ EDIT (full form, hidden — kept for backwards compat) ═══ -->
-              <template v-if="detailTab === 'edit'">
-                <div class="px-6 py-5 space-y-4">
-                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
-                      <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
-                    </div>
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                      <MarkdownField v-model="editForm.description" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="3" placeholder="Describe the risk..." />
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
-                      <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="draft">Draft</option><option value="open">Open</option><option value="closed">Closed</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                      <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
-                      <select v-model="editForm.category" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="">None</option>
-                        <option v-for="cat in riskCategories" :key="cat.key" :value="cat.key">{{ cat.label }}</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Risk Type</label>
-                      <select v-model="editForm.risk_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="threat">Threat</option><option value="opportunity">Opportunity</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Origin</label>
-                      <select v-model="editForm.origin" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="internal">Internal</option><option value="external">External</option><option value="internal and external">Internal &amp; External</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Treatment</label>
-                      <select v-model="editForm.treatment" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="">Not decided</option><option value="mitigate">Mitigate</option><option value="accept">Accept</option><option value="transfer">Transfer</option><option value="avoid">Avoid</option>
-                      </select>
-                    </div>
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Treatment Plan</label>
-                      <MarkdownField v-model="editForm.treatment_plan" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="2" placeholder="Treatment plan..." />
-                    </div>
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Notes</label>
-                      <MarkdownField v-model="editForm.notes" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="2" placeholder="Additional notes..." />
-                    </div>
-                  </div>
-                  <div class="flex justify-end gap-3 pt-2 border-t border-slate-800">
-                    <button @click="cancelSection(); detailTab = 'overview'" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200">Cancel</button>
-                    <button @click="saveSection().then(() => { detailTab = 'overview' })" :disabled="riskSaving" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg">
-                      {{ riskSaving ? 'Saving...' : 'Save' }}
-                    </button>
-                  </div>
-                </div>
-              </template>
-
-              <!-- ═══ EDIT (shown when editing from overview) ═══ -->
-              <template v-if="detailTab === 'edit'">
-                <div class="px-6 py-5 space-y-4">
-                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
-                      <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
-                    </div>
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                      <textarea v-model="editForm.description" rows="3" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" placeholder="Risk scenario..."></textarea>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
-                      <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="draft">Draft</option>
-                        <option value="open">Open</option>
-                        <option value="closed">Closed</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                      <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
-                      <select v-model="editForm.category" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="">None</option>
-                        <option v-for="cat in riskCategories" :key="cat.key" :value="cat.key">{{ cat.label }}</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Risk Type</label>
-                      <select v-model="editForm.risk_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="threat">Threat</option>
-                        <option value="opportunity">Opportunity</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Origin</label>
-                      <select v-model="editForm.origin" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="internal">Internal</option>
-                        <option value="external">External</option>
-                        <option value="internal and external">Internal &amp; External</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Treatment</label>
-                      <select v-model="editForm.treatment" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="">Not decided</option>
-                        <option value="mitigate">Mitigate</option>
-                        <option value="accept">Accept</option>
-                        <option value="transfer">Transfer</option>
-                        <option value="avoid">Avoid</option>
-                      </select>
-                    </div>
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Treatment Plan</label>
-                      <MarkdownField v-model="editForm.treatment_plan" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="2" placeholder="Treatment plan..." />
-                    </div>
-                    <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Notes</label>
-                      <MarkdownField v-model="editForm.notes" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="2" placeholder="Additional notes..." />
-                    </div>
-                  </div>
-                  <div class="flex justify-end gap-3 pt-2 border-t border-slate-800">
-                    <button @click="cancelSection(); detailTab = 'overview'" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-                    <button @click="saveSection().then(() => { detailTab = 'overview' })" :disabled="riskSaving" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors">
-                      {{ riskSaving ? 'Saving...' : 'Save' }}
                     </button>
                   </div>
                 </div>
@@ -565,17 +422,17 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('risks.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
                     <div>
-                      <MarkdownField v-model="editForm.notes" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="12" placeholder="Add notes, observations, meeting minutes, references..." />
+                      <MarkdownField v-model="editForm.notes" :self-type="'risk'" :self-id="selectedRisk?.identifier || ''" :rows="12" :placeholder="t('risks.placeholder.notes')" />
                     </div>
                   </template>
                   <template v-else>
                     <div v-if="selectedRisk.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedRisk.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -588,19 +445,19 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDay(selectedRisk.next_review) }}
+                    {{ t('common.review.overdue_since', { date: formatDay(selectedRisk.next_review) }) }}
                   </div>
 
                   <!-- Score summary -->
                   <div class="flex items-center gap-4">
                     <div class="flex gap-3 flex-1">
                       <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-3 text-center min-w-[90px]">
-                        <div class="text-[9px] text-slate-500 uppercase tracking-wider">Inherent</div>
+                        <div class="text-[9px] text-slate-500 uppercase tracking-wider">{{ t('risks.assessment.inherent') }}</div>
                         <div v-if="selectedRisk.inherent_score" class="text-xl font-bold tabular-nums mt-1" :class="scoreColor(selectedRisk.inherent_score)">{{ selectedRisk.inherent_score }}</div>
                         <div v-else class="text-xl text-slate-700 mt-1">—</div>
                       </div>
                       <div class="bg-slate-800/60 border border-slate-600/50 rounded-lg px-5 py-3 text-center min-w-[90px] ring-1 ring-slate-600/20">
-                        <div class="text-[9px] text-slate-400 uppercase tracking-wider">Current</div>
+                        <div class="text-[9px] text-slate-400 uppercase tracking-wider">{{ t('risks.assessment.current') }}</div>
                         <div v-if="selectedRisk.current_score" class="text-xl font-bold tabular-nums mt-1" :class="scoreColor(selectedRisk.current_score)">{{ selectedRisk.current_score }}</div>
                         <div v-else class="text-xl text-slate-700 mt-1">—</div>
                       </div>
@@ -612,8 +469,8 @@
                     </div>
                   </div>
                   <div class="flex gap-4 text-[10px] text-slate-500">
-                    <span v-if="selectedRisk.last_review">Last review: {{ formatDay(selectedRisk.last_review) }}</span>
-                    <span v-if="selectedRisk.next_review && !isOverdue(selectedRisk.next_review)">Next review: {{ formatDay(selectedRisk.next_review) }}</span>
+                    <span v-if="selectedRisk.last_review">{{ t('common.review.last', { date: formatDay(selectedRisk.last_review) }) }}</span>
+                    <span v-if="selectedRisk.next_review && !isOverdue(selectedRisk.next_review)">{{ t('common.review.next', { date: formatDay(selectedRisk.next_review) }) }}</span>
                   </div>
 
                   <!-- Readings panel -->
@@ -632,7 +489,7 @@
 
                   <!-- Linked Assets -->
                   <div v-if="riskLinkedAssets[selectedRisk.id]?.length" class="bg-slate-800/40 border border-slate-700/50 rounded-lg p-3 space-y-1.5">
-                    <div class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Linked Assets</div>
+                    <div class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">{{ t('risks.links.linked_assets') }}</div>
                     <div v-for="asset in riskLinkedAssets[selectedRisk.id]" :key="asset.id" class="flex items-center gap-3 px-3 py-1.5 bg-slate-900/60 rounded">
                       <span class="text-sm text-slate-200 truncate flex-1">{{ asset.name }}</span>
                       <span v-if="asset.confidentiality > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.confidentiality)">C{{ asset.confidentiality }}</span>
@@ -677,10 +534,10 @@
 
                   <!-- Danger zone -->
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this risk is permanent and cannot be undone. History, comments, and linked references will be lost.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('risks.danger.warning') }}</div>
                     <button @click="deleteSelectedRisk" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete risk
+                      {{ t('risks.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -690,8 +547,8 @@
           </div>
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="riskSaving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ riskSaving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="riskSaving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ riskSaving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -706,6 +563,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import { DEFAULT_RISK_CATEGORIES, categoryLabel as resolveCategoryLabel } from '../riskCategories'
 import StatusBadge from '../components/StatusBadge.vue'
@@ -730,7 +588,11 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate as formatDateValue, formatDay as formatDayValue } from '../composables/useFormat.js'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
+const { t } = useI18n()
+const { enumLabel, entityLabel } = useEnumLabel()
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
 
@@ -770,7 +632,7 @@ async function reload() {
   try {
     await loadRisks()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -799,17 +661,48 @@ const editingSection = ref('') // which section is being edited: 'core', 'classi
 
 // orgPath is provided by useCurrentOrg() — see top of script.
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'treatment', label: 'Treatment' },
-  { key: 'assessment', label: 'Assessment' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'actions', label: 'Actions' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// The members each <select> offers. The set is this view's own choice — a
+// risk is only ever draft/open/closed, though `status` catalogues forty
+// values — so the list stays here and only the label comes from the shared
+// catalogue.
+const STATUSES = ['draft', 'open', 'closed']
+const LEVELS = ['critical', 'high', 'medium', 'low']
+const RISK_TYPES = ['threat', 'opportunity']
+const ORIGINS = ['internal', 'external', 'internal and external']
+const TREATMENTS = ['mitigate', 'accept', 'transfer', 'avoid']
+
+// Message keys, not labels: a module-scope array of translated strings would
+// freeze the tab bar in whichever locale was active when this module first
+// evaluated. Resolved per render in the computed below.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'treatment', label: 'common.tab.treatment' },
+  { key: 'assessment', label: 'common.tab.assessment' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'actions', label: 'common.tab.actions' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
+
+// Per-value lookups and option lists, both resolved here rather than in the
+// template. A group name is a stored identifier, and the raw-text scanner reads
+// a bare quoted word in a mustache as unextracted copy — correctly, since that
+// is what one usually is.
+const statusLabel = (v) => enumLabel('status', v)
+const riskTypeLabel = (v) => enumLabel('risk_type', v)
+const originLabel = (v) => enumLabel('origin', v)
+const treatmentLabel = (v) => enumLabel('treatment', v)
+const levelLabel = (v) => enumLabel('severity', v)
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const levelOptions = options(LEVELS, levelLabel)
+const riskTypeOptions = options(RISK_TYPES, riskTypeLabel)
+const originOptions = options(ORIGINS, originLabel)
+const treatmentOptions = options(TREATMENTS, treatmentLabel)
 
 function editSection(section) {
   startEdit(selectedRisk.value)
@@ -834,9 +727,9 @@ async function saveSection() {
       startEdit(updated) // refresh editForm with saved data
     }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('risks.error.save', { message: renderApiError(e) }))
   } finally {
     riskSaving.value = false
   }
@@ -845,9 +738,9 @@ async function saveSection() {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('risks.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('risks.dirty.discard'),
     })
     if (!ok) return
   }
@@ -858,9 +751,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('risks.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('risks.dirty.discard'),
     })
     if (!ok) return
   }
@@ -899,14 +792,6 @@ function isOverdue(dateStr) {
   return d < new Date()
 }
 
-const levelOptions = [
-  { value: '', label: 'All' },
-  { value: 'critical', label: 'Critical' },
-  { value: 'high', label: 'High' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'low', label: 'Low' },
-]
-
 const stats = ref({ total: 0, critical: 0, high: 0, medium: 0, low: 0, open: 0, closed: 0, draft: 0 })
 const criticalCount = computed(() => stats.value.critical)
 const highCount = computed(() => stats.value.high)
@@ -915,10 +800,10 @@ const treatedCount = computed(() => stats.value.closed)
 // dimensions), so they render as static StatStrip chips — the tall stat-card
 // grid was reclaimed for the list; the Risk Map stays in its collapsible "More".
 const summaryStats = computed(() => [
-  { key: 'total', label: 'Total Risks', count: risks.value.length, color: 'text-slate-100', static: true },
-  { key: 'critical', label: 'Critical', count: criticalCount.value, color: criticalCount.value > 0 ? 'text-red-400' : 'text-slate-100', static: true },
-  { key: 'high', label: 'High', count: highCount.value, color: highCount.value > 0 ? 'text-orange-400' : 'text-slate-100', static: true },
-  { key: 'closed', label: 'Closed', count: treatedCount.value, color: 'text-emerald-400', static: true },
+  { key: 'total', label: t('risks.stat.total'), count: risks.value.length, color: 'text-slate-100', static: true },
+  { key: 'critical', label: levelLabel('critical'), count: criticalCount.value, color: criticalCount.value > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: 'high', label: levelLabel('high'), count: highCount.value, color: highCount.value > 0 ? 'text-orange-400' : 'text-slate-100', static: true },
+  { key: 'closed', label: statusLabel('closed'), count: treatedCount.value, color: 'text-emerald-400', static: true },
 ])
 
 // Refetch on filter/search/page change
@@ -943,21 +828,10 @@ function resolveUserName(email) {
   return u?.name || email
 }
 
-function formatLabel(s) {
-  return (s || '').replace(/_/g, ' ')
-}
-
 // Display name for a stored category key — see src/riskCategories.js for the
 // resolution rules (configured label, de-slugged key for orphans).
 function categoryLabel(key) {
   return resolveCategoryLabel(key, riskCategories.value)
-}
-
-function formatOrigin(o) {
-  if (o === 'internal and external') return 'Internal & External'
-  if (o === 'internal') return 'Internal'
-  if (o === 'external') return 'External'
-  return o ? o.charAt(0).toUpperCase() + o.slice(1) : ''
 }
 
 // The table renders a dash for a missing date, where the shared seam returns
@@ -970,7 +844,17 @@ function formatDay(dateStr) {
   return formatDayValue(dateStr) || '-'
 }
 
-const ciaLabel = (v) => ['Not Assessed','Insignificant','Minor','Moderate','Major','Severe'][v] || 'N/A'
+// Keys written out rather than built from the index: a runtime-composed key
+// defeats keyset extraction, which is why the convention forbids it.
+const CIA_KEYS = [
+  'common.cia.not_assessed',
+  'common.cia.insignificant',
+  'common.cia.minor',
+  'common.cia.moderate',
+  'common.cia.major',
+  'common.cia.severe',
+]
+const ciaLabel = (v) => (CIA_KEYS[v] ? t(CIA_KEYS[v]) : t('common.cia.na'))
 
 function ciaColor(v) {
   switch (v) {
@@ -1000,7 +884,7 @@ async function loadRisks() {
     loadAllAdvisories()
     loadAllRisksForMap()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -1111,50 +995,6 @@ function startEdit(risk) {
   captureEditSnapshot()
 }
 
-async function saveRiskField(risk, field, value) {
-  try {
-    const id = risk.risk_id || risk.id || risk.document_id
-    await api.putJSON(`/api/v1/risks/${id}`, { [field]: value })
-  } catch (e) {
-    showError('Failed to save: ' + (e.message || 'unknown error'))
-  }
-}
-
-async function changeRiskStatus(risk, status) {
-  try {
-    const id = risk.risk_id || risk.id || risk.document_id
-    await api.putJSON(`/api/v1/risks/${id}`, { status })
-    risk.status = status
-    if (selectedRisk.value?.id === risk.id) {
-      selectedRisk.value = { ...selectedRisk.value, status }
-    }
-  } catch (e) {
-    showError('Failed to update status: ' + e.message)
-  }
-}
-
-const canEdit = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
-
-async function saveRisk() {
-  riskSaving.value = true
-  try {
-    const id = selectedRisk.value.risk_id || selectedRisk.value.id || selectedRisk.value.document_id
-    const payload = { ...editForm.value }
-    await api.putJSON(`/api/v1/risks/${id}`, payload)
-    await loadRisks()
-    if (selectedRisk.value) {
-      const updated = risks.value.find(r => r.id === selectedRisk.value.id)
-      if (updated) selectedRisk.value = updated
-    }
-    // Re-populate editForm with fresh data
-    if (selectedRisk.value) startEdit(selectedRisk.value)
-  } catch (e) {
-    showError('Failed to save risk: ' + e.message)
-  } finally {
-    riskSaving.value = false
-  }
-}
-
 async function createRisk() {
   try {
     const payload = { ...newRisk.value }
@@ -1183,7 +1023,7 @@ async function createRisk() {
       router.push(orgPath(`/risks/${fresh.id}`))
     }
   } catch (e) {
-    showError('Failed to create risk: ' + e.message)
+    showError(t('risks.error.create', { message: renderApiError(e) }))
   }
 }
 
@@ -1202,7 +1042,7 @@ function createLinkedTask() {
 
 async function deleteSelectedRisk() {
   if (!selectedRisk.value) return
-  const ok = await confirmDialog({ message: 'Delete this risk? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({ message: t('risks.danger.confirm'), variant: 'danger', confirmLabel: t('common.action.delete') })
   if (!ok) return
   showOverflow.value = false
   try {
@@ -1211,7 +1051,7 @@ async function deleteSelectedRisk() {
     selectedRisk.value = null
     await loadRisks()
   } catch (e) {
-    showError('Failed to delete risk: ' + e.message)
+    showError(t('risks.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -1233,7 +1073,7 @@ onMounted(async () => {
     await loadRisks()
     loadAllAdvisories()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -189,9 +189,9 @@
                 </td>
                 <td class="px-5 py-3.5 text-center">
                   <div class="flex gap-0.5 justify-center">
-                    <span v-if="risk.confidentiality_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.confidentiality_impact)" :title="t('risks.table.cia_title.confidentiality', { level: ciaLabel(risk.confidentiality_impact) })">C{{ risk.confidentiality_impact }}</span>
-                    <span v-if="risk.integrity_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.integrity_impact)" :title="t('risks.table.cia_title.integrity', { level: ciaLabel(risk.integrity_impact) })">I{{ risk.integrity_impact }}</span>
-                    <span v-if="risk.availability_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.availability_impact)" :title="t('risks.table.cia_title.availability', { level: ciaLabel(risk.availability_impact) })">A{{ risk.availability_impact }}</span>
+                    <span v-if="risk.confidentiality_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.confidentiality_impact)" :title="t('risks.table.cia_title.confidentiality', { level: ciaLabel(risk.confidentiality_impact) })">{{ t('common.cia_abbr.c') }}{{ risk.confidentiality_impact }}</span>
+                    <span v-if="risk.integrity_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.integrity_impact)" :title="t('risks.table.cia_title.integrity', { level: ciaLabel(risk.integrity_impact) })">{{ t('common.cia_abbr.i') }}{{ risk.integrity_impact }}</span>
+                    <span v-if="risk.availability_impact > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(risk.availability_impact)" :title="t('risks.table.cia_title.availability', { level: ciaLabel(risk.availability_impact) })">{{ t('common.cia_abbr.a') }}{{ risk.availability_impact }}</span>
                     <span v-if="!risk.confidentiality_impact && !risk.integrity_impact && !risk.availability_impact" class="text-slate-600 text-xs">-</span>
                   </div>
                 </td>
@@ -463,9 +463,9 @@
                       </div>
                     </div>
                     <div v-if="selectedRisk.confidentiality_impact || selectedRisk.integrity_impact || selectedRisk.availability_impact" class="flex items-center gap-1.5">
-                      <span class="inline-flex items-center justify-center w-8 h-8 rounded text-[11px] font-bold" :class="scoreColor(selectedRisk.confidentiality_impact)">C{{ selectedRisk.confidentiality_impact || 0 }}</span>
-                      <span class="inline-flex items-center justify-center w-8 h-8 rounded text-[11px] font-bold" :class="scoreColor(selectedRisk.integrity_impact)">I{{ selectedRisk.integrity_impact || 0 }}</span>
-                      <span class="inline-flex items-center justify-center w-8 h-8 rounded text-[11px] font-bold" :class="scoreColor(selectedRisk.availability_impact)">A{{ selectedRisk.availability_impact || 0 }}</span>
+                      <span class="inline-flex items-center justify-center w-8 h-8 rounded text-[11px] font-bold" :class="scoreColor(selectedRisk.confidentiality_impact)">{{ t('common.cia_abbr.c') }}{{ selectedRisk.confidentiality_impact || 0 }}</span>
+                      <span class="inline-flex items-center justify-center w-8 h-8 rounded text-[11px] font-bold" :class="scoreColor(selectedRisk.integrity_impact)">{{ t('common.cia_abbr.i') }}{{ selectedRisk.integrity_impact || 0 }}</span>
+                      <span class="inline-flex items-center justify-center w-8 h-8 rounded text-[11px] font-bold" :class="scoreColor(selectedRisk.availability_impact)">{{ t('common.cia_abbr.a') }}{{ selectedRisk.availability_impact || 0 }}</span>
                     </div>
                   </div>
                   <div class="flex gap-4 text-[10px] text-slate-500">
@@ -492,9 +492,9 @@
                     <div class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">{{ t('risks.links.linked_assets') }}</div>
                     <div v-for="asset in riskLinkedAssets[selectedRisk.id]" :key="asset.id" class="flex items-center gap-3 px-3 py-1.5 bg-slate-900/60 rounded">
                       <span class="text-sm text-slate-200 truncate flex-1">{{ asset.name }}</span>
-                      <span v-if="asset.confidentiality > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.confidentiality)">C{{ asset.confidentiality }}</span>
-                      <span v-if="asset.integrity > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.integrity)">I{{ asset.integrity }}</span>
-                      <span v-if="asset.availability > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.availability)">A{{ asset.availability }}</span>
+                      <span v-if="asset.confidentiality > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.confidentiality)">{{ t('common.cia_abbr.c') }}{{ asset.confidentiality }}</span>
+                      <span v-if="asset.integrity > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.integrity)">{{ t('common.cia_abbr.i') }}{{ asset.integrity }}</span>
+                      <span v-if="asset.availability > 0" class="px-1 py-0.5 rounded text-[9px] font-semibold" :class="ciaColor(asset.availability)">{{ t('common.cia_abbr.a') }}{{ asset.availability }}</span>
                     </div>
                   </div>
 

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -155,9 +155,9 @@
               </td>
               <td class="px-5 py-3.5 text-center">
                 <div class="flex gap-0.5 justify-center">
-                  <span v-if="supplier.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.confidentiality)" :title="t('suppliers.table.cia_title.confidentiality', { level: ciaLabel(supplier.confidentiality) })">C{{ supplier.confidentiality }}</span>
-                  <span v-if="supplier.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.integrity)" :title="t('suppliers.table.cia_title.integrity', { level: ciaLabel(supplier.integrity) })">I{{ supplier.integrity }}</span>
-                  <span v-if="supplier.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.availability)" :title="t('suppliers.table.cia_title.availability', { level: ciaLabel(supplier.availability) })">A{{ supplier.availability }}</span>
+                  <span v-if="supplier.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.confidentiality)" :title="t('suppliers.table.cia_title.confidentiality', { level: ciaLabel(supplier.confidentiality) })">{{ t('common.cia_abbr.c') }}{{ supplier.confidentiality }}</span>
+                  <span v-if="supplier.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.integrity)" :title="t('suppliers.table.cia_title.integrity', { level: ciaLabel(supplier.integrity) })">{{ t('common.cia_abbr.i') }}{{ supplier.integrity }}</span>
+                  <span v-if="supplier.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.availability)" :title="t('suppliers.table.cia_title.availability', { level: ciaLabel(supplier.availability) })">{{ t('common.cia_abbr.a') }}{{ supplier.availability }}</span>
                   <span v-if="!supplier.confidentiality && !supplier.integrity && !supplier.availability" class="text-slate-600 text-xs">-</span>
                 </div>
               </td>

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -19,15 +19,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Supplier Register</h1>
-          <p class="text-sm text-slate-500 mt-1">Third-party suppliers, criticality, and assessment</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('suppliers.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('suppliers.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite" @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ showCreateForm ? 'Cancel' : 'Add Supplier' }}
+            {{ showCreateForm ? t('common.action.cancel') : t('suppliers.action.add') }}
           </button>
-          <SuggestNewButton entityType="supplier" typeLabel="Supplier" />
+          <SuggestNewButton entityType="supplier" :typeLabel="entityLabel('supplier')" />
         </div>
       </div>
 
@@ -38,7 +38,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
           <div class="flex items-center justify-between mb-2">
-            <h2 class="text-sm font-semibold text-slate-200">Add Supplier</h2>
+            <h2 class="text-sm font-semibold text-slate-200">{{ t('suppliers.create.heading') }}</h2>
             <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -47,37 +47,37 @@
           </div>
           <div class="space-y-3">
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Name *</label>
-              <input v-model="newItem.name" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. AWS, Office 365" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.create.name_label') }}</label>
+              <input v-model="newItem.name" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('suppliers.create.name_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.create.type_label') }}</label>
               <div class="flex flex-wrap gap-1.5">
-                <button v-for="t in supplierTypes" :key="t.key"
-                  @click="newItem.supplier_type = newItem.supplier_type === t.key ? '' : t.key"
+                <button v-for="o in typeOptions" :key="o.value"
+                  @click="newItem.supplier_type = newItem.supplier_type === o.value ? '' : o.value"
                   class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
-                  :class="newItem.supplier_type === t.key ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
-                  {{ t.label }}
+                  :class="newItem.supplier_type === o.value ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
+                  {{ o.label }}
                 </button>
               </div>
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Criticality</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.create.criticality_label') }}</label>
               <div class="flex flex-wrap gap-1.5">
-                <button v-for="c in criticalityLevels" :key="c.key"
-                  @click="newItem.criticality = newItem.criticality === c.key ? '' : c.key"
+                <button v-for="c in criticalityOptions" :key="c.value"
+                  @click="newItem.criticality = newItem.criticality === c.value ? '' : c.value"
                   class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
-                  :class="newItem.criticality === c.key ? criticalityChipColor(c.key) : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
+                  :class="newItem.criticality === c.value ? criticalityChipColor(c.value) : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
                   {{ c.label }}
                 </button>
               </div>
             </div>
           </div>
-          <div class="text-[10px] text-slate-600 mt-1">You can add CIA classification, owner, contract details after creating.</div>
+          <div class="text-[10px] text-slate-600 mt-1">{{ t('suppliers.create.fill_in_later') }}</div>
           <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
             <button @click="createItem" :disabled="!newItem.name" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-              Add
+              {{ t('suppliers.create.submit') }}
             </button>
           </div>
         </div>
@@ -96,38 +96,35 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="searchQuery" type="text" placeholder="Search..."
+            <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="filterType" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All types</option>
-            <option v-for="t in supplierTypes" :key="t.key" :value="t.key">{{ t.label }}</option>
+            <option value="">{{ t('common.filter.all_types') }}</option>
+            <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <select v-model="filterCriticality" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All criticality</option>
-            <option v-for="c in criticalityLevels" :key="c.key" :value="c.key">{{ c.label }}</option>
+            <option value="">{{ t('common.filter.all_criticality') }}</option>
+            <option v-for="c in criticalityOptions" :key="c.value" :value="c.value">{{ c.label }}</option>
           </select>
           <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="active">Active</option>
-            <option value="under_review">Under Review</option>
-            <option value="suspended">Suspended</option>
-            <option value="terminated">Terminated</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <button v-if="filterType || filterCriticality || filterStatus || searchQuery"
             @click="filterType = ''; filterCriticality = ''; filterStatus = ''; searchQuery = ''"
             class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-            Clear
+            {{ t('common.action.clear') }}
           </button>
           <div class="ml-auto text-xs text-slate-500 tabular-nums">
-            {{ total }} total
+            {{ t('common.count.total', { count: total }) }}
           </div>
         </div>
       </div>
 
       <!-- Empty state -->
       <div v-if="suppliers.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-        <div class="text-sm text-slate-500">No suppliers found</div>
+        <div class="text-sm text-slate-500">{{ t('suppliers.filter.empty') }}</div>
       </div>
 
       <!-- Table -->
@@ -135,13 +132,13 @@
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Supplier</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Type</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Criticality</th>
-              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">C/I/A</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Next Review</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.supplier') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.type') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.criticality') }}</th>
+              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.cia') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.status') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.owner') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('suppliers.table.header.next_review') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-800/50">
@@ -152,15 +149,15 @@
               <td class="px-5 py-3.5">
                 <div class="text-sm font-medium text-slate-200">{{ supplier.name }}</div>
               </td>
-              <td class="px-5 py-3.5 text-sm text-slate-400 capitalize">{{ formatLabel(supplier.supplier_type) }}</td>
+              <td class="px-5 py-3.5 text-sm text-slate-400">{{ typeLabel(supplier.supplier_type) || '—' }}</td>
               <td class="px-5 py-3.5">
-                <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(supplier.criticality)">{{ supplier.criticality }}</span>
+                <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(supplier.criticality)">{{ criticalityLabel(supplier.criticality) }}</span>
               </td>
               <td class="px-5 py-3.5 text-center">
                 <div class="flex gap-0.5 justify-center">
-                  <span v-if="supplier.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.confidentiality)" :title="'Confidentiality: ' + ciaLabel(supplier.confidentiality)">C{{ supplier.confidentiality }}</span>
-                  <span v-if="supplier.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.integrity)" :title="'Integrity: ' + ciaLabel(supplier.integrity)">I{{ supplier.integrity }}</span>
-                  <span v-if="supplier.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.availability)" :title="'Availability: ' + ciaLabel(supplier.availability)">A{{ supplier.availability }}</span>
+                  <span v-if="supplier.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.confidentiality)" :title="t('suppliers.table.cia_title.confidentiality', { level: ciaLabel(supplier.confidentiality) })">C{{ supplier.confidentiality }}</span>
+                  <span v-if="supplier.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.integrity)" :title="t('suppliers.table.cia_title.integrity', { level: ciaLabel(supplier.integrity) })">I{{ supplier.integrity }}</span>
+                  <span v-if="supplier.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(supplier.availability)" :title="t('suppliers.table.cia_title.availability', { level: ciaLabel(supplier.availability) })">A{{ supplier.availability }}</span>
                   <span v-if="!supplier.confidentiality && !supplier.integrity && !supplier.availability" class="text-slate-600 text-xs">-</span>
                 </div>
               </td>
@@ -205,10 +202,10 @@
             <!-- Left nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -220,56 +217,53 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('suppliers.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Name</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.name') }}</label>
                         <input v-model="editForm.name" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.type') }}</label>
                         <select v-model="editForm.supplier_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="">None</option>
-                          <option v-for="t in supplierTypes" :key="t.key" :value="t.key">{{ t.label }}</option>
+                          <option value="">{{ t('common.option.none') }}</option>
+                          <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Criticality</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.criticality') }}</label>
                         <select v-model="editForm.criticality" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="c in criticalityLevels" :key="c.key" :value="c.key">{{ c.label }}</option>
+                          <option v-for="c in criticalityOptions" :key="c.value" :value="c.value">{{ c.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="active">Active</option>
-                          <option value="under_review">Under Review</option>
-                          <option value="suspended">Suspended</option>
-                          <option value="terminated">Terminated</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                        <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.owner') }}</label>
+                        <MemberPicker v-model="editForm.owner" :members="orgMembers" :placeholder="t('common.placeholder.select_owner')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Contact</label>
-                        <input v-model="editForm.contact" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="contact@supplier.com" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.contact') }}</label>
+                        <input v-model="editForm.contact" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('suppliers.placeholder.contact')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Contract Reference</label>
-                        <input v-model="editForm.contract_ref" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="DPA / contract URL" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.contract_ref') }}</label>
+                        <input v-model="editForm.contract_ref" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('suppliers.placeholder.contract_ref')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Contract Expiry</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('suppliers.field.contract_expiry') }}</label>
                         <input v-model="editForm.contract_expiry" type="date" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="flex items-center gap-2 sm:col-span-2 pt-1">
                         <input id="data_access" type="checkbox" v-model="editForm.data_access" class="w-4 h-4 bg-slate-800 border-slate-700 rounded focus:ring-blue-500" />
-                        <label for="data_access" class="text-xs text-slate-400">Supplier has access to our data</label>
+                        <label for="data_access" class="text-xs text-slate-400">{{ t('suppliers.data_access.checkbox') }}</label>
                       </div>
                     </div>
                   </template>
@@ -277,43 +271,43 @@
                     <div class="space-y-4">
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ formatLabel(selectedItem.supplier_type) }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.type') }}</div>
+                          <div class="text-sm text-slate-300">{{ typeLabel(selectedItem.supplier_type) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Criticality</div>
-                          <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(selectedItem.criticality)">{{ selectedItem.criticality }}</span>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.criticality') }}</div>
+                          <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(selectedItem.criticality)">{{ criticalityLabel(selectedItem.criticality) }}</span>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.status') }}</div>
                           <StatusBadge :status="selectedItem.status" />
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.owner') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.owner) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Contact</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.contact') }}</div>
                           <div class="text-sm text-slate-300">{{ selectedItem.contact || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Contract Reference</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.contract_ref') }}</div>
                           <div class="text-sm text-slate-300">{{ selectedItem.contract_ref || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Contract Expiry</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.contract_expiry') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDay(selectedItem.contract_expiry) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Data Access</div>
-                          <div class="text-sm text-slate-300">{{ selectedItem.data_access ? 'Yes' : 'No' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.data_access') }}</div>
+                          <div class="text-sm text-slate-300">{{ selectedItem.data_access ? t('suppliers.data_access.yes') : t('suppliers.data_access.no') }}</div>
                         </div>
                         <div v-if="selectedItem.created_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedItem.created_at) }}</div>
                         </div>
                         <div v-if="selectedItem.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('suppliers.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.created_by) }}</div>
                         </div>
                       </div>
@@ -321,7 +315,7 @@
                       <!-- Linked systems (reverse direction: systems.supplier_id -> this supplier) -->
                       <div v-if="linkedSystems.length" class="border-t border-slate-800 pt-4">
                         <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-2">
-                          Linked systems ({{ linkedSystems.length }})
+                          {{ t('suppliers.linked_systems.heading', linkedSystems.length) }}
                         </div>
                         <div class="space-y-1">
                           <router-link v-for="sys in linkedSystems" :key="sys.id" :to="orgPath(`/systems/${sys.id}`)"
@@ -344,25 +338,25 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDay(selectedItem.next_review) }}
+                    {{ t('common.review.overdue_since', { date: formatDay(selectedItem.next_review) }) }}
                   </div>
 
                   <!-- CIA scores -->
                   <div class="grid grid-cols-3 gap-4">
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Confidentiality</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('suppliers.assessment.confidentiality') }}</div>
                       <div v-if="selectedItem.confidentiality" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.confidentiality)">{{ selectedItem.confidentiality }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.confidentiality" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.confidentiality) }}</div>
                     </div>
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Integrity</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('suppliers.assessment.integrity') }}</div>
                       <div v-if="selectedItem.integrity" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.integrity)">{{ selectedItem.integrity }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.integrity" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.integrity) }}</div>
                     </div>
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Availability</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('suppliers.assessment.availability') }}</div>
                       <div v-if="selectedItem.availability" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.availability)">{{ selectedItem.availability }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.availability" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.availability) }}</div>
@@ -370,8 +364,8 @@
                   </div>
 
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">{{ t('common.review.last', { date: formatDay(selectedItem.last_review) }) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">{{ t('common.review.next', { date: formatDay(selectedItem.next_review) }) }}</span>
                   </div>
 
                   <!-- Readings -->
@@ -394,15 +388,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('suppliers.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'supplier'" :self-id="selectedItem?.identifier || ''" :rows="12" placeholder="Additional notes... Type /doc to link a document" />
+                    <MarkdownField v-model="editForm.notes" :self-type="'supplier'" :self-id="selectedItem?.identifier || ''" :rows="12" :placeholder="t('suppliers.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedItem.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedItem.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -433,10 +427,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="supplier" :entityId="String(selectedItem.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this supplier is permanent and cannot be undone. History, comments, reviews and linked references will be lost.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('suppliers.danger.warning') }}</div>
                     <button @click="deleteSelectedItem" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete supplier
+                      {{ t('suppliers.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -447,8 +441,8 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -463,6 +457,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -486,7 +481,11 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate, formatDay } from '../composables/useFormat.js'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
+const { t } = useI18n()
+const { enumLabel, entityLabel } = useEnumLabel()
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
 
@@ -507,7 +506,7 @@ async function reload() {
   try {
     await loadSuppliers()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -518,11 +517,13 @@ const orgMembers = ref([])
 const saving = ref(false)
 const stats = ref({ total: 0, active: 0, under_review: 0, suspended: 0, terminated: 0, critical: 0, high: 0, medium: 0, low: 0 })
 const statusStats = computed(() => [
-  { key: '', label: 'Total', count: stats.value.total, color: 'text-slate-100' },
-  { key: 'active', label: 'Active', count: stats.value.active, color: 'text-emerald-400' },
-  { key: 'under_review', label: 'Under Review', count: stats.value.under_review, color: 'text-amber-400' },
-  { key: 'suspended', label: 'Suspended', count: stats.value.suspended || 0, color: 'text-orange-400' },
-  { key: 'critical', label: 'Critical', count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: '', label: t('common.stat.total'), count: stats.value.total, color: 'text-slate-100' },
+  { key: 'active', label: statusLabel('active'), count: stats.value.active, color: 'text-emerald-400' },
+  { key: 'under_review', label: statusLabel('under_review'), count: stats.value.under_review, color: 'text-amber-400' },
+  { key: 'suspended', label: statusLabel('suspended'), count: stats.value.suspended || 0, color: 'text-orange-400' },
+  // `critical` here counts criticality, not status — a different family, so a
+  // different group.
+  { key: 'critical', label: criticalityLabel('critical'), count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
 ])
 
 const selectedItem = ref(null)
@@ -553,34 +554,43 @@ const page = ref(1)
 const pageSize = ref(50)
 const total = ref(0)
 
-const supplierTypes = [
-  { key: 'cloud', label: 'Cloud' },
-  { key: 'saas', label: 'SaaS' },
-  { key: 'consulting', label: 'Consulting' },
-  { key: 'hosting', label: 'Hosting' },
-  { key: 'infrastructure', label: 'Infrastructure' },
-  { key: 'software', label: 'Software' },
-  { key: 'contractor', label: 'Contractor' },
-  { key: 'other', label: 'Other' },
+// The members each picker offers, matching the supplier_type CHECK widened by
+// migrations/20260713000000_v0.7.1.sql. Only the label comes from the shared
+// catalogue.
+const SUPPLIER_TYPES = [
+  'cloud', 'saas', 'consulting', 'hosting', 'infrastructure', 'software',
+  'contractor', 'other',
 ]
+const CRITICALITIES = ['critical', 'high', 'medium', 'low']
+const STATUSES = ['active', 'under_review', 'suspended', 'terminated']
 
-const criticalityLevels = [
-  { key: 'critical', label: 'Critical' },
-  { key: 'high', label: 'High' },
-  { key: 'medium', label: 'Medium' },
-  { key: 'low', label: 'Low' },
+// Message keys, not labels: a module-scope array of translated strings freezes
+// the tab bar in whichever locale was active when this module first evaluated.
+// `reviews` is this view's own copy — "Reviews", where Systems says "Access
+// Reviews" — so it is not a common.tab.* entry.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'assessment', label: 'common.tab.assessment' },
+  { key: 'reviews', label: 'suppliers.tab.reviews' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'assessment', label: 'Assessment' },
-  { key: 'reviews', label: 'Reviews' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
-]
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+const statusLabel = (v) => enumLabel('status', v)
+const typeLabel = (v) => enumLabel('supplier_type', v)
+const criticalityLabel = (v) => enumLabel('criticality', v)
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const typeOptions = options(SUPPLIER_TYPES, typeLabel)
+const criticalityOptions = options(CRITICALITIES, criticalityLabel)
 
 useModalEscape(showCreateForm)
 useModalEscape(computed(() => !!selectedItem.value), closeDetail)
@@ -596,7 +606,17 @@ watch([filterType, filterCriticality, filterStatus], () => {
 })
 watch([page, pageSize], () => loadSuppliers())
 
-const ciaLabel = (v) => ['Not Assessed','Insignificant','Minor','Moderate','Major','Severe'][v] || 'N/A'
+// Keys written out rather than built from the index: a runtime-composed key
+// defeats keyset extraction, which is why the convention forbids it.
+const CIA_KEYS = [
+  'common.cia.not_assessed',
+  'common.cia.insignificant',
+  'common.cia.minor',
+  'common.cia.moderate',
+  'common.cia.major',
+  'common.cia.severe',
+]
+const ciaLabel = (v) => (CIA_KEYS[v] ? t(CIA_KEYS[v]) : t('common.cia.na'))
 
 function ciaColor(v) {
   switch (v) {
@@ -640,10 +660,6 @@ function criticalityChipColor(c) {
   }
 }
 
-function formatLabel(s) {
-  return (s || '').replace(/_/g, ' ')
-}
-
 function isOverdue(dateStr) {
   if (!dateStr) return false
   const d = typeof dateStr === 'number' ? new Date(dateStr * 1000) : new Date(dateStr)
@@ -670,7 +686,7 @@ async function loadSuppliers() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -725,24 +741,11 @@ async function saveSection() {
     await api.putJSON(`/api/v1/suppliers/${selectedItem.value.id}`, { ...editForm.value })
     await refreshSelectedItem()
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('suppliers.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
-  }
-}
-
-async function changeSupplierStatus(newStatus) {
-  if (!selectedItem.value) return
-  try {
-    await api.putJSON(`/api/v1/suppliers/${selectedItem.value.id}`, { status: newStatus })
-    selectedItem.value.status = newStatus
-    await refreshSelectedItem()
-    await loadStats()
-    showSaved('Status updated')
-  } catch (e) {
-    showError('Failed to update status: ' + (e.message || 'unknown error'))
   }
 }
 
@@ -768,9 +771,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('suppliers.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('suppliers.dirty.discard'),
     })
     if (!ok) return
   }
@@ -781,9 +784,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('suppliers.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('suppliers.dirty.discard'),
     })
     if (!ok) return
   }
@@ -812,20 +815,20 @@ async function createItem() {
       router.push(orgPath(`/suppliers/${fresh.id}`))
     }
   } catch (e) {
-    showError('Failed to create supplier: ' + e.message)
+    showError(t('suppliers.error.create', { message: renderApiError(e) }))
   }
 }
 
 async function deleteSelectedItem() {
   if (!selectedItem.value) return
-  const ok = await confirmDialog({ message: 'Delete this supplier? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({ message: t('suppliers.danger.confirm'), variant: 'danger', confirmLabel: t('common.action.delete') })
   if (!ok) return
   try {
     await api.deleteJSON(`/api/v1/suppliers/${selectedItem.value.id}`)
     closeDetail()
     await loadSuppliers()
   } catch (e) {
-    showError('Failed to delete: ' + e.message)
+    showError(t('suppliers.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -838,7 +841,7 @@ onMounted(async () => {
     ])
     orgMembers.value = users || []
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -538,7 +538,10 @@ async function loadLinkedSystems() {
   if (!selectedItem.value) { linkedSystems.value = []; return }
   try {
     const res = await api.listSystemsLinked({ supplier_id: String(selectedItem.value.id), limit: '100' })
-    linkedSystems.value = Array.isArray(res?.data) ? res.data : []
+    // fetchJSON unwraps a {data: [...]} body and hands back the array itself, so
+    // reading `res.data` here always yielded undefined and the block never
+    // rendered. Same shape Systems.vue's loadAccessReviews already uses.
+    linkedSystems.value = Array.isArray(res) ? res : (res?.data || [])
   } catch { linkedSystems.value = [] }
 }
 watch(() => selectedItem.value?.id, loadLinkedSystems, { immediate: true })

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -160,9 +160,9 @@
               </td>
               <td class="px-5 py-3.5 text-center">
                 <div class="flex gap-0.5 justify-center">
-                  <span v-if="sys.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.confidentiality)" :title="t('systems.table.cia_title.confidentiality', { level: ciaLabel(sys.confidentiality) })">C{{ sys.confidentiality }}</span>
-                  <span v-if="sys.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.integrity)" :title="t('systems.table.cia_title.integrity', { level: ciaLabel(sys.integrity) })">I{{ sys.integrity }}</span>
-                  <span v-if="sys.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.availability)" :title="t('systems.table.cia_title.availability', { level: ciaLabel(sys.availability) })">A{{ sys.availability }}</span>
+                  <span v-if="sys.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.confidentiality)" :title="t('systems.table.cia_title.confidentiality', { level: ciaLabel(sys.confidentiality) })">{{ t('common.cia_abbr.c') }}{{ sys.confidentiality }}</span>
+                  <span v-if="sys.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.integrity)" :title="t('systems.table.cia_title.integrity', { level: ciaLabel(sys.integrity) })">{{ t('common.cia_abbr.i') }}{{ sys.integrity }}</span>
+                  <span v-if="sys.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.availability)" :title="t('systems.table.cia_title.availability', { level: ciaLabel(sys.availability) })">{{ t('common.cia_abbr.a') }}{{ sys.availability }}</span>
                   <span v-if="!sys.confidentiality && !sys.integrity && !sys.availability" class="text-slate-600 text-xs">-</span>
                 </div>
               </td>

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -19,15 +19,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Systems Register</h1>
-          <p class="text-sm text-slate-500 mt-1">IT systems, recovery objectives, access control, and supplier links</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('systems.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('systems.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite" @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ showCreateForm ? 'Cancel' : 'Add System' }}
+            {{ showCreateForm ? t('common.action.cancel') : t('systems.action.add') }}
           </button>
-          <SuggestNewButton entityType="system" typeLabel="System" />
+          <SuggestNewButton entityType="system" :typeLabel="entityLabel('system')" />
         </div>
       </div>
 
@@ -38,7 +38,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
           <div class="flex items-center justify-between mb-2">
-            <h2 class="text-sm font-semibold text-slate-200">Add System</h2>
+            <h2 class="text-sm font-semibold text-slate-200">{{ t('systems.create.heading') }}</h2>
             <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -47,44 +47,44 @@
           </div>
           <div class="space-y-3">
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Name *</label>
-              <input v-model="newItem.name" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. Production ERP" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.create.name_label') }}</label>
+              <input v-model="newItem.name" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('systems.create.name_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Classification</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.create.classification_label') }}</label>
               <div class="flex flex-wrap gap-1.5">
-                <button v-for="t in classifications" :key="t.key"
-                  @click="newItem.classification = t.key"
+                <button v-for="c in classificationOptions" :key="c.value"
+                  @click="newItem.classification = c.value"
                   class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
-                  :class="newItem.classification === t.key ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
-                  {{ t.label }}
-                </button>
-              </div>
-            </div>
-            <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Criticality</label>
-              <div class="flex flex-wrap gap-1.5">
-                <button v-for="c in criticalityLevels" :key="c.key"
-                  @click="newItem.criticality = c.key"
-                  class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
-                  :class="newItem.criticality === c.key ? criticalityChipColor(c.key) : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
+                  :class="newItem.classification === c.value ? 'bg-blue-600/20 text-blue-400 border-blue-500/40' : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
                   {{ c.label }}
                 </button>
               </div>
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Supplier</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.create.criticality_label') }}</label>
+              <div class="flex flex-wrap gap-1.5">
+                <button v-for="c in criticalityOptions" :key="c.value"
+                  @click="newItem.criticality = c.value"
+                  class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
+                  :class="newItem.criticality === c.value ? criticalityChipColor(c.value) : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
+                  {{ c.label }}
+                </button>
+              </div>
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.create.supplier_label') }}</label>
               <select v-model="newItem.supplier_id" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                <option :value="null">— None —</option>
+                <option :value="null">{{ t('systems.option.no_supplier') }}</option>
                 <option v-for="s in suppliers" :key="s.id" :value="s.id">{{ s.name }}</option>
               </select>
             </div>
           </div>
-          <div class="text-[10px] text-slate-600 mt-1">You can add CIA classification, RPO/RTO, and owner after creating.</div>
+          <div class="text-[10px] text-slate-600 mt-1">{{ t('systems.create.fill_in_later') }}</div>
           <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
             <button @click="createItem" :disabled="!newItem.name" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-              Add
+              {{ t('systems.create.submit') }}
             </button>
           </div>
         </div>
@@ -103,33 +103,31 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="searchQuery" type="text" placeholder="Search..."
+            <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="filterCriticality" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All criticality</option>
-            <option v-for="c in criticalityLevels" :key="c.key" :value="c.key">{{ c.label }}</option>
+            <option value="">{{ t('common.filter.all_criticality') }}</option>
+            <option v-for="c in criticalityOptions" :key="c.value" :value="c.value">{{ c.label }}</option>
           </select>
           <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="active">Active</option>
-            <option value="under_review">Under Review</option>
-            <option value="decommissioned">Decommissioned</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <button v-if="filterCriticality || filterStatus || searchQuery"
             @click="filterCriticality = ''; filterStatus = ''; searchQuery = ''"
             class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-            Clear
+            {{ t('common.action.clear') }}
           </button>
           <div class="ml-auto text-xs text-slate-500 tabular-nums">
-            {{ total }} total
+            {{ t('common.count.total', { count: total }) }}
           </div>
         </div>
       </div>
 
       <!-- Empty state -->
       <div v-if="systems.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-        <div class="text-sm text-slate-500">No systems found</div>
+        <div class="text-sm text-slate-500">{{ t('systems.filter.empty') }}</div>
       </div>
 
       <!-- Table -->
@@ -137,15 +135,15 @@
         <table class="w-full">
           <thead>
             <tr class="border-b border-slate-800">
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">System</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Classification</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Criticality</th>
-              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">C/I/A</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">RPO</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">RTO</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Next Review</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.system') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.classification') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.criticality') }}</th>
+              <th class="text-center px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.cia') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.rpo') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.rto') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.status') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.owner') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('systems.table.header.next_review') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-800/50">
@@ -158,18 +156,18 @@
               </td>
               <td class="px-5 py-3.5"><StatusBadge :status="sys.classification" group="classification" /></td>
               <td class="px-5 py-3.5">
-                <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(sys.criticality)">{{ sys.criticality }}</span>
+                <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(sys.criticality)">{{ criticalityLabel(sys.criticality) }}</span>
               </td>
               <td class="px-5 py-3.5 text-center">
                 <div class="flex gap-0.5 justify-center">
-                  <span v-if="sys.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.confidentiality)" :title="'Confidentiality: ' + ciaLabel(sys.confidentiality)">C{{ sys.confidentiality }}</span>
-                  <span v-if="sys.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.integrity)" :title="'Integrity: ' + ciaLabel(sys.integrity)">I{{ sys.integrity }}</span>
-                  <span v-if="sys.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.availability)" :title="'Availability: ' + ciaLabel(sys.availability)">A{{ sys.availability }}</span>
+                  <span v-if="sys.confidentiality > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.confidentiality)" :title="t('systems.table.cia_title.confidentiality', { level: ciaLabel(sys.confidentiality) })">C{{ sys.confidentiality }}</span>
+                  <span v-if="sys.integrity > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.integrity)" :title="t('systems.table.cia_title.integrity', { level: ciaLabel(sys.integrity) })">I{{ sys.integrity }}</span>
+                  <span v-if="sys.availability > 0" class="inline-block px-1 py-0.5 rounded text-[9px] font-medium" :class="ciaColor(sys.availability)" :title="t('systems.table.cia_title.availability', { level: ciaLabel(sys.availability) })">A{{ sys.availability }}</span>
                   <span v-if="!sys.confidentiality && !sys.integrity && !sys.availability" class="text-slate-600 text-xs">-</span>
                 </div>
               </td>
-              <td class="px-5 py-3.5 text-sm tabular-nums" :class="rpoColor(sys.rpo_hours)">{{ sys.rpo_hours || 0 }}h</td>
-              <td class="px-5 py-3.5 text-sm tabular-nums" :class="rtoColor(sys.rto_hours)">{{ sys.rto_hours || 0 }}h</td>
+              <td class="px-5 py-3.5 text-sm tabular-nums" :class="rpoColor(sys.rpo_hours)">{{ t('systems.table.hours', { count: sys.rpo_hours || 0 }) }}</td>
+              <td class="px-5 py-3.5 text-sm tabular-nums" :class="rtoColor(sys.rto_hours)">{{ t('systems.table.hours', { count: sys.rto_hours || 0 }) }}</td>
               <td class="px-5 py-3.5">
                 <StatusBadge :status="sys.status" />
               </td>
@@ -211,10 +209,10 @@
             <!-- Left nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -226,112 +224,110 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('systems.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Name</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.name') }}</label>
                         <input v-model="editForm.name" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'system'" :self-id="selectedItem?.identifier || ''" :rows="2" placeholder="Describe the system..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'system'" :self-id="selectedItem?.identifier || ''" :rows="2" :placeholder="t('systems.placeholder.description')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Classification</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.classification') }}</label>
                         <select v-model="editForm.classification" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="c in classifications" :key="c.key" :value="c.key">{{ c.label }}</option>
+                          <option v-for="c in classificationOptions" :key="c.value" :value="c.value">{{ c.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Criticality</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.criticality') }}</label>
                         <select v-model="editForm.criticality" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="c in criticalityLevels" :key="c.key" :value="c.key">{{ c.label }}</option>
+                          <option v-for="c in criticalityOptions" :key="c.value" :value="c.value">{{ c.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="active">Active</option>
-                          <option value="under_review">Under Review</option>
-                          <option value="decommissioned">Decommissioned</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                        <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.owner') }}</label>
+                        <MemberPicker v-model="editForm.owner" :members="orgMembers" :placeholder="t('common.placeholder.select_owner')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Department</label>
-                        <input v-model="editForm.department" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="IT, Engineering, Marketing..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.department') }}</label>
+                        <input v-model="editForm.department" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('systems.placeholder.department')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Supplier</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.supplier') }}</label>
                         <select v-model="editForm.supplier_id" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option :value="null">— None —</option>
+                          <option :value="null">{{ t('systems.option.no_supplier') }}</option>
                           <option v-for="s in suppliers" :key="s.id" :value="s.id">{{ s.name }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">RPO (hours)</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.rpo') }}</label>
                         <input v-model.number="editForm.rpo_hours" type="number" min="0" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
-                        <div class="text-[10px] text-slate-600 mt-1">Max acceptable data loss (hours)</div>
+                        <div class="text-[10px] text-slate-600 mt-1">{{ t('systems.hint.rpo') }}</div>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">RTO (hours)</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('systems.field.rto') }}</label>
                         <input v-model.number="editForm.rto_hours" type="number" min="0" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
-                        <div class="text-[10px] text-slate-600 mt-1">Max acceptable downtime (hours)</div>
+                        <div class="text-[10px] text-slate-600 mt-1">{{ t('systems.hint.rto') }}</div>
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('systems.field.description') }}</div>
                         <div v-if="selectedItem.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedItem.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Classification</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.classification') }}</div>
                           <StatusBadge :status="selectedItem.classification" group="classification" />
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Criticality</div>
-                          <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(selectedItem.criticality)">{{ selectedItem.criticality }}</span>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.criticality') }}</div>
+                          <span class="inline-block px-2 py-0.5 rounded text-[10px] font-medium" :class="criticalityColor(selectedItem.criticality)">{{ criticalityLabel(selectedItem.criticality) }}</span>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.status') }}</div>
                           <StatusBadge :status="selectedItem.status" />
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.owner') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.owner) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Department</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.department') }}</div>
                           <div class="text-sm text-slate-300">{{ selectedItem.department || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Supplier</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.supplier') }}</div>
                           <div class="text-sm text-slate-300">{{ supplierName(selectedItem.supplier_id) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">RPO / RTO</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.rpo_rto') }}</div>
                           <div class="text-sm text-slate-300">
-                            <span class="tabular-nums" :class="rpoColor(selectedItem.rpo_hours)">{{ selectedItem.rpo_hours || 0 }}h</span>
+                            <span class="tabular-nums" :class="rpoColor(selectedItem.rpo_hours)">{{ t('systems.table.hours', { count: selectedItem.rpo_hours || 0 }) }}</span>
                             <span class="text-slate-600 mx-1">/</span>
-                            <span class="tabular-nums" :class="rtoColor(selectedItem.rto_hours)">{{ selectedItem.rto_hours || 0 }}h</span>
+                            <span class="tabular-nums" :class="rtoColor(selectedItem.rto_hours)">{{ t('systems.table.hours', { count: selectedItem.rto_hours || 0 }) }}</span>
                           </div>
                         </div>
                         <div v-if="selectedItem.created_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedItem.created_at) }}</div>
                         </div>
                         <div v-if="selectedItem.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('systems.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedItem.created_by) }}</div>
                         </div>
                       </div>
@@ -347,25 +343,25 @@
                     <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                     </svg>
-                    Review overdue since {{ formatDay(selectedItem.next_review) }}
+                    {{ t('common.review.overdue_since', { date: formatDay(selectedItem.next_review) }) }}
                   </div>
 
                   <!-- CIA scores -->
                   <div class="grid grid-cols-3 gap-4">
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Confidentiality</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('systems.assessment.confidentiality') }}</div>
                       <div v-if="selectedItem.confidentiality" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.confidentiality)">{{ selectedItem.confidentiality }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.confidentiality" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.confidentiality) }}</div>
                     </div>
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Integrity</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('systems.assessment.integrity') }}</div>
                       <div v-if="selectedItem.integrity" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.integrity)">{{ selectedItem.integrity }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.integrity" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.integrity) }}</div>
                     </div>
                     <div class="bg-slate-800/40 border border-slate-700/50 rounded-lg px-5 py-4 text-center">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">Availability</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider">{{ t('systems.assessment.availability') }}</div>
                       <div v-if="selectedItem.availability" class="text-2xl font-bold tabular-nums mt-1.5" :class="ciaColorText(selectedItem.availability)">{{ selectedItem.availability }}</div>
                       <div v-else class="text-2xl text-slate-700 mt-1.5">—</div>
                       <div v-if="selectedItem.availability" class="text-[10px] text-slate-500 mt-0.5">{{ ciaLabel(selectedItem.availability) }}</div>
@@ -373,8 +369,8 @@
                   </div>
 
                   <div class="flex gap-4 text-[10px] text-slate-500 flex-wrap">
-                    <span v-if="selectedItem.last_review">Last review: {{ formatDay(selectedItem.last_review) }}</span>
-                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">Next review: {{ formatDay(selectedItem.next_review) }}</span>
+                    <span v-if="selectedItem.last_review">{{ t('common.review.last', { date: formatDay(selectedItem.last_review) }) }}</span>
+                    <span v-if="selectedItem.next_review && !isOverdue(selectedItem.next_review)">{{ t('common.review.next', { date: formatDay(selectedItem.next_review) }) }}</span>
                   </div>
 
                   <!-- Readings -->
@@ -390,9 +386,9 @@
               <template v-if="detailTab === 'reviews'">
                 <div class="px-6 py-5 space-y-4">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Access Reviews</div>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('systems.reviews.heading') }}</div>
                     <button v-if="canWrite" @click="showAddReview = !showAddReview" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">
-                      {{ showAddReview ? 'Cancel' : '+ Record review' }}
+                      {{ showAddReview ? t('common.action.cancel') : t('systems.reviews.add') }}
                     </button>
                   </div>
 
@@ -400,20 +396,20 @@
                   <div v-if="showAddReview" class="bg-slate-800/50 rounded-lg p-4 space-y-3">
                     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
                       <div>
-                        <label class="block text-[10px] font-medium text-slate-500 mb-1">Users Added</label>
+                        <label class="block text-[10px] font-medium text-slate-500 mb-1">{{ t('systems.reviews.users_added') }}</label>
                         <input v-model.number="reviewForm.users_added" type="number" min="0" class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div>
-                        <label class="block text-[10px] font-medium text-slate-500 mb-1">Users Removed</label>
+                        <label class="block text-[10px] font-medium text-slate-500 mb-1">{{ t('systems.reviews.users_removed') }}</label>
                         <input v-model.number="reviewForm.users_removed" type="number" min="0" class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="col-span-2">
-                        <label class="block text-[10px] font-medium text-slate-500 mb-1">Notes</label>
-                        <input v-model="reviewForm.notes" class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Removed former employees..." />
+                        <label class="block text-[10px] font-medium text-slate-500 mb-1">{{ t('systems.reviews.notes_label') }}</label>
+                        <input v-model="reviewForm.notes" class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('systems.reviews.notes_placeholder')" />
                       </div>
                     </div>
                     <button @click="addAccessReview" :disabled="reviewSaving" class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-xs font-medium rounded-lg transition-colors">
-                      {{ reviewSaving ? 'Saving...' : 'Record Review' }}
+                      {{ reviewSaving ? t('common.state.saving') : t('systems.reviews.submit') }}
                     </button>
                   </div>
 
@@ -421,7 +417,12 @@
                   <div v-if="accessReviews.length > 0" class="space-y-2">
                     <div v-for="ar in accessReviews" :key="ar.id" class="flex items-center justify-between bg-slate-800/30 rounded-lg px-4 py-2">
                       <div>
-                        <div class="text-xs text-slate-300">{{ ar.reviewed_by }} <span class="text-slate-600">reviewed</span></div>
+                        <div class="text-xs text-slate-300">
+                          <i18n-t keypath="systems.reviews.reviewed_by" scope="global">
+                            <template #name>{{ ar.reviewed_by }}</template>
+                            <template #reviewed><span class="text-slate-600">{{ t('systems.reviews.reviewed') }}</span></template>
+                          </i18n-t>
+                        </div>
                         <div class="text-[10px] text-slate-500 mt-0.5">
                           {{ formatDate(ar.reviewed_at) }}
                           <span v-if="ar.users_added || ar.users_removed" class="ml-2">
@@ -433,7 +434,7 @@
                       </div>
                     </div>
                   </div>
-                  <div v-else class="text-xs text-slate-600 italic">No access reviews recorded.</div>
+                  <div v-else class="text-xs text-slate-600 italic">{{ t('systems.reviews.empty') }}</div>
                 </div>
               </template>
 
@@ -441,15 +442,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('systems.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'system'" :self-id="selectedItem?.identifier || ''" :rows="12" placeholder="Additional notes... Type /doc to link a document" />
+                    <MarkdownField v-model="editForm.notes" :self-type="'system'" :self-id="selectedItem?.identifier || ''" :rows="12" :placeholder="t('systems.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedItem.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedItem.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -480,10 +481,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="system" :entityId="String(selectedItem.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this system is permanent and cannot be undone. History, comments, access reviews and linked references will be lost.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('systems.danger.warning') }}</div>
                     <button @click="deleteSelectedItem" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete system
+                      {{ t('systems.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -494,8 +495,8 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -510,6 +511,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -532,7 +534,11 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate, formatDay } from '../composables/useFormat.js'
+import { useEnumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
+const { t } = useI18n()
+const { enumLabel, entityLabel } = useEnumLabel()
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
 
@@ -553,7 +559,7 @@ async function reload() {
   try {
     await loadSystems()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -565,11 +571,13 @@ const orgMembers = ref([])
 const saving = ref(false)
 const stats = ref({ total: 0, active: 0, under_review: 0, decommissioned: 0, critical: 0, high: 0, medium: 0, low: 0 })
 const statusStats = computed(() => [
-  { key: '', label: 'Total', count: stats.value.total, color: 'text-slate-100' },
-  { key: 'active', label: 'Active', count: stats.value.active, color: 'text-emerald-400' },
-  { key: 'under_review', label: 'Under Review', count: stats.value.under_review, color: 'text-amber-400' },
-  { key: 'decommissioned', label: 'Decommissioned', count: stats.value.decommissioned || 0, color: 'text-slate-400' },
-  { key: 'critical', label: 'Critical', count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
+  { key: '', label: t('common.stat.total'), count: stats.value.total, color: 'text-slate-100' },
+  { key: 'active', label: statusLabel('active'), count: stats.value.active, color: 'text-emerald-400' },
+  { key: 'under_review', label: statusLabel('under_review'), count: stats.value.under_review, color: 'text-amber-400' },
+  { key: 'decommissioned', label: statusLabel('decommissioned'), count: stats.value.decommissioned || 0, color: 'text-slate-400' },
+  // `critical` here counts criticality, not status — a different family, so a
+  // different group.
+  { key: 'critical', label: criticalityLabel('critical'), count: stats.value.critical, color: stats.value.critical > 0 ? 'text-red-400' : 'text-slate-100', static: true },
 ])
 
 const selectedItem = ref(null)
@@ -594,30 +602,39 @@ const showAddReview = ref(false)
 const reviewForm = ref({ users_added: 0, users_removed: 0, notes: '' })
 const reviewSaving = ref(false)
 
-const classifications = [
-  { key: 'public', label: 'Public' },
-  { key: 'internal', label: 'Internal' },
-  { key: 'confidential', label: 'Confidential' },
-  { key: 'restricted', label: 'Restricted' },
-]
+// The members each picker offers. The set is this view's own choice; only the
+// label comes from the shared catalogue.
+const CLASSIFICATIONS = ['public', 'internal', 'confidential', 'restricted']
+const CRITICALITIES = ['critical', 'high', 'medium', 'low']
+const STATUSES = ['active', 'under_review', 'decommissioned']
 
-const criticalityLevels = [
-  { key: 'critical', label: 'Critical' },
-  { key: 'high', label: 'High' },
-  { key: 'medium', label: 'Medium' },
-  { key: 'low', label: 'Low' },
+// Message keys, not labels: a module-scope array of translated strings freezes
+// the tab bar in whichever locale was active when this module first evaluated.
+// `reviews` is this view's own copy — "Access Reviews", where Suppliers says
+// just "Reviews" — so it is not a common.tab.* entry.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'assessment', label: 'common.tab.assessment' },
+  { key: 'reviews', label: 'systems.tab.reviews' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'assessment', label: 'Assessment' },
-  { key: 'reviews', label: 'Access Reviews' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
-]
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+const statusLabel = (v) => enumLabel('status', v)
+const classificationLabel = (v) => enumLabel('classification', v)
+const criticalityLabel = (v) => enumLabel('criticality', v)
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const classificationOptions = options(CLASSIFICATIONS, classificationLabel)
+const criticalityOptions = options(CRITICALITIES, criticalityLabel)
 
 useModalEscape(showCreateForm)
 useModalEscape(computed(() => !!selectedItem.value), closeDetail)
@@ -633,7 +650,17 @@ watch([filterCriticality, filterStatus], () => {
 })
 watch([page, pageSize], () => loadSystems())
 
-const ciaLabel = (v) => ['Not Assessed','Insignificant','Minor','Moderate','Major','Severe'][v] || 'N/A'
+// Keys written out rather than built from the index: a runtime-composed key
+// defeats keyset extraction, which is why the convention forbids it.
+const CIA_KEYS = [
+  'common.cia.not_assessed',
+  'common.cia.insignificant',
+  'common.cia.minor',
+  'common.cia.moderate',
+  'common.cia.major',
+  'common.cia.severe',
+]
+const ciaLabel = (v) => (CIA_KEYS[v] ? t(CIA_KEYS[v]) : t('common.cia.na'))
 
 function ciaColor(v) {
   switch (v) {
@@ -724,7 +751,7 @@ async function loadSystems() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -765,7 +792,7 @@ async function addAccessReview() {
     await loadAccessReviews()
     await refreshSelectedItem()
   } catch (e) {
-    showError('Failed to record review: ' + e.message)
+    showError(t('systems.error.record_review', { message: renderApiError(e) }))
   } finally {
     reviewSaving.value = false
   }
@@ -807,24 +834,11 @@ async function saveSection() {
     await api.putJSON(`/api/v1/systems/${selectedItem.value.id}`, { ...editForm.value })
     await refreshSelectedItem()
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('systems.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
-  }
-}
-
-async function changeSystemStatus(newStatus) {
-  if (!selectedItem.value) return
-  try {
-    await api.putJSON(`/api/v1/systems/${selectedItem.value.id}`, { status: newStatus })
-    selectedItem.value.status = newStatus
-    await refreshSelectedItem()
-    await loadStats()
-    showSaved('Status updated')
-  } catch (e) {
-    showError('Failed to update status: ' + (e.message || 'unknown error'))
   }
 }
 
@@ -850,9 +864,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('systems.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('systems.dirty.discard'),
     })
     if (!ok) return
   }
@@ -863,9 +877,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('systems.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('systems.dirty.discard'),
     })
     if (!ok) return
   }
@@ -894,20 +908,20 @@ async function createItem() {
       router.push(orgPath(`/systems/${fresh.id}`))
     }
   } catch (e) {
-    showError('Failed to create system: ' + e.message)
+    showError(t('systems.error.create', { message: renderApiError(e) }))
   }
 }
 
 async function deleteSelectedItem() {
   if (!selectedItem.value) return
-  const ok = await confirmDialog({ message: 'Delete this system? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({ message: t('systems.danger.confirm'), variant: 'danger', confirmLabel: t('common.action.delete') })
   if (!ok) return
   try {
     await api.deleteJSON(`/api/v1/systems/${selectedItem.value.id}`)
     closeDetail()
     await loadSystems()
   } catch (e) {
-    showError('Failed to delete: ' + e.message)
+    showError(t('systems.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -926,7 +940,7 @@ onMounted(async () => {
     suppliers.value = sup || []
     orgMembers.value = users || []
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -40,6 +40,48 @@ const GROUPS = {
   suggestion_type: ['create', 'update', 'reassess', 'link', 'review', 'reading'],
 }
 
+// The register groups added by the 3.5 extraction. Pinned against `en` like
+// every other group, but deliberately NOT in the id-ID mirror below: their
+// values are hardcoded English literals in the views today, so an untranslated
+// key is not a regression, while an unreviewed Indonesian ISO term is one.
+// Risk treatment in particular is clause 6.1.3 vocabulary — the category
+// web/src/locales/README.md records as having shipped wrong twice because the
+// wrong choice reads fluently. They join the mirror when a speaker works the
+// procedure in that README.
+//
+// Members mirror the CHECK constraints in migrations/ verbatim.
+const PENDING_TRANSLATION = {
+  treatment: ['mitigate', 'accept', 'transfer', 'avoid'],
+  risk_type: ['threat', 'opportunity'],
+  // risks.origin and incidents.source share one value set under two column
+  // names. Named for the value set, which also leaves `source` free for
+  // corrective_actions.source — a different set entirely.
+  origin: ['internal', 'external', 'internal and external'],
+  incident_type: ['incident', 'event', 'weakness'],
+  gdpr_role: ['controller', 'processor'],
+  // incidents.authority_notified and incidents.subjects_notified.
+  notification_status: ['not_required', 'pending', 'notified'],
+  supplier_type: [
+    'cloud', 'saas', 'consulting', 'hosting', 'infrastructure', 'software',
+    'contractor', 'other',
+  ],
+  asset_type: [
+    'infrastructure', 'processing_devices', 'software', 'system', 'network',
+    'service', 'financial_info', 'personal_data', 'ipr', 'sales_marketing',
+    'processing_facility', 'products_services', 'supply_chain', 'other',
+  ],
+  // The five the server accepts (db.LegalCategories) plus the seven Legal.vue
+  // has always offered. The view's list does not match the server's and six of
+  // its options are rejected on save (#269) — a pre-existing bug, not an
+  // extraction's to fix. Both sets carry labels so a stored value renders
+  // whichever list produced it.
+  legal_category: [
+    'privacy', 'security', 'sector', 'contractual', 'other',
+    'data_protection', 'employment', 'regulatory', 'intellectual_property',
+    'financial', 'environmental', 'corporate',
+  ],
+}
+
 // The suggestion `entity` param, resolved through common.entity.* rather than
 // common.enum.* — an entity name is a noun the whole app reuses, not an enum
 // member. Matches the entity_type CHECK on `suggestions`.
@@ -50,7 +92,7 @@ const ENTITIES = [
 ]
 
 test('every enum member a register can store has a label', () => {
-  for (const [group, values] of Object.entries(GROUPS)) {
+  for (const [group, values] of Object.entries({ ...GROUPS, ...PENDING_TRANSLATION })) {
     for (const value of values) {
       assert.ok(
         en.common.enum[group]?.[value],

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -1,6 +1,5 @@
 {
   "composables/useDocumentEditor.js": 1,
-  "views/Assets.vue": 6,
   "views/Audit.vue": 19,
   "views/Changes.vue": 4,
   "views/CorrectiveActions.vue": 7,

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -7,7 +7,6 @@
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
   "views/Incidents.vue": 9,
-  "views/Legal.vue": 6,
   "views/Objectives.vue": 12,
   "views/Programs.vue": 5,
   "views/Reviews.vue": 12,

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -6,7 +6,6 @@
   "views/CorrectiveActions.vue": 7,
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
-  "views/Incidents.vue": 9,
   "views/Objectives.vue": 12,
   "views/Programs.vue": 5,
   "views/Reviews.vue": 12,

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -11,6 +11,5 @@
   "views/Programs.vue": 5,
   "views/Reviews.vue": 12,
   "views/Suppliers.vue": 7,
-  "views/Systems.vue": 8,
   "views/Tasks.vue": 4
 }

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -10,6 +10,5 @@
   "views/Objectives.vue": 12,
   "views/Programs.vue": 5,
   "views/Reviews.vue": 12,
-  "views/Suppliers.vue": 7,
   "views/Tasks.vue": 4
 }

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -11,7 +11,6 @@
   "views/Objectives.vue": 12,
   "views/Programs.vue": 5,
   "views/Reviews.vue": 12,
-  "views/Risks.vue": 9,
   "views/Suppliers.vue": 7,
   "views/Systems.vue": 8,
   "views/Tasks.vue": 4

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,5 +1,4 @@
 {
-  "views/Assets.vue": 68,
   "views/Audit.vue": 218,
   "views/Changes.vue": 106,
   "views/CorrectiveActions.vue": 90,

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -5,7 +5,6 @@
   "views/CorrectiveActions.vue": 90,
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
-  "views/Incidents.vue": 120,
   "views/Objectives.vue": 98,
   "views/Programs.vue": 36,
   "views/Reviews.vue": 146,

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -6,7 +6,6 @@
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
   "views/Incidents.vue": 120,
-  "views/Legal.vue": 90,
   "views/Objectives.vue": 98,
   "views/Programs.vue": 36,
   "views/Reviews.vue": 146,

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -10,7 +10,6 @@
   "views/Objectives.vue": 98,
   "views/Programs.vue": 36,
   "views/Reviews.vue": 146,
-  "views/Risks.vue": 167,
   "views/Suppliers.vue": 80,
   "views/Systems.vue": 92,
   "views/Tasks.vue": 105

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -10,6 +10,5 @@
   "views/Programs.vue": 36,
   "views/Reviews.vue": 146,
   "views/Suppliers.vue": 80,
-  "views/Systems.vue": 92,
   "views/Tasks.vue": 105
 }

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -9,6 +9,5 @@
   "views/Objectives.vue": 98,
   "views/Programs.vue": 36,
   "views/Reviews.vue": 146,
-  "views/Suppliers.vue": 80,
   "views/Tasks.vue": 105
 }


### PR DESCRIPTION
Makes the six register screens translatable: **Risks, Legal, Systems, Suppliers, Incidents and Assets**. Continues #212, following the auth views (#264), the shell and landing page (#266), the shared components (#267) and the admin surface (#268).

**Please merge with a merge commit, not a squash.** There are ten commits and each one is a single view or a single decision; the per-view record is what makes this reviewable and what the next contributor will read. #268 carried the same request and was squashed, so its eight commits are gone.

## What changes for a user

Nothing, today. Every one of these screens renders exactly the same English it did before, because English is the only language the app currently offers. What changes is that the text is now *capable* of being another language — it comes out of translation files instead of being baked into the code.

Three visible differences, all deliberate:

- **Some labels change capitalisation.** "Under Review" becomes "Under review", "Data Protection" becomes "Data protection", "Not Required" becomes "Not required". These labels now come from the app's shared vocabulary, which has always used sentence case — and which the status badges on these same screens were already using. The alternative was two spellings of the same word on one screen. Words are unchanged; only the capital letters are.
- **Two labels are now correct that were wrong.** An asset typed as intellectual property displayed as "Ipr", and one typed as sales & marketing displayed as "Sales marketing". Both were the side effect of the code guessing a label from a database value. They now read "Intellectual property" and "Sales & marketing".
- **A panel that never appeared now appears.** See the bug fix below.

## What this fixes

**The supplier detail page's "Linked systems" panel could never render.** If you had systems pointing at a supplier, opening that supplier showed nothing where the list should be. Cause was a one-line mismatch in how the response was read. Found while checking that a newly added label could actually be seen — it could not, which is what made the bug findable.

## What this deliberately does not fix

**Legal requirement categories are broken and stay broken here — filed as #269.** The category dropdown offers eight options; the server accepts five, and only one of those is in both lists. Six of the eight fail on save. Changing which options a user sees is a product decision, not something a translation pass should slip in, so the list is untouched and the bug is tracked separately.

**Three kinds of text on these screens are still English regardless of language**, because the text does not come from the app:

- Risk categories, which each organisation configures for itself
- Legal jurisdictions, which are free-text country names
- Anything an administrator has typed into a setting

Making those translatable needs the server to send codes instead of sentences, which is separate work already scoped under this issue.

## Risk

**Low, and mechanically checked.** Two automated gates run in CI and both are at zero for all six files: one counts untranslated text, the other counts error messages that bypass the translation layer. Between them they went from 617 and 45 findings to none.

The gates do not see everything, so each of the six screens was also opened in a browser and driven through a stand-in second language, which makes any text that failed to translate immediately obvious. That pass is what caught the last two problems in this branch — a set of letters no automated check can see, and the broken panel above.

**Around 200 lines of unreachable code were deleted** rather than translated: two duplicate edit forms on the risk screen that no navigation could reach, and a status-change helper that five of the six screens each carried a copy of, none of them called. Translating dead screens would have meant shipping vocabulary for buttons nobody can press.

## Scope

- 6 screens, 617 pieces of text, 45 error messages
- 435 new translation entries: 344 belonging to individual screens, 91 shared
- The shared vocabulary lands first, in its own two commits, because these six screens are near-copies of each other and would otherwise have produced six copies of every shared label. The workflow and document screens still to come will draw on the same vocabulary — the tab bar alone is nine labels they all share.

## Verification

- `npm test` — 150 pass
- `npm run build`
- `go test ./internal/isms/i18n/...`
- Both text gates at zero for all six files; the totals they track fall from 1692 to 1075 and from 145 to 100
- All six screens opened in a browser against a stand-in locale, with no missing-translation warnings

Closes the register portion of #212. The workflow screens (audit, tasks, objectives, corrective actions, changes, programs) and the document screens are next.