### PR TITLE
feat(i18n): extract the six workflow views (#212)

### DIFF
--- a/internal/isms/i18n/release_gate_test.go
+++ b/internal/isms/i18n/release_gate_test.go
@@ -18,9 +18,9 @@ const rawTextBaseline = "../../../web/test/rawText.baseline.json"
 // punctuation, and attribute values it cannot distinguish from copy — so a
 // fully extracted tree still carries a residue, and 100 is an estimate of it.
 //
-// For scale: the tree started at 2488 and sits at 1075 now that the auth,
-// shell, component, admin and register surfaces are extracted — so roughly 10x
-// above the threshold, with the workflow and document views left. The estimate
+// For scale: the tree started at 2488 and sits at 422 now that the auth,
+// shell, component, admin, register and workflow surfaces are extracted — so
+// roughly 4x above the threshold, with only the document views left. The estimate
 // still wants revisiting once a fully extracted tree shows what the residue
 // actually is; the threshold is a judgement, and says so. The coupling it
 // enforces is not.

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -400,7 +400,10 @@ export const api = {
   updateAuditProgramme: (id, data) => putJSON(`${API}/audit/programmes/${id}`, data),
   deleteAuditProgramme: (id) => deleteJSON(`${API}/audit/programmes/${id}`),
   getAuditCalendar: (year) => fetchJSON(`${API}/audit/calendar?year=${year || new Date().getFullYear()}`),
-  getAuditFindingsPaginated: (params) => fetchJSON(`${API}/audit/findings?${new URLSearchParams(params || {})}`),
+  // fetchRaw, not fetchJSON: the caller reads `.data` and `.total` off the
+  // envelope, and fetchJSON unwraps `{data: [...]}` to a bare array — which
+  // left the audit Findings tab and its four counters permanently at zero.
+  getAuditFindingsPaginated: (params) => fetchRaw(`${API}/audit/findings?${new URLSearchParams(params || {})}`),
   listAuditFindings: (params) => fetchJSON(`${API}/audit/findings?${new URLSearchParams(params || {})}`),
   getAudits: (programmeId) => fetchJSON(`${API}/audits${programmeId ? '?programme_id=' + programmeId : ''}`),
   listAudits: (params) => fetchJSON(`${API}/audits?${new URLSearchParams(params || {})}`),

--- a/web/src/composables/useEnumLabel.js
+++ b/web/src/composables/useEnumLabel.js
@@ -47,6 +47,19 @@ export function enumLabelInline(group, value) {
   return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : enumLabel(group, value)
 }
 
+// Abbreviated form, for a control too narrow to hold the full label — an
+// <option> in a filter bar, a badge in a dense table. Like the inline form it
+// is authored, not derived: which abbreviation a language uses ("OFI" is an
+// English initialism) is a property of that language.
+//
+// Falls back to the standalone label, so a group with no abbreviations
+// authored still renders.
+export function enumLabelAbbr(group, value) {
+  if (value === null || value === undefined || value === '') return ''
+  const key = `common.enum_abbr.${group}.${value}`
+  return i18n.global.te(key, FALLBACK) ? i18n.global.t(key) : enumLabel(group, value)
+}
+
 // Entity names run through common.entity.* rather than common.enum.*, and need
 // the same two forms for the same reason.
 export function entityLabel(value, { inline = false } = {}) {
@@ -63,5 +76,5 @@ export function entityLabel(value, { inline = false } = {}) {
 // enumLabel() so plain .js modules can use the same seam without a component
 // instance, exactly as `t` is exported from @/i18n for the same reason.
 export function useEnumLabel() {
-  return { enumLabel, enumLabelInline, entityLabel }
+  return { enumLabel, enumLabelInline, enumLabelAbbr, entityLabel }
 }

--- a/web/src/composables/useFormat.js
+++ b/web/src/composables/useFormat.js
@@ -104,6 +104,17 @@ export function formatMonthShort(monthIndex) {
   }).format(Date.UTC(2021, i, 1))
 }
 
+// The same, spelled out — the audit calendar heads each month section with a
+// full name. The server sends one too, in English; this reads the active
+// locale instead.
+export function formatMonthLong(monthIndex) {
+  if (!Number.isInteger(monthIndex) || monthIndex < 0 || monthIndex > 11) return ''
+  return formatter(Intl.DateTimeFormat, 'date', activeLocale(), {
+    month: 'long',
+    timeZone: 'UTC',
+  }).format(Date.UTC(2021, monthIndex, 1))
+}
+
 // A duration in whole hours, for the RPO/RTO columns. Same reasoning as the
 // date shapes: the unit is locale-specific ("4h" in English, "4 j" in French),
 // so Intl supplies it and no unit letter lands in a translation file. Narrow
@@ -162,6 +173,7 @@ export function useFormat() {
     date: formatDate,
     day: formatDay,
     monthShort: formatMonthShort,
+    monthLong: formatMonthLong,
     hours: formatHours,
     number: formatNumber,
     relative: formatRelative,

--- a/web/src/locales/en/audit.json
+++ b/web/src/locales/en/audit.json
@@ -1,0 +1,232 @@
+{
+  "title": "Internal Audit",
+  "subtitle": "Audit programmes, schedule, and findings",
+  "error": {
+    "load": "Failed to load audit module. {message}",
+    "load_programmes": "Failed to load programmes: {message}",
+    "load_audits": "Failed to load audits: {message}",
+    "load_calendar": "Failed to load calendar: {message}",
+    "load_findings": "Failed to load findings: {message}",
+    "load_audit_detail": "Failed to load audit details: {message}",
+    "create_programme": "Failed to create programme: {message}",
+    "save_programme": "Failed to save programme: {message}",
+    "delete_programme": "Failed to delete programme: {message}",
+    "create_audit": "Failed to create audit: {message}",
+    "save_audit": "Failed to save audit: {message}",
+    "save_report": "Failed to save report: {message}",
+    "add_item": "Failed to add item: {message}",
+    "save_item": "Failed to save: {message}",
+    "remove_item": "Failed to remove: {message}",
+    "create_finding": "Failed to add finding: {message}",
+    "save_finding": "Failed to save finding: {message}",
+    "delete_finding": "Failed to delete finding: {message}"
+  },
+  "toast": {
+    "programme_added": "Programme added",
+    "programme_deleted": "Programme deleted",
+    "audit_added": "Audit added",
+    "report_saved": "Report saved",
+    "item_added": "Item added",
+    "item_removed": "Item removed",
+    "finding_added": "Finding added",
+    "finding_deleted": "Finding deleted"
+  },
+  "tab": {
+    "calendar": "Calendar",
+    "programmes": "Programmes",
+    "findings": "Findings",
+    "audits": "Audits",
+    "items": "Items",
+    "report": "Report",
+    "discussion": "Discussion",
+    "linked": "Linked CAs"
+  },
+  "action": {
+    "add_programme": "Add Programme",
+    "add_finding": "Add Finding",
+    "add_audit": "Add Audit"
+  },
+  "calendar": {
+    "loading": "Loading calendar...",
+    "audit_count": "{count} audit | {count} audits",
+    "month_empty": "No audits planned this month",
+    "unscheduled": "Unscheduled",
+    "unscheduled_count": "{count} audit without planned date | {count} audits without planned date",
+    "unscheduled_range": "unscheduled",
+    "empty": "No audits in {year}. Add an audit from a programme to see it here."
+  },
+  "programme": {
+    "search_placeholder": "Search programmes...",
+    "all_years": "All years",
+    "empty_filtered": "No programmes match your filter.",
+    "empty": "No audit programmes yet — click Add Programme to create one.",
+    "table": {
+      "id": "ID",
+      "title": "Title",
+      "year": "Year",
+      "audits": "Audits",
+      "findings": "Findings",
+      "status": "Status"
+    },
+    "create": {
+      "heading": "Add Programme",
+      "title_label": "Title *",
+      "title_placeholder": "e.g. 2026 Annual Audit Programme",
+      "year_label": "Year *",
+      "fill_in_later": "You can add description, status and audits after creating.",
+      "submitting": "Adding...",
+      "submit": "Add"
+    },
+    "field": {
+      "title": "Title",
+      "year": "Year",
+      "status": "Status",
+      "description": "Description",
+      "notes": "Notes",
+      "audits": "Audits",
+      "created_by": "Created by",
+      "created": "Created"
+    },
+    "placeholder": {
+      "description": "Programme objectives and scope...",
+      "notes": "Internal notes..."
+    },
+    "audits_heading": "Audits in this programme",
+    "add_audit": "+ Add Audit",
+    "audits_empty": "No audits in this programme yet.",
+    "open_findings": "{count} open",
+    "danger": {
+      "warning": "Programmes with audits cannot be deleted. Remove all audits first.",
+      "delete": "Delete programme",
+      "confirm": "Delete programme \"{title}\"? This cannot be undone."
+    }
+  },
+  "audit": {
+    "loading_detail": "Loading audit details...",
+    "create": {
+      "heading": "Add Audit",
+      "title_label": "Title *",
+      "title_placeholder": "Audit title",
+      "programme_label": "Programme",
+      "no_programme": "No programme (ad-hoc)",
+      "type_label": "Audit Type",
+      "fill_in_later": "You can add scope, auditor, dates and items after creating.",
+      "submitting": "Adding...",
+      "submit": "Add"
+    },
+    "field": {
+      "title": "Title",
+      "scope": "Scope",
+      "type": "Audit Type",
+      "status": "Status",
+      "auditor": "Auditor",
+      "programme": "Programme",
+      "planned_date": "Planned Date",
+      "end_date": "End Date",
+      "planned": "Planned",
+      "started": "Started",
+      "completed": "Completed",
+      "items": "Items",
+      "findings": "Findings",
+      "notes": "Notes"
+    },
+    "placeholder": {
+      "scope": "Scope description. Type /doc to link controls or clauses...",
+      "auditor": "Select auditor...",
+      "notes": "Internal audit notes..."
+    },
+    "open_count": "({count} open)",
+    "danger": {
+      "warning": "Audits cannot currently be deleted from the UI. Manage destructive actions via CLI."
+    }
+  },
+  "items": {
+    "heading": "Audit Items ({count})",
+    "add": "+ Add Item",
+    "search_placeholder": "Search documents, controls, clauses, risks, assets...",
+    "searching": "Searching...",
+    "no_matches": "No matches.",
+    "empty": "No items yet — add controls, clauses, risks or other items to assess.",
+    "raise_finding": "Raise finding",
+    "raise_finding_title": "Create a finding from this item",
+    "delete_title": "Delete item",
+    "evidence": "Evidence",
+    "evidence_placeholder": "Evidence reference, link or description...",
+    "notes": "Notes",
+    "notes_empty": "Notes (empty)",
+    "notes_placeholder": "Inline notes for this item...",
+    "save_notes": "Save notes",
+    "confirm_remove": "Remove \"{title}\" from this audit?",
+    "remove": "Remove"
+  },
+  "findings": {
+    "search_placeholder": "Search findings...",
+    "all_audits": "All audits",
+    "overdue_toggle_title": "Toggle: Overdue only",
+    "overdue_only": "Overdue only",
+    "overdue": "Overdue",
+    "empty_filtered": "No findings match your filter.",
+    "empty": "No findings recorded yet.",
+    "heading_count": "Findings ({count})",
+    "add": "+ Add Finding",
+    "audit_empty": "No findings recorded for this audit yet.",
+    "table": {
+      "id": "ID",
+      "title": "Title",
+      "audit": "Audit",
+      "type": "Type",
+      "owner": "Owner",
+      "due": "Due",
+      "status": "Status"
+    },
+    "create": {
+      "heading": "Add Finding",
+      "title_label": "Title *",
+      "title_placeholder": "Finding title",
+      "audit_label": "Audit *",
+      "audit_placeholder": "Select audit...",
+      "type_label": "Type",
+      "fill_in_later": "You can add description, owner, due date and corrective action links after creating.",
+      "submitting": "Adding...",
+      "submit": "Add"
+    },
+    "field": {
+      "title": "Title",
+      "description": "Description",
+      "type": "Type",
+      "status": "Status",
+      "owner": "Owner",
+      "due_date": "Due Date",
+      "due_date_read": "Due date",
+      "audit": "Audit",
+      "audit_item": "Audit Item",
+      "created": "Created",
+      "closed": "Closed"
+    },
+    "placeholder": {
+      "description": "Detailed finding description, evidence, root cause analysis...",
+      "owner": "Select owner..."
+    },
+    "item_ref": "item #{id}",
+    "quick_action": "Quick action",
+    "create_ca": "Create Corrective Action from finding",
+    "create_ca_hint": "Spawn a CA pre-filled with this finding's title and severity.",
+    "danger": {
+      "warning": "Deleting this finding is permanent. Linked corrective actions stay but lose this back-reference.",
+      "delete": "Delete finding",
+      "confirm": "Delete this finding? This cannot be undone."
+    }
+  },
+  "report": {
+    "heading": "Audit Report",
+    "placeholder": "Auditor's final report — observations, conclusions, recommendations. Use slash commands to link controls, clauses, evidence...",
+    "empty": "No report written yet."
+  },
+  "dirty": {
+    "report_switch_tab": "You have unsaved report changes. Discard and switch tab?",
+    "report_close": "You have unsaved report changes. Discard and close?"
+  },
+  "detail": {
+    "overview": "Overview"
+  }
+}

--- a/web/src/locales/en/changes.json
+++ b/web/src/locales/en/changes.json
@@ -1,0 +1,65 @@
+{
+  "title": "Change Management",
+  "subtitle": "Track and approve changes to your management system.",
+  "error": {
+    "load": "Failed to load changes: {message}",
+    "create": "Failed to create change request: {message}",
+    "save": "Failed to save: {message}",
+    "delete": "Failed to delete change request: {message}"
+  },
+  "action": {
+    "add": "Add Change Request"
+  },
+  "create": {
+    "heading": "Add Change Request",
+    "type_label": "Type",
+    "title_label": "Title",
+    "title_placeholder": "e.g. Migrate authentication to OIDC",
+    "priority_label": "Priority",
+    "category_label": "Category",
+    "fill_in_later": "You can add description, justification, planned date, risk level, assignee, rollback plan and notes after creating.",
+    "submitting": "Creating...",
+    "submit": "Add"
+  },
+  "filter": {
+    "empty": "No change requests found"
+  },
+  "list": {
+    "requested_by": "Requested by {name}",
+    "assigned_to": "Assigned to {name}",
+    "risk": "Risk: {level}"
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "type": "Type",
+    "priority": "Priority",
+    "category": "Category",
+    "risk_level": "Risk Level",
+    "status": "Status",
+    "assigned_to": "Assigned to",
+    "assignee": "Assignee",
+    "planned_for": "Planned for",
+    "justification": "Justification",
+    "rollback_plan": "Rollback Plan",
+    "requested_by": "Requested by",
+    "created": "Created"
+  },
+  "placeholder": {
+    "description": "Describe the change...",
+    "assignee": "Select...",
+    "justification": "Why is this change needed?",
+    "rollback_plan": "How to revert?",
+    "notes": "Add notes..."
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes",
+    "progress": "Progress"
+  },
+  "danger": {
+    "warning": "Deleting this change request is permanent and cannot be undone.",
+    "delete": "Delete change request",
+    "confirm": "Delete this change request? This cannot be undone."
+  }
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -517,5 +517,10 @@
     "switch_tab": "You have unsaved changes. Discard and switch tab?",
     "close": "You have unsaved changes. Discard and close?",
     "discard": "Discard"
+  },
+  "bytes": {
+    "b": "{value} B",
+    "kb": "{value} KB",
+    "mb": "{value} MB"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -453,7 +453,8 @@
   "count": {
     "total": "{count} total",
     "comments": "{count} comment | {count} comments",
-    "outdated_comments": "{count} outdated comment | {count} outdated comments"
+    "outdated_comments": "{count} outdated comment | {count} outdated comments",
+    "of": "{shown} of {total}"
   },
   "placeholder": {
     "search": "Search...",
@@ -522,6 +523,14 @@
       "minor_nc": "Minor NC",
       "observation": "Observation",
       "opportunity": "OFI"
+    },
+    "audit_result": {
+      "not_assessed": "Not assessed",
+      "conforming": "Conforming",
+      "minor_nc": "Minor NC",
+      "major_nc": "Major NC",
+      "observation": "Observation",
+      "opportunity": "Opportunity"
     }
   },
   "dirty": {
@@ -540,5 +549,9 @@
   },
   "separator": {
     "dot": "·"
+  },
+  "detail": {
+    "at_by": "{datetime} {by}",
+    "by": "by {name}"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -512,5 +512,10 @@
       "observation": "Observation",
       "opportunity": "OFI"
     }
+  },
+  "dirty": {
+    "switch_tab": "You have unsaved changes. Discard and switch tab?",
+    "close": "You have unsaved changes. Discard and close?",
+    "discard": "Discard"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -305,6 +305,60 @@
       "financial": "Financial regulation",
       "environmental": "Environmental",
       "corporate": "Corporate governance"
+    },
+    "audit_type": {
+      "internal": "Internal",
+      "external": "External",
+      "surveillance": "Surveillance",
+      "certification": "Certification",
+      "recertification": "Recertification"
+    },
+    "change_category": {
+      "process": "Process",
+      "technology": "Technology",
+      "people": "People",
+      "documentation": "Documentation",
+      "infrastructure": "Infrastructure",
+      "other": "Other"
+    },
+    "task_type": {
+      "general": "General",
+      "review": "Review",
+      "incident_followup": "Incident follow-up",
+      "audit_followup": "Audit follow-up",
+      "ca_followup": "Corrective action follow-up",
+      "change_followup": "Change follow-up",
+      "onboarding": "Onboarding",
+      "offboarding": "Offboarding",
+      "training": "Training",
+      "other": "Other"
+    },
+    "source": {
+      "internal_audit": "Internal audit",
+      "external_audit": "External audit",
+      "risk_assessment": "Risk assessment",
+      "security_incident": "Security incident",
+      "objective": "Objective",
+      "feedback": "Feedback",
+      "other": "Other"
+    },
+    "priority": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    },
+    "outcome": {
+      "satisfactory": "Satisfactory",
+      "concerns": "Concerns",
+      "unsatisfactory": "Unsatisfactory"
+    },
+    "target_operator": {
+      "gte": "≥",
+      "lte": "≤",
+      "eq": "=",
+      "gt": ">",
+      "lt": "<"
     }
   },
   "enum_inline": {
@@ -412,7 +466,11 @@
     "all_levels": "All levels",
     "all_criticality": "All criticality",
     "all_categories": "All categories",
-    "all_severities": "All severities"
+    "all_severities": "All severities",
+    "all_priorities": "All priorities",
+    "all_sources": "All sources",
+    "all_programs": "All programs",
+    "all_owners": "All owners"
   },
   "option": {
     "none": "None",
@@ -446,5 +504,13 @@
     "major": "Major",
     "severe": "Severe",
     "na": "N/A"
+  },
+  "enum_abbr": {
+    "finding_type": {
+      "major_nc": "Major NC",
+      "minor_nc": "Minor NC",
+      "observation": "Observation",
+      "opportunity": "OFI"
+    }
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -359,6 +359,16 @@
       "eq": "=",
       "gt": ">",
       "lt": "<"
+    },
+    "change_type": {
+      "change": "Change",
+      "access_request": "Access request"
+    },
+    "risk_level": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
     }
   },
   "enum_inline": {
@@ -527,5 +537,8 @@
   "seed": {
     "created_from": "Created from [{label}]({link})",
     "created_from_audit_finding": "Created from audit finding {label}"
+  },
+  "separator": {
+    "dot": "·"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -477,7 +477,8 @@
     "not_decided": "Not decided"
   },
   "stat": {
-    "total": "Total"
+    "total": "Total",
+    "overdue": "Overdue"
   },
   "heading": {
     "quick_actions": "Quick actions",
@@ -522,5 +523,9 @@
     "b": "{value} B",
     "kb": "{value} KB",
     "mb": "{value} MB"
+  },
+  "seed": {
+    "created_from": "Created from [{label}]({link})",
+    "created_from_audit_finding": "Created from audit finding {label}"
   }
 }

--- a/web/src/locales/en/corrective_actions.json
+++ b/web/src/locales/en/corrective_actions.json
@@ -1,0 +1,70 @@
+{
+  "title": "Corrective Actions",
+  "subtitle": "Track nonconformities, observations, and opportunities for improvement",
+  "error": {
+    "save": "Failed to save: {message}"
+  },
+  "action": {
+    "add": "Add Corrective Action"
+  },
+  "filter": {
+    "assignee_placeholder": "Any assignee",
+    "empty": "No corrective actions match your filter.",
+    "empty_all": "No corrective actions yet — click Add to create your first one."
+  },
+  "create": {
+    "heading": "Add Corrective Action",
+    "title_label": "Title *",
+    "title_placeholder": "Brief title of the nonconformity or improvement",
+    "fill_in_later": "You can add description, assignee, due date and notes after creating.",
+    "submit": "Add"
+  },
+  "source_option": {
+    "internal_audit": "Internal Audit Finding",
+    "external_audit": "External Audit Finding",
+    "risk_assessment": "Risk Assessment",
+    "security_incident": "Security Incident",
+    "objective": "Objective",
+    "feedback": "Feedback / Suggestion",
+    "other": "Other"
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "source": "Source",
+    "severity": "Severity",
+    "status": "Status",
+    "assignee": "Assignee",
+    "due_date": "Due date",
+    "root_cause": "Root Cause",
+    "created": "Created",
+    "created_by": "Created by",
+    "resolved": "Resolved"
+  },
+  "placeholder": {
+    "description": "Describe the corrective action...",
+    "assignee": "Select assignee...",
+    "root_cause": "Root cause analysis...",
+    "notes": "Add notes..."
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes",
+    "resolved_by": "{datetime} {by}",
+    "by": "by {name}"
+  },
+  "actions": {
+    "create_task": "Create Implementation Task",
+    "create_task_hint": "Spawn a task to do the corrective work; auto-linked back to this CA."
+  },
+  "danger": {
+    "warning": "Deleting this corrective action is permanent and cannot be undone.",
+    "delete": "Delete corrective action",
+    "confirm": "Delete this corrective action? This cannot be undone."
+  },
+  "seed": {
+    "from_incident": "Created from [{label}]({link})",
+    "from_audit_finding": "Created from audit finding {label}",
+    "from_risk": "Created from [{label}]({link})"
+  }
+}

--- a/web/src/locales/en/corrective_actions.json
+++ b/web/src/locales/en/corrective_actions.json
@@ -49,9 +49,7 @@
   },
   "detail": {
     "overview": "Overview",
-    "notes": "Notes",
-    "resolved_by": "{datetime} {by}",
-    "by": "by {name}"
+    "notes": "Notes"
   },
   "actions": {
     "create_task": "Create Implementation Task",

--- a/web/src/locales/en/corrective_actions.json
+++ b/web/src/locales/en/corrective_actions.json
@@ -61,10 +61,5 @@
     "warning": "Deleting this corrective action is permanent and cannot be undone.",
     "delete": "Delete corrective action",
     "confirm": "Delete this corrective action? This cannot be undone."
-  },
-  "seed": {
-    "from_incident": "Created from [{label}]({link})",
-    "from_audit_finding": "Created from audit finding {label}",
-    "from_risk": "Created from [{label}]({link})"
   }
 }

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -14,6 +14,7 @@
 import admin from './admin.json' with { type: 'json' }
 import assets from './assets.json' with { type: 'json' }
 import auth from './auth.json' with { type: 'json' }
+import changes from './changes.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
 import correctiveActions from './corrective_actions.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
@@ -36,6 +37,7 @@ export default {
   admin,
   assets,
   auth,
+  changes,
   common,
   corrective_actions: correctiveActions,
   components,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -22,6 +22,7 @@ import incidents from './incidents.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
 import legal from './legal.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
+import objectives from './objectives.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
 import programs from './programs.json' with { type: 'json' }
 import risks from './risks.json' with { type: 'json' }
@@ -42,6 +43,7 @@ export default {
   landing,
   legal,
   notifications,
+  objectives,
   organizations,
   programs,
   risks,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -22,6 +22,7 @@ import landing from './landing.json' with { type: 'json' }
 import legal from './legal.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
+import programs from './programs.json' with { type: 'json' }
 import risks from './risks.json' with { type: 'json' }
 import settings from './settings.json' with { type: 'json' }
 import shell from './shell.json' with { type: 'json' }
@@ -40,6 +41,7 @@ export default {
   legal,
   notifications,
   organizations,
+  programs,
   risks,
   settings,
   shell,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -13,6 +13,7 @@
 // in the bundler and under `node --test`.
 import admin from './admin.json' with { type: 'json' }
 import assets from './assets.json' with { type: 'json' }
+import audit from './audit.json' with { type: 'json' }
 import auth from './auth.json' with { type: 'json' }
 import changes from './changes.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
@@ -36,6 +37,7 @@ import tasks from './tasks.json' with { type: 'json' }
 export default {
   admin,
   assets,
+  audit,
   auth,
   changes,
   common,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -15,6 +15,7 @@ import admin from './admin.json' with { type: 'json' }
 import assets from './assets.json' with { type: 'json' }
 import auth from './auth.json' with { type: 'json' }
 import common from './common.json' with { type: 'json' }
+import correctiveActions from './corrective_actions.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
 import components from './components.json' with { type: 'json' }
 import incidents from './incidents.json' with { type: 'json' }
@@ -34,6 +35,7 @@ export default {
   assets,
   auth,
   common,
+  corrective_actions: correctiveActions,
   components,
   dashboard,
   incidents,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -30,6 +30,7 @@ import settings from './settings.json' with { type: 'json' }
 import shell from './shell.json' with { type: 'json' }
 import suppliers from './suppliers.json' with { type: 'json' }
 import systems from './systems.json' with { type: 'json' }
+import tasks from './tasks.json' with { type: 'json' }
 
 export default {
   admin,
@@ -51,4 +52,5 @@ export default {
   shell,
   suppliers,
   systems,
+  tasks,
 }

--- a/web/src/locales/en/objectives.json
+++ b/web/src/locales/en/objectives.json
@@ -1,0 +1,98 @@
+{
+  "title": "Objectives",
+  "subtitle": "Track measurable ISMS objectives and KPI performance",
+  "error": {
+    "save": "Failed to save: {message}",
+    "download": "Download failed: unexpected response from server"
+  },
+  "action": {
+    "add": "Add Objective"
+  },
+  "filter": {
+    "all_programs": "All programs",
+    "owner_placeholder": "Owner...",
+    "empty": "No objectives found"
+  },
+  "create": {
+    "heading": "Add Objective",
+    "program_label": "Program *",
+    "program_placeholder": "Select program...",
+    "owner_label": "Owner",
+    "title_label": "Title *",
+    "title_placeholder": "Monthly phishing test completion rate",
+    "fill_in_later": "You can add target value, source, measurement method, description and notes after creating.",
+    "submit": "Add"
+  },
+  "table": {
+    "header": {
+      "id": "ID",
+      "title": "Title",
+      "target": "Target",
+      "status": "Status",
+      "owner": "Owner"
+    }
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "owner": "Owner",
+    "source": "Source",
+    "status": "Status",
+    "measurement_method": "Measurement method",
+    "measurement": "Measurement",
+    "operator": "Operator",
+    "target_value": "Target value",
+    "target": "Target",
+    "unit": "Unit",
+    "checkin_cycle_months": "Check-in cycle (months)",
+    "checkin_cycle": "Check-in cycle",
+    "last_checkin": "Last check-in",
+    "created": "Created",
+    "created_by": "Created by",
+    "months": "{count} month | {count} months"
+  },
+  "placeholder": {
+    "description": "What is this objective?",
+    "owner": "Select owner...",
+    "source": "ISO 27001 6.2, etc.",
+    "measurement_method": "How is this measured?",
+    "unit": "%, count, hours...",
+    "notes": "Add notes..."
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes"
+  },
+  "checkin": {
+    "heading": "Check-ins",
+    "summary": "{pass} pass · {fail} fail · {total} total",
+    "record_heading": "Record check-in",
+    "value_label": "Value",
+    "value_placeholder": "97.5",
+    "result_label": "Result",
+    "result": {
+      "unspecified": "Unspecified",
+      "pass": "Pass",
+      "fail": "Fail"
+    },
+    "message_label": "Internal note",
+    "message_placeholder": "Internal context...",
+    "public_note_placeholder": "Public-facing note (visible to stakeholders)",
+    "submit": "Record",
+    "empty": "No check-ins recorded yet",
+    "pass_badge": "PASS",
+    "fail_badge": "FAIL",
+    "public": "Public: {note}",
+    "confirm_delete": "Delete this checkin?"
+  },
+  "evidence": {
+    "download": "Download",
+    "attach": "Attach evidence",
+    "confirm_delete": "Delete evidence \"{title}\"?"
+  },
+  "danger": {
+    "warning": "Deleting this objective is permanent and cannot be undone.",
+    "delete": "Delete objective",
+    "confirm": "Delete objective \"{title}\"? This cannot be undone."
+  }
+}

--- a/web/src/locales/en/programs.json
+++ b/web/src/locales/en/programs.json
@@ -1,0 +1,48 @@
+{
+  "title": "Program Register",
+  "subtitle": "Group ISMS objectives into programs of work",
+  "error": {
+    "save": "Failed to save: {message}"
+  },
+  "action": {
+    "add": "Add Program"
+  },
+  "create": {
+    "heading": "Add Program",
+    "key_label": "Key (uppercase) *",
+    "key_placeholder": "AWARE",
+    "title_label": "Title *",
+    "title_placeholder": "Security Awareness",
+    "fill_in_later": "You can add description and notes after creating.",
+    "submit": "Add"
+  },
+  "filter": {
+    "empty": "No programs yet"
+  },
+  "table": {
+    "header": {
+      "key": "Key",
+      "title": "Title",
+      "description": "Description"
+    }
+  },
+  "field": {
+    "key": "Key",
+    "title": "Title",
+    "description": "Description",
+    "created": "Created"
+  },
+  "placeholder": {
+    "description": "What is this program?",
+    "notes": "Add notes..."
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes"
+  },
+  "danger": {
+    "warning": "Deleting this program also deletes all objectives under it. This cannot be undone.",
+    "delete": "Delete program",
+    "confirm": "Delete program \"{key}\"? All objectives under it will also be deleted."
+  }
+}

--- a/web/src/locales/en/tasks.json
+++ b/web/src/locales/en/tasks.json
@@ -1,0 +1,69 @@
+{
+  "title": "Tasks",
+  "subtitle": "Review tasks, follow-ups, and operational work items.",
+  "error": {
+    "create": "Failed to create task: {message}",
+    "save": "Failed to save: {message}",
+    "delete": "Failed to delete task: {message}"
+  },
+  "action": {
+    "add": "Add Task"
+  },
+  "create": {
+    "heading": "Add Task",
+    "title_label": "Title",
+    "title_placeholder": "e.g. Review risk register",
+    "priority_label": "Priority",
+    "type_label": "Type",
+    "visibility_label": "Visibility",
+    "fill_in_later": "You can add description, assignee, due date and notes after creating.",
+    "submitting": "Creating...",
+    "submit": "Add"
+  },
+  "visibility": {
+    "public": "Public — everyone in the org",
+    "private": "Private — assignee, creator & managers",
+    "private_badge": "Private",
+    "private_title": "Private — visible to assignee, creator & managers"
+  },
+  "filter": {
+    "assignee_placeholder": "Any assignee",
+    "empty": "No tasks match your filter.",
+    "empty_all": "No tasks yet — click Add to create your first one.",
+    "empty_hint": "Tasks are also generated automatically from overdue review cycles."
+  },
+  "list": {
+    "due": "Due {date}",
+    "created_by": "by {name}"
+  },
+  "field": {
+    "title": "Title",
+    "description": "Description",
+    "assignee": "Assignee",
+    "priority": "Priority",
+    "status": "Status",
+    "due_date": "Due date",
+    "type": "Type",
+    "created": "Created",
+    "created_by": "Created by",
+    "completed": "Completed"
+  },
+  "placeholder": {
+    "description": "Describe the task...",
+    "assignee": "Select assignee...",
+    "notes": "Add notes..."
+  },
+  "detail": {
+    "overview": "Overview",
+    "notes": "Notes",
+    "progress": "Progress"
+  },
+  "stat": {
+    "active": "Active"
+  },
+  "danger": {
+    "warning": "Deleting this task is permanent and cannot be undone.",
+    "delete": "Delete task",
+    "confirm": "Delete task \"{title}\"?"
+  }
+}

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -9,7 +9,7 @@
     <!-- Error -->
     <div v-else-if="error" class="max-w-5xl mx-auto px-8 py-12">
       <div class="bg-red-950/40 border border-red-900/50 rounded-lg p-6 text-red-300 text-sm flex items-center justify-between gap-4">
-        <span>Failed to load audit module. {{ error }}</span>
+        <span>{{ t('audit.error.load', { message: error }) }}</span>
         <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
     </div>
@@ -19,38 +19,38 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Internal Audit</h1>
-          <p class="text-sm text-slate-500 mt-1">Audit programmes, schedule, and findings</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('audit.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('audit.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <RefreshButton :loading="refreshing" @refresh="reload" />
           <button v-if="canWrite && activeTab === 'programmes'"
             @click="openCreateProgramme"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Programme
+            {{ t('audit.action.add_programme') }}
           </button>
           <button v-if="canWrite && activeTab === 'findings'"
             @click="openCreateFinding(null)"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Finding
+            {{ t('audit.action.add_finding') }}
           </button>
           <button v-if="canWrite && activeTab === 'calendar'"
             @click="openCreateAudit(null)"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Audit
+            {{ t('audit.action.add_audit') }}
           </button>
-          <SuggestNewButton entityType="audit_finding" typeLabel="Audit Finding" />
+          <SuggestNewButton entityType="audit_finding" :typeLabel="entityLabel('audit_finding')" />
         </div>
       </div>
 
       <!-- Top-level tabs -->
       <div class="flex items-center border-b border-slate-800">
         <div class="flex gap-1 flex-1">
-          <button v-for="t in topTabs" :key="t.key"
-            @click="switchTab(t.key)"
+          <button v-for="tab in topTabs" :key="tab.key"
+            @click="switchTab(tab.key)"
             class="flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px"
-            :class="activeTab === t.key ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'">
-            {{ t.label }}
+            :class="activeTab === tab.key ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'">
+            {{ tab.label }}
           </button>
         </div>
       </div>
@@ -74,15 +74,15 @@
 
         <!-- Type legend -->
         <div class="flex items-center gap-4 flex-wrap">
-          <div v-for="t in auditTypeKeys" :key="t" class="flex items-center gap-1.5 text-xs text-slate-400">
-            <span class="w-2.5 h-2.5 rounded-full" :class="auditTypeDot(t)"></span>
-            <span class="capitalize">{{ t }}</span>
+          <div v-for="type in auditTypeOptions" :key="type.value" class="flex items-center gap-1.5 text-xs text-slate-400">
+            <span class="w-2.5 h-2.5 rounded-full" :class="auditTypeDot(type.value)"></span>
+            <span>{{ type.label }}</span>
           </div>
         </div>
 
         <!-- Loading -->
         <div v-if="calendarLoading" class="flex items-center justify-center h-48">
-          <div class="text-slate-400 text-sm">Loading calendar...</div>
+          <div class="text-slate-400 text-sm">{{ t('audit.calendar.loading') }}</div>
         </div>
 
         <!-- Month sections -->
@@ -90,12 +90,12 @@
           <div v-for="month in calendarMonths" :key="month.month"
             class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
             <div class="px-5 py-3 border-b border-slate-800 flex items-center justify-between">
-              <h3 class="text-sm font-semibold text-slate-300">{{ month.name }}</h3>
+              <h3 class="text-sm font-semibold text-slate-300">{{ monthName(month) }}</h3>
               <span class="text-[11px] text-slate-500">
-                {{ month.audits.length }} audit{{ month.audits.length === 1 ? '' : 's' }}
+                {{ t('audit.calendar.audit_count', { count: month.audits.length }, month.audits.length) }}
               </span>
             </div>
-            <div v-if="month.audits.length === 0" class="px-5 py-3 text-xs text-slate-600 italic">No audits planned this month</div>
+            <div v-if="month.audits.length === 0" class="px-5 py-3 text-xs text-slate-600 italic">{{ t('audit.calendar.month_empty') }}</div>
             <div v-else class="divide-y divide-slate-800/50">
               <div v-for="audit in month.audits" :key="audit.id"
                 @click="selectAuditFromCalendar(audit)"
@@ -104,9 +104,9 @@
                 <div class="flex-1 min-w-0">
                   <div class="text-sm font-medium text-slate-200 truncate">{{ audit.title }}</div>
                   <div class="text-[11px] text-slate-500 truncate">
-                    {{ programmeTitle(audit.programme_id) }} ·
-                    {{ resolveUserName(audit.auditor) }} ·
-                    <span class="capitalize">{{ audit.audit_type }}</span>
+                    {{ programmeTitle(audit.programme_id) }} {{ dot }}
+                    {{ resolveUserName(audit.auditor) }} {{ dot }}
+                    <span>{{ auditTypeLabel(audit.audit_type) }}</span>
                   </div>
                 </div>
                 <span class="text-xs text-slate-500 tabular-nums whitespace-nowrap flex-shrink-0">
@@ -120,9 +120,9 @@
           <!-- Unscheduled bucket -->
           <div v-if="calendarUnscheduled.length > 0" class="bg-slate-900 border border-amber-900/40 rounded-xl overflow-hidden">
             <div class="px-5 py-3 border-b border-amber-900/40 flex items-center justify-between">
-              <h3 class="text-sm font-semibold text-amber-400">Unscheduled</h3>
+              <h3 class="text-sm font-semibold text-amber-400">{{ t('audit.calendar.unscheduled') }}</h3>
               <span class="text-[11px] text-slate-500">
-                {{ calendarUnscheduled.length }} audit{{ calendarUnscheduled.length === 1 ? '' : 's' }} without planned date
+                {{ t('audit.calendar.unscheduled_count', { count: calendarUnscheduled.length }, calendarUnscheduled.length) }}
               </span>
             </div>
             <div class="divide-y divide-slate-800/50">
@@ -133,7 +133,7 @@
                 <div class="flex-1 min-w-0">
                   <div class="text-sm font-medium text-slate-200 truncate">{{ audit.title }}</div>
                   <div class="text-[11px] text-slate-500 truncate">
-                    {{ programmeTitle(audit.programme_id) }} · {{ resolveUserName(audit.auditor) }}
+                    {{ programmeTitle(audit.programme_id) }} {{ dot }} {{ resolveUserName(audit.auditor) }}
                   </div>
                 </div>
                 <StatusBadge :status="audit.status" />
@@ -143,7 +143,7 @@
 
           <div v-if="calendarMonths.every(m => m.audits.length === 0) && calendarUnscheduled.length === 0"
             class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center text-sm text-slate-500">
-            No audits in {{ calendarYear }}. Add an audit from a programme to see it here.
+            {{ t('audit.calendar.empty', { year: calendarYear }) }}
           </div>
         </div>
       </template>
@@ -159,49 +159,47 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="programmeSearch" type="text" placeholder="Search programmes..."
+            <input v-model="programmeSearch" type="text" :placeholder="t('audit.programme.search_placeholder')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model.number="programmeYearFilter" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option :value="0">All years</option>
+            <option :value="0">{{ t('audit.programme.all_years') }}</option>
             <option v-for="y in programmeYears" :key="y" :value="y">{{ y }}</option>
           </select>
           <select v-model="programmeStatusFilter" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="draft">Draft</option>
-            <option value="active">Active</option>
-            <option value="closed">Closed</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in programmeStatusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <button v-if="programmeSearch || programmeYearFilter || programmeStatusFilter"
             @click="programmeSearch = ''; programmeYearFilter = 0; programmeStatusFilter = ''"
             class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-            Clear
+            {{ t('common.action.clear') }}
           </button>
-          <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ filteredProgrammes.length }} of {{ programmes.length }}</div>
+          <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.of', { shown: filteredProgrammes.length, total: programmes.length }) }}</div>
         </div>
 
         <!-- List -->
         <div v-if="filteredProgrammes.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-          <div v-if="programmeSearch || programmeYearFilter || programmeStatusFilter" class="text-sm text-slate-500">No programmes match your filter.</div>
-          <div v-else class="text-sm text-slate-500">No audit programmes yet — click Add Programme to create one.</div>
+          <div v-if="programmeSearch || programmeYearFilter || programmeStatusFilter" class="text-sm text-slate-500">{{ t('audit.programme.empty_filtered') }}</div>
+          <div v-else class="text-sm text-slate-500">{{ t('audit.programme.empty') }}</div>
         </div>
         <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
           <table class="w-full">
             <thead>
               <tr class="border-b border-slate-800">
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">ID</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Year</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Audits</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Findings</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.programme.table.id') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.programme.table.title') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.programme.table.year') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.programme.table.audits') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.programme.table.findings') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.programme.table.status') }}</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-slate-800/50">
               <tr v-for="prog in filteredProgrammes" :key="prog.id"
                 @click="selectProgramme(prog)"
                 class="hover:bg-slate-800/50 transition-colors cursor-pointer">
-                <td class="px-5 py-3.5 text-[10px] font-mono uppercase tracking-wider text-slate-600">PROG-{{ prog.id }}</td>
+                <td class="px-5 py-3.5 text-[10px] font-mono uppercase tracking-wider text-slate-600">{{ progRef(prog.id) }}</td>
                 <td class="px-5 py-3.5">
                   <div class="text-sm font-medium text-slate-200">{{ prog.title }}</div>
                   <div v-if="prog.description" class="text-xs text-slate-500 mt-0.5 truncate max-w-md">{{ stripMd(prog.description) }}</div>
@@ -228,9 +226,9 @@
             :class="findingOverdueOnly
               ? 'border-amber-500/50 bg-amber-500/10 text-amber-200'
               : 'border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-700 hover:text-slate-300'"
-            title="Toggle: Overdue only">
+            :title="t('audit.findings.overdue_toggle_title')">
             <span class="font-bold tabular-nums" :class="findingOverdueOnly ? '' : (overdueFindingsTotal > 0 ? 'text-amber-400' : 'text-slate-100')">{{ overdueFindingsTotal }}</span>
-            <span>Overdue</span>
+            <span>{{ t('audit.findings.overdue') }}</span>
           </button>
         </div>
 
@@ -240,58 +238,54 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="findingSearch" type="text" placeholder="Search findings..."
+            <input v-model="findingSearch" type="text" :placeholder="t('audit.findings.search_placeholder')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="findingStatusFilter" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="open">Open</option>
-            <option value="closed">Closed</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in findingStatusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <select v-model="findingTypeFilter" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All types</option>
-            <option value="major_nc">Major NC</option>
-            <option value="minor_nc">Minor NC</option>
-            <option value="observation">Observation</option>
-            <option value="opportunity">OFI</option>
+            <option value="">{{ t('common.filter.all_types') }}</option>
+            <option v-for="o in findingTypeAbbrOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
           <select v-model.number="findingAuditFilter" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option :value="0">All audits</option>
+            <option :value="0">{{ t('audit.findings.all_audits') }}</option>
             <option v-for="a in audits" :key="a.id" :value="a.id">{{ a.title }}</option>
           </select>
           <select v-model="findingOwnerFilter" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All owners</option>
+            <option value="">{{ t('common.filter.all_owners') }}</option>
             <option v-for="m in orgMembers" :key="m.email" :value="m.email">{{ m.name || m.email }}</option>
           </select>
           <label class="flex items-center gap-1.5 text-xs text-slate-400">
             <input type="checkbox" v-model="findingOverdueOnly" class="rounded bg-slate-800 border-slate-700" />
-            Overdue only
+            {{ t('audit.findings.overdue_only') }}
           </label>
-          <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ findingTotal }} total</div>
+          <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: findingTotal }) }}</div>
         </div>
 
         <!-- Table -->
         <div v-if="findings.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-          <div class="text-sm text-slate-500">{{ findingsHasFilter ? 'No findings match your filter.' : 'No findings recorded yet.' }}</div>
+          <div class="text-sm text-slate-500">{{ findingsHasFilter ? t('audit.findings.empty_filtered') : t('audit.findings.empty') }}</div>
         </div>
         <div v-else class="bg-slate-900 border border-slate-800 rounded-xl overflow-x-auto">
           <table class="w-full">
             <thead>
               <tr class="border-b border-slate-800">
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">ID</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Audit</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Type</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Due</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.id') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.title') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.audit') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.type') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.owner') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.due') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('audit.findings.table.status') }}</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-slate-800/50">
               <tr v-for="f in findings" :key="f.id"
                 @click="selectFinding(f)"
                 class="hover:bg-slate-800/50 transition-colors cursor-pointer">
-                <td class="px-5 py-3.5 text-[10px] font-mono uppercase tracking-wider text-slate-600">FIND-{{ f.id }}</td>
+                <td class="px-5 py-3.5 text-[10px] font-mono uppercase tracking-wider text-slate-600">{{ findingRef(f.id) }}</td>
                 <td class="px-5 py-3.5">
                   <div class="text-sm font-medium text-slate-200">{{ f.title }}</div>
                   <div v-if="f.description" class="text-xs text-slate-500 mt-0.5 truncate max-w-md">{{ stripMd(f.description) }}</div>
@@ -322,27 +316,27 @@
       <div class="absolute inset-0 bg-black/60" @click="showCreateProgramme = false" />
       <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Programme</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('audit.programme.create.heading') }}</h2>
           <button @click="showCreateProgramme = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>
         <div class="space-y-3">
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newProg.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="e.g. 2026 Annual Audit Programme" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.create.title_label') }}</label>
+            <input v-model="newProg.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('audit.programme.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Year *</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.create.year_label') }}</label>
             <input v-model.number="newProg.year" type="number" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="2026" />
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, status and audits after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('audit.programme.create.fill_in_later') }}</div>
         <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-          <button @click="showCreateProgramme = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateProgramme = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createProgramme" :disabled="!newProg.title.trim() || !newProg.year || progSaving"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            {{ progSaving ? 'Adding...' : 'Add' }}
+            {{ progSaving ? t('audit.programme.create.submitting') : t('audit.programme.create.submit') }}
           </button>
         </div>
       </div>
@@ -357,36 +351,36 @@
       <div class="absolute inset-0 bg-black/60" @click="showCreateAudit = false" />
       <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Audit</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('audit.audit.create.heading') }}</h2>
           <button @click="showCreateAudit = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div class="sm:col-span-2">
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newAudit.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Audit title" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.create.title_label') }}</label>
+            <input v-model="newAudit.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('audit.audit.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Programme</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.create.programme_label') }}</label>
             <select v-model.number="newAudit.programme_id" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option :value="0">No programme (ad-hoc)</option>
+              <option :value="0">{{ t('audit.audit.create.no_programme') }}</option>
               <option v-for="p in programmes" :key="p.id" :value="p.id">{{ p.title }} ({{ p.year }})</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Audit Type</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.create.type_label') }}</label>
             <select v-model="newAudit.audit_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option v-for="t in auditTypeKeys" :key="t" :value="t" class="capitalize">{{ t }}</option>
+              <option v-for="o in auditTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add scope, auditor, dates and items after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('audit.audit.create.fill_in_later') }}</div>
         <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-          <button @click="showCreateAudit = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateAudit = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createAudit" :disabled="!newAudit.title.trim() || auditCreating"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            {{ auditCreating ? 'Adding...' : 'Add' }}
+            {{ auditCreating ? t('audit.audit.create.submitting') : t('audit.audit.create.submit') }}
           </button>
         </div>
       </div>
@@ -401,39 +395,36 @@
       <div class="absolute inset-0 bg-black/60" @click="showCreateFinding = false" />
       <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Finding</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('audit.findings.create.heading') }}</h2>
           <button @click="showCreateFinding = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div class="sm:col-span-2">
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newFinding.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Finding title" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.create.title_label') }}</label>
+            <input v-model="newFinding.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('audit.findings.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Audit *</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.create.audit_label') }}</label>
             <select v-model.number="newFinding.audit_id" :disabled="newFindingAuditLocked" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50">
-              <option :value="0">Select audit...</option>
+              <option :value="0">{{ t('audit.findings.create.audit_placeholder') }}</option>
               <option v-for="a in audits" :key="a.id" :value="a.id">{{ a.title }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.create.type_label') }}</label>
             <select v-model="newFinding.finding_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option value="major_nc">Major Non-conformity</option>
-              <option value="minor_nc">Minor Non-conformity</option>
-              <option value="observation">Observation</option>
-              <option value="opportunity">Opportunity for Improvement</option>
+              <option v-for="o in findingTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, owner, due date and corrective action links after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('audit.findings.create.fill_in_later') }}</div>
         <div class="flex justify-end gap-3 pt-3 border-t border-slate-800">
-          <button @click="showCreateFinding = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateFinding = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createFinding" :disabled="!newFinding.title.trim() || !newFinding.audit_id || findingCreating"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            {{ findingCreating ? 'Adding...' : 'Add' }}
+            {{ findingCreating ? t('audit.findings.create.submitting') : t('audit.findings.create.submit') }}
           </button>
         </div>
       </div>
@@ -450,7 +441,7 @@
         <!-- Header -->
         <div class="flex-shrink-0 border-b border-slate-800 px-6 py-3 flex items-center justify-between gap-4">
           <div class="flex items-center gap-6 min-w-0">
-            <span class="text-[10px] font-mono uppercase tracking-wider text-slate-600 flex-shrink-0">PROG-{{ selectedProgramme.id }}</span>
+            <span class="text-[10px] font-mono uppercase tracking-wider text-slate-600 flex-shrink-0">{{ progRef(selectedProgramme.id) }}</span>
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedProgramme.title }}</h2>
             <span class="text-xs text-slate-500 flex-shrink-0 tabular-nums">{{ selectedProgramme.year }}</span>
           </div>
@@ -465,11 +456,11 @@
         <div class="flex flex-1 min-h-0">
           <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
             <div class="space-y-0.5">
-              <button v-for="t in programmeDetailTabs" :key="t.key" @click="switchProgrammeTab(t.key)"
+              <button v-for="tab in programmeDetailTabs" :key="tab.key" @click="switchProgrammeTab(tab.key)"
                 class="w-full text-left px-3 py-2 text-xs font-medium transition-colors flex items-center justify-between"
-                :class="programmeTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                <span>{{ t.label }}</span>
-                <span v-if="t.count !== undefined" class="text-[10px] text-slate-600">{{ t.count }}</span>
+                :class="programmeTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                <span>{{ tab.label }}</span>
+                <span v-if="tab.count !== undefined" class="text-[10px] text-slate-600">{{ tab.count }}</span>
               </button>
             </div>
           </nav>
@@ -478,68 +469,66 @@
             <template v-if="programmeTab === 'overview'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                  <button v-if="canWrite && !progEditing" @click="startProgEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.detail.overview') }}</div>
+                  <button v-if="canWrite && !progEditing" @click="startProgEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                 </div>
                 <template v-if="progEditing">
                   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.field.title') }}</label>
                       <input v-model="progEditForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Year</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.field.year') }}</label>
                       <input v-model.number="progEditForm.year" type="number" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.field.status') }}</label>
                       <select v-model="progEditForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="draft">Draft</option>
-                        <option value="active">Active</option>
-                        <option value="closed">Closed</option>
+                        <option v-for="o in programmeStatusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                       </select>
                     </div>
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                      <MarkdownField v-model="progEditForm.description" :self-type="'audit_programme'" :self-id="String(selectedProgramme.id)" :rows="3" placeholder="Programme objectives and scope..." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.field.description') }}</label>
+                      <MarkdownField v-model="progEditForm.description" :self-type="'audit_programme'" :self-id="String(selectedProgramme.id)" :rows="3" :placeholder="t('audit.programme.placeholder.description')" />
                     </div>
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Notes</label>
-                      <MarkdownField v-model="progEditForm.notes" :self-type="'audit_programme'" :self-id="String(selectedProgramme.id)" :rows="3" placeholder="Internal notes..." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.programme.field.notes') }}</label>
+                      <MarkdownField v-model="progEditForm.notes" :self-type="'audit_programme'" :self-id="String(selectedProgramme.id)" :rows="3" :placeholder="t('audit.programme.placeholder.notes')" />
                     </div>
                   </div>
                 </template>
                 <template v-else>
                   <div class="space-y-4">
                     <div>
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('audit.programme.field.description') }}</div>
                       <div v-if="selectedProgramme.description" class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedProgramme.description)"></div>
                       <div v-else class="text-sm text-slate-600">—</div>
                     </div>
                     <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Year</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.programme.field.year') }}</div>
                         <div class="text-sm text-slate-300 tabular-nums">{{ selectedProgramme.year }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.programme.field.status') }}</div>
                         <StatusBadge :status="selectedProgramme.status" />
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Audits</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.programme.field.audits') }}</div>
                         <div class="text-sm text-slate-300 tabular-nums">{{ selectedProgramme.audit_count || 0 }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.programme.field.created_by') }}</div>
                         <div class="text-sm text-slate-300">{{ resolveUserName(selectedProgramme.created_by) }}</div>
                       </div>
                       <div v-if="selectedProgramme.created_at">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.programme.field.created') }}</div>
                         <div class="text-sm text-slate-300">{{ formatDate(selectedProgramme.created_at) }}</div>
                       </div>
                     </div>
                     <div v-if="selectedProgramme.notes" class="border-t border-slate-800 pt-4">
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Notes</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('audit.programme.field.notes') }}</div>
                       <div class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedProgramme.notes)"></div>
                     </div>
                   </div>
@@ -551,10 +540,10 @@
             <template v-if="programmeTab === 'audits'">
               <div class="px-6 py-5 space-y-3">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Audits in this programme</div>
-                  <button v-if="canWrite" @click="openCreateAudit(selectedProgramme.id)" class="text-xs text-blue-400 hover:text-blue-300">+ Add Audit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.programme.audits_heading') }}</div>
+                  <button v-if="canWrite" @click="openCreateAudit(selectedProgramme.id)" class="text-xs text-blue-400 hover:text-blue-300">{{ t('audit.programme.add_audit') }}</button>
                 </div>
-                <div v-if="programmeAudits(selectedProgramme.id).length === 0" class="text-xs text-slate-600 italic">No audits in this programme yet.</div>
+                <div v-if="programmeAudits(selectedProgramme.id).length === 0" class="text-xs text-slate-600 italic">{{ t('audit.programme.audits_empty') }}</div>
                 <div v-else class="space-y-2">
                   <div v-for="a in programmeAudits(selectedProgramme.id)" :key="a.id"
                     @click="selectAuditFromProgramme(a)"
@@ -563,12 +552,12 @@
                     <div class="flex-1 min-w-0">
                       <div class="text-sm font-medium text-slate-200 truncate">{{ a.title }}</div>
                       <div class="text-[11px] text-slate-500 truncate">
-                        <span class="capitalize">{{ a.audit_type }}</span> ·
-                        {{ resolveUserName(a.auditor) || '—' }} ·
-                        {{ formatDateRange(a.planned_date, a.end_date) || 'unscheduled' }}
+                        <span>{{ auditTypeLabel(a.audit_type) }}</span> {{ dot }}
+                        {{ resolveUserName(a.auditor) || '—' }} {{ dot }}
+                        {{ formatDateRange(a.planned_date, a.end_date) || t('audit.calendar.unscheduled_range') }}
                       </div>
                     </div>
-                    <span v-if="a.open_findings > 0" class="text-[10px] px-1.5 py-0.5 rounded bg-red-900/40 text-red-400 font-medium">{{ a.open_findings }} open</span>
+                    <span v-if="a.open_findings > 0" class="text-[10px] px-1.5 py-0.5 rounded bg-red-900/40 text-red-400 font-medium">{{ t('audit.programme.open_findings', { count: a.open_findings }) }}</span>
                     <StatusBadge :status="a.status" />
                   </div>
                 </div>
@@ -587,11 +576,11 @@
               <div class="px-6 py-5 space-y-6">
                 <HistoryPanel entityType="audit_programme" :entityId="String(selectedProgramme.id)" />
                 <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                  <div class="text-xs text-slate-400">Programmes with audits cannot be deleted. Remove all audits first.</div>
+                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                  <div class="text-xs text-slate-400">{{ t('audit.programme.danger.warning') }}</div>
                   <button @click="deleteSelectedProgramme" :disabled="(selectedProgramme.audit_count || 0) > 0"
                     class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 disabled:bg-slate-800 disabled:text-slate-600 disabled:cursor-not-allowed text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                    Delete programme
+                    {{ t('audit.programme.danger.delete') }}
                   </button>
                 </div>
               </div>
@@ -600,9 +589,9 @@
         </div>
         <!-- Footer (edit) -->
         <div v-if="progEditing" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-          <button @click="cancelProgEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="cancelProgEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="saveProgEdit" :disabled="progSaving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ progSaving ? 'Saving...' : 'Save' }}
+            {{ progSaving ? t('common.state.saving') : t('common.action.save') }}
           </button>
         </div>
       </div>
@@ -619,9 +608,9 @@
         <!-- Header -->
         <div class="flex-shrink-0 border-b border-slate-800 px-6 py-3 flex items-center justify-between gap-4">
           <div class="flex items-center gap-3 min-w-0">
-            <span class="text-[10px] font-mono uppercase tracking-wider text-slate-600 flex-shrink-0">AUDIT-{{ selectedAudit.id }}</span>
+            <span class="text-[10px] font-mono uppercase tracking-wider text-slate-600 flex-shrink-0">{{ auditRef(selectedAudit.id) }}</span>
             <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold rounded uppercase tracking-wider whitespace-nowrap"
-              :class="auditTypeBadge(selectedAudit.audit_type)">{{ selectedAudit.audit_type }}</span>
+              :class="auditTypeBadge(selectedAudit.audit_type)">{{ auditTypeLabel(selectedAudit.audit_type) }}</span>
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedAudit.title }}</h2>
           </div>
           <div class="flex items-center gap-2 flex-shrink-0">
@@ -636,122 +625,120 @@
         <div class="flex flex-1 min-h-0">
           <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
             <div class="space-y-0.5">
-              <button v-for="t in auditDetailTabs" :key="t.key" @click="switchAuditTab(t.key)"
+              <button v-for="tab in auditDetailTabs" :key="tab.key" @click="switchAuditTab(tab.key)"
                 class="w-full text-left px-3 py-2 text-xs font-medium transition-colors flex items-center justify-between"
-                :class="auditTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                <span>{{ t.label }}</span>
-                <span v-if="t.count !== undefined" class="text-[10px] text-slate-600">{{ t.count }}</span>
+                :class="auditTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                <span>{{ tab.label }}</span>
+                <span v-if="tab.count !== undefined" class="text-[10px] text-slate-600">{{ tab.count }}</span>
               </button>
             </div>
           </nav>
           <div class="flex-1 overflow-y-auto min-h-0">
-            <div v-if="auditDetailLoading" class="px-6 py-10 text-center text-xs text-slate-500">Loading audit details...</div>
+            <div v-if="auditDetailLoading" class="px-6 py-10 text-center text-xs text-slate-500">{{ t('audit.audit.loading_detail') }}</div>
             <template v-else>
 
               <!-- Overview -->
               <template v-if="auditTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !auditEditing" @click="startAuditEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.detail.overview') }}</div>
+                    <button v-if="canWrite && !auditEditing" @click="startAuditEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="auditEditing">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.title') }}</label>
                         <input v-model="auditEditForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Scope</label>
-                        <MarkdownField v-model="auditEditForm.scope" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="3" placeholder="Scope description. Type /doc to link controls or clauses..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.scope') }}</label>
+                        <MarkdownField v-model="auditEditForm.scope" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="3" :placeholder="t('audit.audit.placeholder.scope')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Audit Type</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.type') }}</label>
                         <select v-model="auditEditForm.audit_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="t in auditTypeKeys" :key="t" :value="t" class="capitalize">{{ t }}</option>
+                          <option v-for="o in auditTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.status') }}</label>
                         <select v-model="auditEditForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="planned">Planned</option>
-                          <option value="in_progress">In Progress</option>
-                          <option value="completed">Completed</option>
+                          <option v-for="o in auditStatusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Auditor</label>
-                        <MemberPicker v-model="auditEditForm.auditor" :members="orgMembers" placeholder="Select auditor..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.auditor') }}</label>
+                        <MemberPicker v-model="auditEditForm.auditor" :members="orgMembers" :placeholder="t('audit.audit.placeholder.auditor')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Programme</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.programme') }}</label>
                         <select v-model.number="auditEditForm.programme_id" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option :value="0">No programme (ad-hoc)</option>
+                          <option :value="0">{{ t('audit.audit.create.no_programme') }}</option>
                           <option v-for="p in programmes" :key="p.id" :value="p.id">{{ p.title }} ({{ p.year }})</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Planned Date</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.planned_date') }}</label>
                         <input v-model="auditEditForm.planned_date" type="date" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">End Date</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.end_date') }}</label>
                         <input v-model="auditEditForm.end_date" type="date" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Notes</label>
-                        <MarkdownField v-model="auditEditForm.notes" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="3" placeholder="Internal audit notes..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.audit.field.notes') }}</label>
+                        <MarkdownField v-model="auditEditForm.notes" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="3" :placeholder="t('audit.audit.placeholder.notes')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Scope</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('audit.audit.field.scope') }}</div>
                         <div v-if="selectedAudit.scope" class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedAudit.scope)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Programme</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.programme') }}</div>
                           <div class="text-sm">
                             <button v-if="selectedAudit.programme_id" @click="goToProgrammeFromAudit(selectedAudit.programme_id)" class="text-blue-400 hover:text-blue-300">{{ programmeTitle(selectedAudit.programme_id) }}</button>
                             <span v-else class="text-slate-600">—</span>
                           </div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Auditor</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.auditor') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedAudit.auditor) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Planned</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.planned') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDateRange(selectedAudit.planned_date, selectedAudit.end_date) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Audit Type</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ selectedAudit.audit_type }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.type') }}</div>
+                          <div class="text-sm text-slate-300">{{ auditTypeLabel(selectedAudit.audit_type) }}</div>
                         </div>
                         <div v-if="selectedAudit.started_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Started</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.started') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDateTime(selectedAudit.started_at) }}</div>
                         </div>
                         <div v-if="selectedAudit.completed_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Completed</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.completed') }}</div>
                           <div class="text-sm text-emerald-400">{{ formatDateTime(selectedAudit.completed_at) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Items</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.items') }}</div>
                           <div class="text-sm text-slate-300 tabular-nums">{{ selectedAudit.item_count || 0 }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Findings</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.audit.field.findings') }}</div>
                           <div class="text-sm tabular-nums" :class="(selectedAudit.open_findings || 0) > 0 ? 'text-red-400' : 'text-slate-300'">
-                            {{ selectedAudit.finding_count || 0 }}<span v-if="(selectedAudit.open_findings || 0) > 0" class="text-slate-500"> ({{ selectedAudit.open_findings }} open)</span>
+                            {{ selectedAudit.finding_count || 0 }}<span v-if="(selectedAudit.open_findings || 0) > 0" class="text-slate-500"> {{ t('audit.audit.open_count', { count: selectedAudit.open_findings }) }}</span>
                           </div>
                         </div>
                       </div>
                       <div v-if="selectedAudit.notes" class="border-t border-slate-800 pt-4">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Notes</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('audit.audit.field.notes') }}</div>
                         <div class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedAudit.notes)"></div>
                       </div>
                     </div>
@@ -763,9 +750,9 @@
               <template v-if="auditTab === 'items'">
                 <div class="px-6 py-5 space-y-3">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Audit Items ({{ auditItems.length }})</div>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.items.heading', { count: auditItems.length }) }}</div>
                     <button v-if="canWrite" @click="showItemPicker = !showItemPicker" class="text-xs text-blue-400 hover:text-blue-300">
-                      {{ showItemPicker ? 'Cancel' : '+ Add Item' }}
+                      {{ showItemPicker ? t('common.action.cancel') : t('audit.items.add') }}
                     </button>
                   </div>
 
@@ -773,7 +760,7 @@
                   <div v-if="showItemPicker" class="bg-slate-950 border border-slate-700 rounded-lg p-3 space-y-2">
                     <input v-model="itemSearchQuery" type="text" ref="itemSearchInput"
                       class="w-full bg-slate-800 border border-slate-700 rounded px-3 py-1.5 text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500"
-                      placeholder="Search documents, controls, clauses, risks, assets..."
+                      :placeholder="t('audit.items.search_placeholder')"
                       @input="doItemSearch"
                       @focus="doItemSearch"
                       @keydown.down.prevent="itemSelectedIdx = Math.min(itemSelectedIdx + 1, itemSearchResults.length - 1)"
@@ -781,7 +768,7 @@
                       @keydown.tab.prevent="itemSearchResults.length && pickAuditItem(itemSearchResults[itemSelectedIdx])"
                       @keydown.enter.prevent="itemSearchResults.length && pickAuditItem(itemSearchResults[itemSelectedIdx])"
                       @keydown.escape="showItemPicker = false" />
-                    <div v-if="itemSearching" class="text-[10px] text-slate-500 italic">Searching...</div>
+                    <div v-if="itemSearching" class="text-[10px] text-slate-500 italic">{{ t('audit.items.searching') }}</div>
                     <div v-else-if="itemSearchResults.length > 0" class="max-h-56 overflow-y-auto space-y-0.5 bg-slate-900 border border-slate-800 rounded">
                       <button v-for="(s, i) in itemSearchResults" :key="s.type + ':' + s.id"
                         @click="pickAuditItem(s)"
@@ -793,12 +780,12 @@
                         <span class="truncate">{{ s.title }}</span>
                       </button>
                     </div>
-                    <div v-else-if="itemSearched" class="text-[10px] text-slate-500 italic">No matches.</div>
+                    <div v-else-if="itemSearched" class="text-[10px] text-slate-500 italic">{{ t('audit.items.no_matches') }}</div>
                   </div>
 
                   <!-- Items list -->
                   <div v-if="auditItems.length === 0 && !showItemPicker" class="bg-slate-950 border border-slate-800 rounded-lg p-8 text-center text-xs text-slate-600 italic">
-                    No items yet — add controls, clauses, risks or other items to assess.
+                    {{ t('audit.items.empty') }}
                   </div>
                   <div v-else-if="auditItems.length > 0" class="space-y-2">
                     <div v-for="item in auditItems" :key="item.id"
@@ -813,23 +800,18 @@
                         <select v-if="canWrite" v-model="item.result" @change="saveItemField(item, 'result', item.result)"
                           class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
                           :class="resultSelectClass(item.result)">
-                          <option value="not_assessed">Not Assessed</option>
-                          <option value="conforming">Conforming</option>
-                          <option value="minor_nc">Minor NC</option>
-                          <option value="major_nc">Major NC</option>
-                          <option value="observation">Observation</option>
-                          <option value="opportunity">Opportunity</option>
+                          <option v-for="o in resultOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                         <span v-else class="text-xs"><StatusBadge :status="item.result || 'not_assessed'" group="audit_result" /></span>
                         <button v-if="canWrite && (item.result === 'minor_nc' || item.result === 'major_nc')"
                           @click="raiseFindingFromItem(item)"
                           class="text-[10px] text-amber-400 hover:text-amber-300 px-2 py-1 rounded border border-amber-800/50 bg-amber-900/20"
-                          title="Create a finding from this item">
-                          Raise finding
+                          :title="t('audit.items.raise_finding_title')">
+                          {{ t('audit.items.raise_finding') }}
                         </button>
                         <button v-if="canWrite" @click="deleteItem(item)"
                           class="text-slate-600 hover:text-red-400 p-1 transition-colors"
-                          title="Delete item">
+                          :title="t('audit.items.delete_title')">
                           <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
                           </svg>
@@ -838,9 +820,9 @@
 
                       <!-- Evidence -->
                       <div class="mt-2 flex items-center gap-2">
-                        <span class="text-[10px] text-slate-500 uppercase tracking-wider whitespace-nowrap">Evidence</span>
+                        <span class="text-[10px] text-slate-500 uppercase tracking-wider whitespace-nowrap">{{ t('audit.items.evidence') }}</span>
                         <input v-if="canWrite" v-model="item.evidence" @change="saveItemField(item, 'evidence', item.evidence)"
-                          type="text" placeholder="Evidence reference, link or description..."
+                          type="text" :placeholder="t('audit.items.evidence_placeholder')"
                           class="flex-1 bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                         <span v-else class="flex-1 text-xs text-slate-500">{{ item.evidence || '—' }}</span>
                       </div>
@@ -848,13 +830,13 @@
                       <!-- Notes (collapsible) -->
                       <div class="mt-1.5">
                         <button @click="toggleItemNotes(item.id)" class="text-[10px] text-slate-500 hover:text-slate-300 transition-colors">
-                          {{ expandedItemNotes.has(item.id) ? '▼' : '▶' }} Notes{{ item.notes ? '' : ' (empty)' }}
+                          {{ expandedItemNotes.has(item.id) ? '▼' : '▶' }} {{ item.notes ? t('audit.items.notes') : t('audit.items.notes_empty') }}
                         </button>
                         <div v-if="expandedItemNotes.has(item.id)" class="mt-2">
-                          <MarkdownField v-if="canWrite" v-model="item.notes" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="3" placeholder="Inline notes for this item..." />
+                          <MarkdownField v-if="canWrite" v-model="item.notes" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="3" :placeholder="t('audit.items.notes_placeholder')" />
                           <div v-else class="text-xs text-slate-400 doc-prose" v-mermaid v-html="renderMd(item.notes || '—')"></div>
                           <div v-if="canWrite" class="flex justify-end mt-1.5">
-                            <button @click="saveItemField(item, 'notes', item.notes)" class="text-[10px] text-blue-400 hover:text-blue-300">Save notes</button>
+                            <button @click="saveItemField(item, 'notes', item.notes)" class="text-[10px] text-blue-400 hover:text-blue-300">{{ t('audit.items.save_notes') }}</button>
                           </div>
                         </div>
                       </div>
@@ -867,10 +849,10 @@
               <template v-if="auditTab === 'findings'">
                 <div class="px-6 py-5 space-y-3">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Findings ({{ auditFindings.length }})</div>
-                    <button v-if="canWrite" @click="openCreateFinding(selectedAudit.id)" class="text-xs text-blue-400 hover:text-blue-300">+ Add Finding</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.findings.heading_count', { count: auditFindings.length }) }}</div>
+                    <button v-if="canWrite" @click="openCreateFinding(selectedAudit.id)" class="text-xs text-blue-400 hover:text-blue-300">{{ t('audit.findings.add') }}</button>
                   </div>
-                  <div v-if="auditFindings.length === 0" class="text-xs text-slate-600 italic">No findings recorded for this audit yet.</div>
+                  <div v-if="auditFindings.length === 0" class="text-xs text-slate-600 italic">{{ t('audit.findings.audit_empty') }}</div>
                   <div v-else class="space-y-2">
                     <div v-for="f in auditFindings" :key="f.id"
                       @click="selectFinding(f)"
@@ -880,8 +862,8 @@
                         <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold rounded uppercase tracking-wider whitespace-nowrap"
                           :class="findingTypeBadge(f.finding_type)">{{ findingTypeLabel(f.finding_type) }}</span>
                         <span class="text-sm font-medium text-slate-200 flex-1 truncate min-w-0">{{ f.title }}</span>
-                        <span v-if="f.audit_item_id" class="text-[10px] text-slate-500 font-mono">item #{{ f.audit_item_id }}</span>
-                        <span v-if="isOverdue(f.due_date) && f.status === 'open'" class="text-[10px] px-1.5 py-0.5 rounded bg-red-900/60 text-red-300 font-semibold tracking-wider uppercase">Overdue</span>
+                        <span v-if="f.audit_item_id" class="text-[10px] text-slate-500 font-mono">{{ t('audit.findings.item_ref', { id: f.audit_item_id }) }}</span>
+                        <span v-if="isOverdue(f.due_date) && f.status === 'open'" class="text-[10px] px-1.5 py-0.5 rounded bg-red-900/60 text-red-300 font-semibold tracking-wider uppercase">{{ t('audit.findings.overdue') }}</span>
                         <span v-if="f.due_date" class="text-xs text-slate-500">{{ formatDay(f.due_date) }}</span>
                         <StatusBadge :status="f.status" />
                       </div>
@@ -894,15 +876,15 @@
               <template v-if="auditTab === 'report'">
                 <div class="px-6 py-5 space-y-4">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Audit Report</div>
-                    <button v-if="canWrite && !reportEditing" @click="startReportEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.report.heading') }}</div>
+                    <button v-if="canWrite && !reportEditing" @click="startReportEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="reportEditing">
-                    <MarkdownField v-model="reportForm.summary" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="20" placeholder="Auditor's final report — observations, conclusions, recommendations. Use slash commands to link controls, clauses, evidence..." />
+                    <MarkdownField v-model="reportForm.summary" :self-type="'audit'" :self-id="String(selectedAudit.id)" :rows="20" :placeholder="t('audit.report.placeholder')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedAudit.summary" class="text-sm text-slate-300 doc-prose leading-relaxed" v-mermaid v-html="renderMd(selectedAudit.summary)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No report written yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('audit.report.empty') }}</div>
                   </template>
                 </div>
               </template>
@@ -926,8 +908,8 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="audit" :entityId="String(selectedAudit.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Audits cannot currently be deleted from the UI. Manage destructive actions via CLI.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('audit.audit.danger.warning') }}</div>
                   </div>
                 </div>
               </template>
@@ -936,10 +918,10 @@
         </div>
         <!-- Footer (edit) -->
         <div v-if="auditEditing || reportEditing" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-          <button @click="auditEditing ? cancelAuditEdit() : cancelReportEdit()" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="auditEditing ? cancelAuditEdit() : cancelReportEdit()" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="auditEditing ? saveAuditEdit() : saveReportEdit()" :disabled="auditSaving"
             class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ auditSaving ? 'Saving...' : 'Save' }}
+            {{ auditSaving ? t('common.state.saving') : t('common.action.save') }}
           </button>
         </div>
       </div>
@@ -956,7 +938,7 @@
         <!-- Header -->
         <div class="flex-shrink-0 border-b border-slate-800 px-6 py-3 flex items-center justify-between gap-4">
           <div class="flex items-center gap-3 min-w-0">
-            <span class="text-[10px] font-mono uppercase tracking-wider text-slate-600 flex-shrink-0">FIND-{{ selectedFinding.id }}</span>
+            <span class="text-[10px] font-mono uppercase tracking-wider text-slate-600 flex-shrink-0">{{ findingRef(selectedFinding.id) }}</span>
             <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold rounded uppercase tracking-wider whitespace-nowrap"
               :class="findingTypeBadge(selectedFinding.finding_type)">{{ findingTypeLabel(selectedFinding.finding_type) }}</span>
             <h2 class="text-[15px] font-semibold text-slate-200 truncate">{{ selectedFinding.title }}</h2>
@@ -972,10 +954,10 @@
         <div class="flex flex-1 min-h-0">
           <nav class="flex-shrink-0 w-32 border-r border-slate-800 py-3">
             <div class="space-y-0.5">
-              <button v-for="t in findingDetailTabs" :key="t.key" @click="switchFindingTab(t.key)"
+              <button v-for="tab in findingDetailTabs" :key="tab.key" @click="switchFindingTab(tab.key)"
                 class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                :class="findingTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                {{ t.label }}
+                :class="findingTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                {{ tab.label }}
               </button>
             </div>
           </nav>
@@ -984,43 +966,42 @@
             <template v-if="findingTab === 'overview'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                  <button v-if="canWrite && !findingEditing" @click="startFindingEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('audit.detail.overview') }}</div>
+                  <button v-if="canWrite && !findingEditing" @click="startFindingEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                 </div>
                 <template v-if="findingEditing">
                   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.field.title') }}</label>
                       <input v-model="findingEditForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                      <MarkdownField v-model="findingEditForm.description" :self-type="'audit_finding'" :self-id="String(selectedFinding.id)" :rows="6" placeholder="Detailed finding description, evidence, root cause analysis..." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.field.description') }}</label>
+                      <MarkdownField v-model="findingEditForm.description" :self-type="'audit_finding'" :self-id="String(selectedFinding.id)" :rows="6" :placeholder="t('audit.findings.placeholder.description')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.field.type') }}</label>
                       <div class="flex flex-wrap gap-1.5">
-                        <button v-for="t in findingTypeKeys" :key="t"
-                          @click="findingEditForm.finding_type = t"
+                        <button v-for="type in findingTypeKeys" :key="type"
+                          @click="findingEditForm.finding_type = type"
                           class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"
-                          :class="findingEditForm.finding_type === t ? findingTypeChipActive(t) : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
-                          {{ findingTypeLabel(t) }}
+                          :class="findingEditForm.finding_type === type ? findingTypeChipActive(type) : 'bg-slate-800 text-slate-400 border-slate-700 hover:border-slate-600'">
+                          {{ findingTypeLabel(type) }}
                         </button>
                       </div>
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.field.status') }}</label>
                       <select v-model="findingEditForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="open">Open</option>
-                        <option value="closed">Closed</option>
+                        <option v-for="o in findingStatusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                       </select>
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                      <MemberPicker v-model="findingEditForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.field.owner') }}</label>
+                      <MemberPicker v-model="findingEditForm.owner" :members="orgMembers" :placeholder="t('audit.findings.placeholder.owner')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Due Date</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('audit.findings.field.due_date') }}</label>
                       <input v-model="findingEditForm.due_date" type="date" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                   </div>
@@ -1028,46 +1009,53 @@
                 <template v-else>
                   <div class="space-y-4">
                     <div>
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('audit.findings.field.description') }}</div>
                       <div v-if="selectedFinding.description" class="text-sm text-slate-300 doc-prose leading-relaxed" v-mermaid v-html="renderMd(selectedFinding.description)"></div>
                       <div v-else class="text-sm text-slate-600">—</div>
                     </div>
                     <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Audit</div>
-                        <button v-if="selectedFinding.audit_id" @click="goToAuditFromFinding(selectedFinding.audit_id)" class="text-sm text-blue-400 hover:text-blue-300 truncate text-left">{{ selectedFinding.audit_title || ('AUDIT-' + selectedFinding.audit_id) }}</button>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.audit') }}</div>
+                        <button v-if="selectedFinding.audit_id" @click="goToAuditFromFinding(selectedFinding.audit_id)" class="text-sm text-blue-400 hover:text-blue-300 truncate text-left">{{ selectedFinding.audit_title || auditRef(selectedFinding.audit_id) }}</button>
                         <span v-else class="text-sm text-slate-600">—</span>
                       </div>
                       <div v-if="selectedFinding.audit_item_id">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Audit Item</div>
-                        <div class="text-sm text-slate-300 font-mono">item #{{ selectedFinding.audit_item_id }}</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.audit_item') }}</div>
+                        <div class="text-sm text-slate-300 font-mono">{{ t('audit.findings.item_ref', { id: selectedFinding.audit_item_id }) }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.type') }}</div>
                         <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold rounded uppercase tracking-wider"
                           :class="findingTypeBadge(selectedFinding.finding_type)">{{ findingTypeLabel(selectedFinding.finding_type) }}</span>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Status</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.status') }}</div>
                         <StatusBadge :status="selectedFinding.status" />
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.owner') }}</div>
                         <div class="text-sm text-slate-300">{{ resolveUserName(selectedFinding.owner) }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Due date</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.due_date_read') }}</div>
                         <div class="text-sm" :class="isOverdue(selectedFinding.due_date) && selectedFinding.status === 'open' ? 'text-red-400 font-medium' : 'text-slate-300'">
                           {{ selectedFinding.due_date ? formatDay(selectedFinding.due_date) : '—' }}
                         </div>
                       </div>
                       <div v-if="selectedFinding.created_at">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.created') }}</div>
                         <div class="text-sm text-slate-300">{{ formatDate(selectedFinding.created_at) }}</div>
                       </div>
                       <div v-if="selectedFinding.closed_at">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Closed</div>
-                        <div class="text-sm text-emerald-400">{{ formatDateTime(selectedFinding.closed_at) }}<span v-if="selectedFinding.closed_by" class="text-slate-500"> by {{ resolveUserName(selectedFinding.closed_by) }}</span></div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('audit.findings.field.closed') }}</div>
+                        <div class="text-sm text-emerald-400">
+                          <i18n-t keypath="common.detail.at_by" scope="global">
+                            <template #datetime>{{ formatDateTime(selectedFinding.closed_at) }}</template>
+                            <template #by>
+                              <span v-if="selectedFinding.closed_by" class="text-slate-500">{{ t('common.detail.by', { name: resolveUserName(selectedFinding.closed_by) }) }}</span>
+                            </template>
+                          </i18n-t>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1080,12 +1068,12 @@
               <div class="px-6 py-5 space-y-4">
                 <ReferenceManager entityType="audit_finding" :entityId="String(selectedFinding.id)" :editable="canWrite" />
                 <div v-if="canWrite" class="bg-slate-950 border border-slate-800 rounded-lg p-4">
-                  <div class="text-[11px] font-semibold text-slate-400 uppercase tracking-wider mb-2">Quick action</div>
+                  <div class="text-[11px] font-semibold text-slate-400 uppercase tracking-wider mb-2">{{ t('audit.findings.quick_action') }}</div>
                   <button @click="createCAFromFinding(selectedFinding)"
                     class="flex items-center justify-between w-full gap-3 px-4 py-2.5 rounded-lg bg-slate-900 hover:bg-slate-800 border border-slate-700 hover:border-slate-600 transition-colors text-left">
                     <div>
-                      <div class="text-sm font-medium text-slate-200">Create Corrective Action from finding</div>
-                      <div class="text-xs text-slate-500 mt-0.5">Spawn a CA pre-filled with this finding's title and severity.</div>
+                      <div class="text-sm font-medium text-slate-200">{{ t('audit.findings.create_ca') }}</div>
+                      <div class="text-xs text-slate-500 mt-0.5">{{ t('audit.findings.create_ca_hint') }}</div>
                     </div>
                     <span class="text-slate-500 text-lg">→</span>
                   </button>
@@ -1105,11 +1093,11 @@
               <div class="px-6 py-5 space-y-6">
                 <HistoryPanel entityType="audit_finding" :entityId="String(selectedFinding.id)" />
                 <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                  <div class="text-xs text-slate-400">Deleting this finding is permanent. Linked corrective actions stay but lose this back-reference.</div>
+                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                  <div class="text-xs text-slate-400">{{ t('audit.findings.danger.warning') }}</div>
                   <button @click="deleteSelectedFinding"
                     class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                    Delete finding
+                    {{ t('audit.findings.danger.delete') }}
                   </button>
                 </div>
               </div>
@@ -1118,10 +1106,10 @@
         </div>
         <!-- Footer (edit) -->
         <div v-if="findingEditing" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-          <button @click="cancelFindingEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="cancelFindingEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="saveFindingEdit" :disabled="findingSaving"
             class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">
-            {{ findingSaving ? 'Saving...' : 'Save' }}
+            {{ findingSaving ? t('common.state.saving') : t('common.action.save') }}
           </button>
         </div>
       </div>
@@ -1134,6 +1122,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import CopyLinkButton from '../components/CopyLinkButton.vue'
@@ -1153,47 +1142,56 @@ import { useConfirm } from '../composables/useConfirm.js'
 import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate, formatDay } from '../composables/useFormat.js'
+import { formatDate, formatDay, formatMonthLong } from '../composables/useFormat.js'
+import { renderApiError } from '../composables/useApiError.js'
+import { enumLabel, enumLabelAbbr, entityLabel } from '../composables/useEnumLabel.js'
 
 const { confirm: confirmDialog } = useConfirm()
 const { show: showError, success: showSaved } = useToast()
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { orgSlug, orgPath } = useCurrentOrg()
+const { orgPath } = useCurrentOrg()
 
 // ═════════════════════ Constants ═════════════════════
 const auditTypeKeys = ['internal', 'external', 'surveillance', 'certification', 'recertification']
 const findingTypeKeys = ['major_nc', 'minor_nc', 'observation', 'opportunity']
 
-const topTabs = [
-  { key: 'calendar', label: 'Calendar' },
-  { key: 'programmes', label: 'Programmes' },
-  { key: 'findings', label: 'Findings' },
+// Tab labels are keys, resolved in computeds below: an array built at module
+// load freezes its labels in whatever locale was active when the file was
+// imported.
+const TOP_TAB_KEYS = [
+  { key: 'calendar', label: 'audit.tab.calendar' },
+  { key: 'programmes', label: 'audit.tab.programmes' },
+  { key: 'findings', label: 'audit.tab.findings' },
 ]
 
-const programmeDetailTabsBase = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'audits', label: 'Audits' },
-  { key: 'discussion', label: 'Discussion' },
-  { key: 'history', label: 'History' },
+const PROGRAMME_TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'audits', label: 'audit.tab.audits' },
+  { key: 'discussion', label: 'audit.tab.discussion' },
+  { key: 'history', label: 'common.tab.history' },
 ]
 
-const auditDetailTabsBase = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'items', label: 'Items' },
-  { key: 'findings', label: 'Findings' },
-  { key: 'report', label: 'Report' },
-  { key: 'links', label: 'Links' },
-  { key: 'discussion', label: 'Discussion' },
-  { key: 'history', label: 'History' },
+const AUDIT_TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'items', label: 'audit.tab.items' },
+  { key: 'findings', label: 'audit.tab.findings' },
+  { key: 'report', label: 'audit.tab.report' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'discussion', label: 'audit.tab.discussion' },
+  { key: 'history', label: 'common.tab.history' },
 ]
 
-const findingDetailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'linked', label: 'Linked CAs' },
-  { key: 'discussion', label: 'Discussion' },
-  { key: 'history', label: 'History' },
+const FINDING_TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'linked', label: 'audit.tab.linked' },
+  { key: 'discussion', label: 'audit.tab.discussion' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+
+const topTabs = computed(() => TOP_TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
+const findingDetailTabs = computed(() => FINDING_TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
 // ═════════════════════ State ═════════════════════
 const userRole = ref('')
@@ -1208,7 +1206,7 @@ async function reload() {
     await Promise.all([loadProgrammes(), loadAudits()])
     await refreshFindingCounts()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -1324,18 +1322,18 @@ const programmeStats = computed(() => {
 })
 
 const programmeStatusStats = computed(() => [
-  { key: '', label: 'Total', count: programmes.value.length, color: 'text-slate-100' },
-  { key: 'active', label: 'Active', count: programmeStats.value.active, color: 'text-emerald-400' },
-  { key: 'closed', label: 'Closed', count: programmeStats.value.closed, color: 'text-slate-400' },
-  { key: 'draft', label: 'Draft', count: programmeStats.value.draft, color: 'text-amber-400' },
+  { key: '', label: t('common.stat.total'), count: programmes.value.length, color: 'text-slate-100' },
+  { key: 'active', label: statusLabel('active'), count: programmeStats.value.active, color: 'text-emerald-400' },
+  { key: 'closed', label: statusLabel('closed'), count: programmeStats.value.closed, color: 'text-slate-400' },
+  { key: 'draft', label: statusLabel('draft'), count: programmeStats.value.draft, color: 'text-amber-400' },
 ])
 
 // Overdue is a boolean toggle (separate dimension), so it rides alongside the
 // status strip as its own chip rather than inside StatStrip's single v-model.
 const findingStatusStats = computed(() => [
-  { key: '', label: 'Total', count: findingTotal.value, color: 'text-slate-100' },
-  { key: 'open', label: 'Open', count: openFindingsTotal.value, color: openFindingsTotal.value > 0 ? 'text-red-400' : 'text-slate-100' },
-  { key: 'closed', label: 'Closed', count: closedFindingsTotal.value, color: 'text-emerald-400' },
+  { key: '', label: t('common.stat.total'), count: findingTotal.value, color: 'text-slate-100' },
+  { key: 'open', label: statusLabel('open'), count: openFindingsTotal.value, color: openFindingsTotal.value > 0 ? 'text-red-400' : 'text-slate-100' },
+  { key: 'closed', label: statusLabel('closed'), count: closedFindingsTotal.value, color: 'text-emerald-400' },
 ])
 
 const filteredProgrammes = computed(() => {
@@ -1348,17 +1346,19 @@ const filteredProgrammes = computed(() => {
   })
 })
 
-const programmeDetailTabs = computed(() => programmeDetailTabsBase.map(t => {
-  if (t.key === 'audits' && selectedProgramme.value) {
-    return { ...t, count: programmeAudits(selectedProgramme.value.id).length }
+const programmeDetailTabs = computed(() => PROGRAMME_TAB_KEYS.map((tab) => {
+  const resolved = { ...tab, label: t(tab.label) }
+  if (tab.key === 'audits' && selectedProgramme.value) {
+    resolved.count = programmeAudits(selectedProgramme.value.id).length
   }
-  return t
+  return resolved
 }))
 
-const auditDetailTabs = computed(() => auditDetailTabsBase.map(t => {
-  if (t.key === 'items') return { ...t, count: auditItems.value.length }
-  if (t.key === 'findings') return { ...t, count: auditFindings.value.length }
-  return t
+const auditDetailTabs = computed(() => AUDIT_TAB_KEYS.map((tab) => {
+  const resolved = { ...tab, label: t(tab.label) }
+  if (tab.key === 'items') resolved.count = auditItems.value.length
+  if (tab.key === 'findings') resolved.count = auditFindings.value.length
+  return resolved
 }))
 
 // ═════════════════════ Helpers ═════════════════════
@@ -1406,12 +1406,46 @@ function programmeTitle(progId) {
   return p ? `${p.title} (${p.year})` : `#${progId}`
 }
 
-function findingTypeLabel(t) {
-  return ({ major_nc: 'Major NC', minor_nc: 'Minor NC', observation: 'Observation', opportunity: 'OFI' })[t] || t
+// Lookups and option lists live here rather than in the template: a group name
+// — and a bare enum value — is a stored identifier, and the raw-text scanner
+// reads a quoted word in a mustache as unextracted copy.
+const PROGRAMME_STATUSES = ['draft', 'active', 'closed']
+const AUDIT_STATUSES = ['planned', 'in_progress', 'completed']
+const FINDING_STATUSES = ['open', 'closed']
+const AUDIT_RESULTS = ['not_assessed', 'conforming', 'minor_nc', 'major_nc', 'observation', 'opportunity']
+
+const statusLabel = (v) => enumLabel('status', v)
+const auditTypeLabel = (v) => enumLabel('audit_type', v)
+// The badge, the filter and the type chips are all narrow: they take the
+// abbreviated form. The create-finding dropdown has room for the full one.
+const findingTypeLabel = (v) => enumLabelAbbr('finding_type', v)
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const auditTypeOptions = options(auditTypeKeys, auditTypeLabel)
+const programmeStatusOptions = options(PROGRAMME_STATUSES, statusLabel)
+const auditStatusOptions = options(AUDIT_STATUSES, statusLabel)
+const findingStatusOptions = options(FINDING_STATUSES, statusLabel)
+const findingTypeOptions = options(findingTypeKeys, (v) => enumLabel('finding_type', v))
+const findingTypeAbbrOptions = options(findingTypeKeys, findingTypeLabel)
+const resultOptions = options(AUDIT_RESULTS, (v) => enumLabelAbbr('audit_result', v))
+
+const dot = computed(() => t('common.separator.dot'))
+
+// Entity identifiers are not copy — building them here keeps the prefix out of
+// the template, where the raw-text scanner reads it as an unextracted word.
+const progRef = (id) => `PROG-${id}`
+const auditRef = (id) => `AUDIT-${id}`
+const findingRef = (id) => `FIND-${id}`
+
+// The calendar API sends an English month name alongside the month number.
+// Render the number through Intl instead, and keep the server's name only as
+// a fallback if it ever sends something unexpected.
+function monthName(month) {
+  return formatMonthLong(Number(month?.month) - 1) || month?.name || ''
 }
 
-function findingTypeBadge(t) {
-  switch (t) {
+function findingTypeBadge(type) {
+  switch (type) {
     case 'major_nc': return 'bg-red-900/60 text-red-300 border border-red-800'
     case 'minor_nc': return 'bg-amber-900/60 text-amber-300 border border-amber-800'
     case 'observation': return 'bg-blue-900/60 text-blue-300 border border-blue-800'
@@ -1420,8 +1454,8 @@ function findingTypeBadge(t) {
   }
 }
 
-function findingTypeChipActive(t) {
-  switch (t) {
+function findingTypeChipActive(type) {
+  switch (type) {
     case 'major_nc': return 'bg-red-600/20 text-red-400 border-red-500/40'
     case 'minor_nc': return 'bg-amber-600/20 text-amber-400 border-amber-500/40'
     case 'observation': return 'bg-blue-600/20 text-blue-400 border-blue-500/40'
@@ -1430,8 +1464,8 @@ function findingTypeChipActive(t) {
   }
 }
 
-function auditTypeBadge(t) {
-  switch (t) {
+function auditTypeBadge(type) {
+  switch (type) {
     case 'internal': return 'bg-blue-900/40 text-blue-300'
     case 'external': return 'bg-purple-900/40 text-purple-300'
     case 'surveillance': return 'bg-amber-900/40 text-amber-300'
@@ -1441,28 +1475,24 @@ function auditTypeBadge(t) {
   }
 }
 
-function auditTypeDot(t) {
+function auditTypeDot(type) {
   return ({
     internal: 'bg-blue-400',
     external: 'bg-purple-400',
     surveillance: 'bg-amber-400',
     certification: 'bg-green-400',
     recertification: 'bg-emerald-400',
-  })[t] || 'bg-slate-400'
+  })[type] || 'bg-slate-400'
 }
 
-function entityTypeShort(t) {
-  return ({
-    document: 'DOC', control: 'CTRL', policy: 'POL', procedure: 'PROC',
-    clause: 'CLS', requirement: 'REQ', record: 'REC', guideline: 'GUIDE',
-    risk: 'RISK', legal: 'LEGAL', asset: 'ASSET',
-    supplier: 'SUP', system: 'SYS', incident: 'INC', change: 'CR',
-    corrective_action: 'CA', objective: 'OBJ', task: 'TASK', program: 'PROG',
-  })[t] || (t || '?').toUpperCase().slice(0, 5)
+// The same map already exists as common.enum.entity_abbr, which StatusBadge
+// and the suggestion renderer read; this was a second copy of it.
+function entityTypeShort(type) {
+  return enumLabel('entity_abbr', type) || (type || '?').toUpperCase().slice(0, 5)
 }
 
-function entityTypeBadge(t) {
-  switch (t) {
+function entityTypeBadge(type) {
+  switch (type) {
     case 'document': case 'policy': case 'procedure': case 'clause': case 'record': case 'guideline':
       return 'bg-blue-900/40 text-blue-300'
     case 'control': return 'bg-indigo-900/40 text-indigo-300'
@@ -1517,14 +1547,14 @@ async function loadProgrammes() {
   try {
     const res = await api.getAuditProgrammes()
     programmes.value = Array.isArray(res) ? res : []
-  } catch (e) { showError('Failed to load programmes: ' + (e.message || e)) }
+  } catch (e) { showError(t('audit.error.load_programmes', { message: renderApiError(e) })) }
 }
 
 async function loadAudits() {
   try {
     const res = await api.getAudits()
     audits.value = Array.isArray(res) ? res : []
-  } catch (e) { showError('Failed to load audits: ' + (e.message || e)) }
+  } catch (e) { showError(t('audit.error.load_audits', { message: renderApiError(e) })) }
 }
 
 async function loadCalendar() {
@@ -1534,7 +1564,7 @@ async function loadCalendar() {
     calendarMonths.value = Array.isArray(data?.months) ? data.months : []
     calendarUnscheduled.value = Array.isArray(data?.unscheduled) ? data.unscheduled : []
   } catch (e) {
-    showError('Failed to load calendar: ' + (e.message || e))
+    showError(t('audit.error.load_calendar', { message: renderApiError(e) }))
     calendarMonths.value = []; calendarUnscheduled.value = []
   } finally {
     calendarLoading.value = false
@@ -1562,7 +1592,7 @@ async function loadFindings() {
     findings.value = Array.isArray(res?.data) ? res.data : []
     findingTotal.value = res?.total || 0
   } catch (e) {
-    showError('Failed to load findings: ' + (e.message || e))
+    showError(t('audit.error.load_findings', { message: renderApiError(e) }))
     findings.value = []
   }
 }
@@ -1593,7 +1623,7 @@ async function createProgramme() {
     showCreateProgramme.value = false
     newProg.value = { title: '', year: new Date().getFullYear() }
     await loadProgrammes()
-    showSaved('Programme added')
+    showSaved(t('audit.toast.programme_added'))
     if (created?.id) {
       let fresh = created
       try { fresh = await api.getAuditProgramme(created.id) } catch { /* fall back */ }
@@ -1603,7 +1633,7 @@ async function createProgramme() {
       router.push(orgPath('/audit/programmes/' + fresh.id))
     }
   } catch (e) {
-    showError(e.message || 'Failed to create programme')
+    showError(t('audit.error.create_programme', { message: renderApiError(e) }))
   } finally {
     progSaving.value = false
   }
@@ -1646,7 +1676,7 @@ async function saveProgEdit() {
     await loadProgrammes()
     showSaved('Saved')
   } catch (e) {
-    showError(e.message || 'Failed to save programme')
+    showError(t('audit.error.save_programme', { message: renderApiError(e) }))
   } finally {
     progSaving.value = false
   }
@@ -1654,7 +1684,7 @@ async function saveProgEdit() {
 
 async function switchProgrammeTab(key) {
   if (progEditing.value && progIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved changes. Discard and switch tab?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('common.dirty.switch_tab'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   programmeTab.value = key
@@ -1663,7 +1693,7 @@ async function switchProgrammeTab(key) {
 
 async function closeProgrammeDetail() {
   if (progEditing.value && progIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved changes. Discard and close?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('common.dirty.close'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   selectedProgramme.value = null
@@ -1674,16 +1704,20 @@ async function closeProgrammeDetail() {
 async function deleteSelectedProgramme() {
   if (!selectedProgramme.value) return
   if ((selectedProgramme.value.audit_count || 0) > 0) return
-  const ok = await confirmDialog({ message: `Delete programme "${selectedProgramme.value.title}"? This cannot be undone.`, variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({
+    message: t('audit.programme.danger.confirm', { title: selectedProgramme.value.title }),
+    variant: 'danger',
+    confirmLabel: t('common.action.delete'),
+  })
   if (!ok) return
   try {
     await api.deleteAuditProgramme(selectedProgramme.value.id)
     selectedProgramme.value = null
     await loadProgrammes()
     router.push(orgPath('/audit/programmes'))
-    showSaved('Programme deleted')
+    showSaved(t('audit.toast.programme_deleted'))
   } catch (e) {
-    showError(e.message || 'Failed to delete programme')
+    showError(t('audit.error.delete_programme', { message: renderApiError(e) }))
   }
 }
 
@@ -1706,7 +1740,7 @@ async function createAudit() {
     showCreateAudit.value = false
     newAudit.value = { title: '', programme_id: 0, audit_type: 'internal' }
     await loadAudits()
-    showSaved('Audit added')
+    showSaved(t('audit.toast.audit_added'))
     if (created?.id) {
       let fresh = created
       try { fresh = await api.getAudit(created.id) } catch { /* fall back */ }
@@ -1719,7 +1753,7 @@ async function createAudit() {
       startAuditEdit()
     }
   } catch (e) {
-    showError(e.message || 'Failed to create audit')
+    showError(t('audit.error.create_audit', { message: renderApiError(e) }))
   } finally {
     auditCreating.value = false
   }
@@ -1736,7 +1770,7 @@ async function loadAuditDetail(audit) {
     auditItems.value = Array.isArray(items) ? items : []
     auditFindings.value = Array.isArray(fr) ? fr : []
   } catch (e) {
-    showError('Failed to load audit details: ' + (e.message || e))
+    showError(t('audit.error.load_audit_detail', { message: renderApiError(e) }))
     auditItems.value = []; auditFindings.value = []
   } finally {
     auditDetailLoading.value = false
@@ -1815,7 +1849,7 @@ async function saveAuditEdit() {
     await loadAudits()
     showSaved('Saved')
   } catch (e) {
-    showError(e.message || 'Failed to save audit')
+    showError(t('audit.error.save_audit', { message: renderApiError(e) }))
   } finally {
     auditSaving.value = false
   }
@@ -1837,9 +1871,9 @@ async function saveReportEdit() {
     const updated = await api.updateAudit(selectedAudit.value.id, { summary: reportForm.value.summary })
     if (updated && updated.id) selectedAudit.value = updated
     reportEditing.value = false
-    showSaved('Report saved')
+    showSaved(t('audit.toast.report_saved'))
   } catch (e) {
-    showError(e.message || 'Failed to save report')
+    showError(t('audit.error.save_report', { message: renderApiError(e) }))
   } finally {
     auditSaving.value = false
   }
@@ -1847,11 +1881,11 @@ async function saveReportEdit() {
 
 async function switchAuditTab(key) {
   if (auditEditing.value && auditIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved changes. Discard and switch tab?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('common.dirty.switch_tab'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   if (reportEditing.value && reportIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved report changes. Discard and switch tab?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('audit.dirty.report_switch_tab'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   auditTab.value = key
@@ -1861,11 +1895,11 @@ async function switchAuditTab(key) {
 
 async function closeAuditDetail() {
   if (auditEditing.value && auditIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved changes. Discard and close?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('common.dirty.close'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   if (reportEditing.value && reportIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved report changes. Discard and close?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('audit.dirty.report_close'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   selectedAudit.value = null
@@ -1917,10 +1951,10 @@ async function pickAuditItem(s) {
     }
     itemSearchQuery.value = ''
     itemSearchResults.value = []
-    showSaved('Item added')
+    showSaved(t('audit.toast.item_added'))
     nextTick(() => itemSearchInput.value?.focus())
   } catch (e) {
-    showError('Failed to add item: ' + (e.message || e))
+    showError(t('audit.error.add_item', { message: renderApiError(e) }))
   }
 }
 
@@ -1930,19 +1964,23 @@ async function saveItemField(item, field, value) {
     const updated = await api.updateAuditItem(item.id, payload)
     if (updated && updated.id) Object.assign(item, updated)
   } catch (e) {
-    showError('Failed to save: ' + (e.message || e))
+    showError(t('audit.error.save_item', { message: renderApiError(e) }))
   }
 }
 
 async function deleteItem(item) {
-  const ok = await confirmDialog({ message: `Remove "${item.title}" from this audit?`, variant: 'danger', confirmLabel: 'Remove' })
+  const ok = await confirmDialog({
+    message: t('audit.items.confirm_remove', { title: item.title }),
+    variant: 'danger',
+    confirmLabel: t('audit.items.remove'),
+  })
   if (!ok) return
   try {
     await api.deleteAuditItem(item.id)
     auditItems.value = auditItems.value.filter(x => x.id !== item.id)
-    showSaved('Item removed')
+    showSaved(t('audit.toast.item_removed'))
   } catch (e) {
-    showError('Failed to remove: ' + (e.message || e))
+    showError(t('audit.error.remove_item', { message: renderApiError(e) }))
   }
 }
 
@@ -1987,7 +2025,7 @@ async function createFinding() {
       const fr = await api.getAuditFindings(selectedAudit.value.id)
       auditFindings.value = Array.isArray(fr) ? fr : []
     }
-    showSaved('Finding added')
+    showSaved(t('audit.toast.finding_added'))
     if (created?.id) {
       let fresh = created
       try { fresh = await api.getAuditFinding(created.id) } catch { /* fall back */ }
@@ -1999,7 +2037,7 @@ async function createFinding() {
       router.push(orgPath('/audit/findings/' + fresh.id))
     }
   } catch (e) {
-    showError(e.message || 'Failed to add finding')
+    showError(t('audit.error.create_finding', { message: renderApiError(e) }))
   } finally {
     findingCreating.value = false
   }
@@ -2044,7 +2082,7 @@ async function saveFindingEdit() {
     if (activeTab.value === 'findings') loadFindings()
     showSaved('Saved')
   } catch (e) {
-    showError(e.message || 'Failed to save finding')
+    showError(t('audit.error.save_finding', { message: renderApiError(e) }))
   } finally {
     findingSaving.value = false
   }
@@ -2052,7 +2090,7 @@ async function saveFindingEdit() {
 
 async function switchFindingTab(key) {
   if (findingEditing.value && findingIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved changes. Discard and switch tab?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('common.dirty.switch_tab'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   findingTab.value = key
@@ -2061,7 +2099,7 @@ async function switchFindingTab(key) {
 
 async function closeFindingDetail() {
   if (findingEditing.value && findingIsDirty()) {
-    const ok = await confirmDialog({ message: 'You have unsaved changes. Discard and close?', variant: 'danger', confirmLabel: 'Discard' })
+    const ok = await confirmDialog({ message: t('common.dirty.close'), variant: 'danger', confirmLabel: t('common.dirty.discard') })
     if (!ok) return
   }
   selectedFinding.value = null
@@ -2071,7 +2109,11 @@ async function closeFindingDetail() {
 
 async function deleteSelectedFinding() {
   if (!selectedFinding.value) return
-  const ok = await confirmDialog({ message: 'Delete this finding? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({
+    message: t('audit.findings.danger.confirm'),
+    variant: 'danger',
+    confirmLabel: t('common.action.delete'),
+  })
   if (!ok) return
   try {
     await api.deleteAuditFinding(selectedFinding.value.id)
@@ -2079,9 +2121,9 @@ async function deleteSelectedFinding() {
     await refreshFindingCounts()
     if (activeTab.value === 'findings') loadFindings()
     router.push(orgPath('/audit/' + activeTab.value))
-    showSaved('Finding deleted')
+    showSaved(t('audit.toast.finding_deleted'))
   } catch (e) {
-    showError(e.message || 'Failed to delete finding')
+    showError(t('audit.error.delete_finding', { message: renderApiError(e) }))
   }
 }
 
@@ -2171,7 +2213,7 @@ onMounted(async () => {
     if (activeTab.value === 'calendar') await loadCalendar()
     if (activeTab.value === 'findings') await loadFindings()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Changes.vue
+++ b/web/src/views/Changes.vue
@@ -4,15 +4,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between mb-8">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Change Management</h1>
-          <p class="text-sm text-slate-500 mt-1">Track and approve changes to your management system.</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('changes.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('changes.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canCreate" @click="showCreate = !showCreate"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Change Request
+            {{ t('changes.action.add') }}
           </button>
-          <SuggestNewButton entityType="change_request" typeLabel="Change Request" />
+          <SuggestNewButton entityType="change_request" :typeLabel="entityLabel('change_request')" />
         </div>
       </div>
 
@@ -23,48 +23,40 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreate = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <form @submit.prevent="create" class="space-y-4">
-        <h2 class="text-sm font-semibold text-slate-300">Add Change Request</h2>
+        <h2 class="text-sm font-semibold text-slate-300">{{ t('changes.create.heading') }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Type</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('changes.create.type_label') }}</label>
             <select v-model="form.type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
-              <option v-for="t in CHANGE_TYPES" :key="t.value" :value="t.value">{{ t.label }}</option>
+              <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Title <span class="text-red-400">*</span></label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('changes.create.title_label') }} <span class="text-red-400">*</span></label>
             <input v-model="form.title" type="text" required autofocus
               class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-              placeholder="e.g. Migrate authentication to OIDC" />
+              :placeholder="t('changes.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Priority</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('changes.create.priority_label') }}</label>
             <select v-model="form.priority" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-              <option value="critical">Critical</option>
+              <option v-for="o in priorityAscOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Category</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('changes.create.category_label') }}</label>
             <select v-model="form.category" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
-              <option value="process">Process</option>
-              <option value="technology">Technology</option>
-              <option value="people">People</option>
-              <option value="documentation">Documentation</option>
-              <option value="infrastructure">Infrastructure</option>
-              <option value="other">Other</option>
+              <option v-for="o in categoryOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, justification, planned date, risk level, assignee, rollback plan and notes after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('changes.create.fill_in_later') }}</div>
         <div class="flex gap-2 pt-2">
           <button type="submit" :disabled="creating || !form.title"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50">
-            {{ creating ? 'Creating...' : 'Add' }}
+            {{ creating ? t('changes.create.submitting') : t('changes.create.submit') }}
           </button>
-          <button type="button" @click="showCreate = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white">Cancel</button>
+          <button type="button" @click="showCreate = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white">{{ t('common.action.cancel') }}</button>
         </div>
         </form>
         </div>
@@ -82,32 +74,24 @@
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
           </svg>
-          <input v-model="searchQuery" type="text" placeholder="Search..."
+          <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
             class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
         </div>
         <select v-model="filterPriority" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All priorities</option>
-          <option value="critical">Critical</option>
-          <option value="high">High</option>
-          <option value="medium">Medium</option>
-          <option value="low">Low</option>
+          <option value="">{{ t('common.filter.all_priorities') }}</option>
+          <option v-for="o in priorityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select v-model="filterCategory" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All categories</option>
-          <option value="process">Process</option>
-          <option value="technology">Technology</option>
-          <option value="people">People</option>
-          <option value="documentation">Documentation</option>
-          <option value="infrastructure">Infrastructure</option>
-          <option value="other">Other</option>
+          <option value="">{{ t('common.filter.all_categories') }}</option>
+          <option v-for="o in categoryOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
-        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ total }} total</div>
+        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: total }) }}</div>
       </div>
 
       <!-- List -->
       <ListSkeleton v-if="loading" :rows="5" />
       <div v-else-if="changes.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
-        <div class="text-slate-500 text-sm">No change requests found</div>
+        <div class="text-slate-500 text-sm">{{ t('changes.filter.empty') }}</div>
       </div>
       <div v-else class="space-y-2">
         <div v-for="cr in changes" :key="cr.id"
@@ -119,13 +103,14 @@
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-sm font-medium text-slate-200">{{ cr.title }}</span>
                 <StatusBadge :status="cr.status" />
-                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(cr.priority)">{{ cr.priority }}</span>
-                <span class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ cr.category }}</span>
+                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(cr.priority)">{{ priorityLabel(cr.priority) }}</span>
+                <span class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ categoryLabel(cr.category) }}</span>
               </div>
               <div class="text-xs text-slate-500 mt-1">
-                Requested by {{ resolveUserName(cr.requested_by) }}<span v-if="cr.assigned_to"> &middot; Assigned to {{ resolveUserName(cr.assigned_to) }}</span>
-                <span v-if="cr.risk_level && cr.risk_level !== 'low'"> &middot; Risk: <span :class="cr.risk_level === 'critical' ? 'text-red-400' : cr.risk_level === 'high' ? 'text-amber-400' : 'text-slate-400'">{{ cr.risk_level }}</span></span>
-                &middot; {{ formatDate(cr.created_at) }}
+                <span>{{ t('changes.list.requested_by', { name: resolveUserName(cr.requested_by) }) }}</span>
+                <span v-if="cr.assigned_to"> {{ dot }} {{ t('changes.list.assigned_to', { name: resolveUserName(cr.assigned_to) }) }}</span>
+                <span v-if="cr.risk_level && cr.risk_level !== 'low'" :class="riskLevelClass(cr.risk_level)"> {{ dot }} {{ t('changes.list.risk', { level: riskLevelLabel(cr.risk_level) }) }}</span>
+                <span> {{ dot }} {{ formatDate(cr.created_at) }}</span>
               </div>
             </div>
           </div>
@@ -160,10 +145,10 @@
           <div class="flex flex-1 min-h-0">
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -174,159 +159,149 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canCreate && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('changes.detail.overview') }}</div>
+                    <button v-if="canCreate && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.title') }}</label>
                         <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" placeholder="Describe the change..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" :placeholder="t('changes.placeholder.description')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.type') }}</label>
                         <select v-model="editForm.type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="t in CHANGE_TYPES" :key="t.value" :value="t.value">{{ t.label }}</option>
+                          <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Priority</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.priority') }}</label>
                         <select v-model="editForm.priority" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option><option value="critical">Critical</option>
+                          <option v-for="o in priorityAscOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Category</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.category') }}</label>
                         <select v-model="editForm.category" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="process">Process</option>
-                          <option value="technology">Technology</option>
-                          <option value="people">People</option>
-                          <option value="documentation">Documentation</option>
-                          <option value="infrastructure">Infrastructure</option>
-                          <option value="other">Other</option>
+                          <option v-for="o in categoryOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Risk Level</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.risk_level') }}</label>
                         <select v-model="editForm.risk_level" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option><option value="critical">Critical</option>
+                          <option v-for="o in riskLevelAscOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div v-if="canWrite">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="proposed">Proposed</option>
-                          <option value="approved">Approved</option>
-                          <option value="rejected">Rejected</option>
-                          <option value="in_progress">In Progress</option>
-                          <option value="implemented">Implemented</option>
-                          <option value="closed">Closed</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Assigned to</label>
-                        <MemberPicker v-model="editForm.assigned_to" :members="orgMembers" placeholder="Select..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.assigned_to') }}</label>
+                        <MemberPicker v-model="editForm.assigned_to" :members="orgMembers" :placeholder="t('changes.placeholder.assignee')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Planned for</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.planned_for') }}</label>
                         <input v-model="editForm.planned_at_str" type="date"
                           class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Justification</label>
-                        <MarkdownField v-model="editForm.justification" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" placeholder="Why is this change needed?" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.justification') }}</label>
+                        <MarkdownField v-model="editForm.justification" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" :placeholder="t('changes.placeholder.justification')" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Rollback Plan</label>
-                        <MarkdownField v-model="editForm.rollback_plan" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" placeholder="How to revert?" />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('changes.field.rollback_plan') }}</label>
+                        <MarkdownField v-model="editForm.rollback_plan" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="3" :placeholder="t('changes.placeholder.rollback_plan')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('changes.field.description') }}</div>
                         <div v-if="selectedChange.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedChange.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
 
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.type') }}</div>
                           <div class="text-sm text-slate-300">{{ typeLabel(selectedChange.type) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Priority</div>
-                          <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(selectedChange.priority)">{{ selectedChange.priority }}</span>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.priority') }}</div>
+                          <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(selectedChange.priority)">{{ priorityLabel(selectedChange.priority) }}</span>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Category</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ selectedChange.category || '—' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.category') }}</div>
+                          <div class="text-sm text-slate-300">{{ categoryLabel(selectedChange.category) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Risk Level</div>
-                          <div class="text-sm font-medium" :class="selectedChange.risk_level === 'critical' ? 'text-red-400' : selectedChange.risk_level === 'high' ? 'text-amber-400' : 'text-slate-300'">{{ selectedChange.risk_level || '—' }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.risk_level') }}</div>
+                          <div class="text-sm font-medium" :class="riskLevelClass(selectedChange.risk_level, 'text-slate-300')">{{ riskLevelLabel(selectedChange.risk_level) || '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Requested by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.requested_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedChange.requested_by) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Assignee</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.assignee') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedChange.assigned_to) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedChange.created_at) }}</div>
                         </div>
                         <div v-if="selectedChange.planned_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Planned for</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('changes.field.planned_for') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedChange.planned_at) }}</div>
                         </div>
                       </div>
 
                       <div class="border-t border-slate-800 pt-4 space-y-3">
                         <div v-if="selectedChange.justification">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Justification</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('changes.field.justification') }}</div>
                           <div class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedChange.justification)"></div>
                         </div>
                         <div v-if="selectedChange.rollback_plan">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Rollback Plan</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('changes.field.rollback_plan') }}</div>
                           <div class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedChange.rollback_plan)"></div>
                         </div>
                       </div>
 
                       <!-- Implementation timeline -->
                       <div class="border-t border-slate-800 pt-4">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-3">Progress</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-3">{{ t('changes.detail.progress') }}</div>
                         <div class="flex items-center gap-3 text-xs text-slate-500">
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="selectedChange.status !== 'proposed' ? 'bg-blue-400' : 'bg-slate-600'"></span>
-                            <span :class="selectedChange.status !== 'proposed' ? 'text-slate-300' : ''">Proposed</span>
+                            <span :class="selectedChange.status !== 'proposed' ? 'text-slate-300' : ''">{{ stepLabel.proposed }}</span>
                           </div>
                           <div class="h-px flex-1 bg-slate-800"></div>
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="['approved','in_progress','implemented','closed'].includes(selectedChange.status) ? 'bg-emerald-400' : 'bg-slate-600'"></span>
-                            <span :class="['approved','in_progress','implemented','closed'].includes(selectedChange.status) ? 'text-slate-300' : ''">Approved</span>
+                            <span :class="['approved','in_progress','implemented','closed'].includes(selectedChange.status) ? 'text-slate-300' : ''">{{ stepLabel.approved }}</span>
                           </div>
                           <div class="h-px flex-1 bg-slate-800"></div>
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="['in_progress','implemented','closed'].includes(selectedChange.status) ? 'bg-amber-400' : 'bg-slate-600'"></span>
-                            <span :class="['in_progress','implemented','closed'].includes(selectedChange.status) ? 'text-slate-300' : ''">In Progress</span>
+                            <span :class="['in_progress','implemented','closed'].includes(selectedChange.status) ? 'text-slate-300' : ''">{{ stepLabel.in_progress }}</span>
                           </div>
                           <div class="h-px flex-1 bg-slate-800"></div>
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="['implemented','closed'].includes(selectedChange.status) ? 'bg-purple-400' : 'bg-slate-600'"></span>
-                            <span :class="['implemented','closed'].includes(selectedChange.status) ? 'text-slate-300' : ''">Implemented</span>
+                            <span :class="['implemented','closed'].includes(selectedChange.status) ? 'text-slate-300' : ''">{{ stepLabel.implemented }}</span>
                           </div>
                           <div class="h-px flex-1 bg-slate-800"></div>
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="selectedChange.status === 'closed' ? 'bg-slate-400' : 'bg-slate-600'"></span>
-                            <span :class="selectedChange.status === 'closed' ? 'text-slate-300' : ''">Closed</span>
+                            <span :class="selectedChange.status === 'closed' ? 'text-slate-300' : ''">{{ stepLabel.closed }}</span>
                           </div>
                         </div>
                       </div>
@@ -339,15 +314,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canCreate && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('changes.detail.notes') }}</div>
+                    <button v-if="canCreate && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="12" placeholder="Add notes..." />
+                    <MarkdownField v-model="editForm.notes" :self-type="'change_request'" :self-id="selectedChange?.identifier || ''" :rows="12" :placeholder="t('changes.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedChange.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedChange.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -378,10 +353,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="change_request" :entityId="String(selectedChange.id)" />
                   <div v-if="canCreate" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this change request is permanent and cannot be undone.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('changes.danger.warning') }}</div>
                     <button @click="confirmDeleteChange(selectedChange)" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete change request
+                      {{ t('changes.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -391,8 +366,8 @@
           </div>
 
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -405,6 +380,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -426,12 +402,15 @@ import { useToast } from '../composables/useToast.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate } from '../composables/useFormat.js'
+import { renderApiError } from '../composables/useApiError.js'
+import { enumLabel, entityLabel } from '../composables/useEnumLabel.js'
 
 const { confirm: confirmDialog } = useConfirm()
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { orgSlug, orgPath } = useCurrentOrg()
+const { orgPath } = useCurrentOrg()
 const { success: showSaved, show: showError } = useToast()
 
 const renderMd = renderMarkdown
@@ -468,14 +447,17 @@ const editForm = ref({})
 const { capture: captureEditSnapshot, isDirty } = useDirtyEdit(editForm)
 const saving = ref(false)
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Tab labels are keys, resolved in a computed: an array built at module load
+// freezes its labels in whatever locale was active when the file was imported.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
 useModalEscape(showCreate)
 useModalEscape(computed(() => !!selectedChange.value), () => closeDetail())
@@ -486,28 +468,59 @@ const canCreate = computed(() => ['admin', 'manager', 'contributor'].includes(us
 const canWrite = computed(() => userRole.value === 'admin' || userRole.value === 'manager')
 const pendingRefs = ref([])
 
-// Change-request types — single source for the create/edit selects and the
-// read-view label. Extend here (+ db.ChangeTypes + the DB CHECK) to add a kind.
-const CHANGE_TYPES = [
-  { value: 'change', label: 'Change' },
-  { value: 'access_request', label: 'Access request' },
-]
-function typeLabel(t) {
-  return (CHANGE_TYPES.find((x) => x.value === t) || CHANGE_TYPES[0]).label
+// Lookups and option lists live here rather than in the template: a group name
+// — and a bare enum value — is a stored identifier, and the raw-text scanner
+// reads a quoted word in a mustache as unextracted copy.
+//
+// Change-request types are the single source for the create/edit selects and
+// the read-view label. Extend here (+ db.ChangeTypes + the DB CHECK) to add a
+// kind; the labels live in common.enum.change_type.
+const CHANGE_TYPES = ['change', 'access_request']
+const STATUSES = ['proposed', 'approved', 'rejected', 'in_progress', 'implemented', 'closed']
+const PRIORITIES = ['critical', 'high', 'medium', 'low']
+const CATEGORIES = ['process', 'technology', 'people', 'documentation', 'infrastructure', 'other']
+const RISK_LEVELS = ['critical', 'high', 'medium', 'low']
+
+const statusLabel = (v) => enumLabel('status', v)
+const priorityLabel = (v) => enumLabel('priority', v)
+const categoryLabel = (v) => enumLabel('change_category', v)
+const riskLevelLabel = (v) => enumLabel('risk_level', v)
+const typeLabel = (v) => enumLabel('change_type', CHANGE_TYPES.includes(v) ? v : CHANGE_TYPES[0])
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const typeOptions = options(CHANGE_TYPES, typeLabel)
+const statusOptions = options(STATUSES, statusLabel)
+const priorityOptions = options(PRIORITIES, priorityLabel)
+const priorityAscOptions = options([...PRIORITIES].reverse(), priorityLabel)
+const categoryOptions = options(CATEGORIES, categoryLabel)
+const riskLevelAscOptions = options([...RISK_LEVELS].reverse(), riskLevelLabel)
+
+// The five progress steps are fixed statuses, not the request's own.
+const stepLabel = computed(() => Object.fromEntries(
+  ['proposed', 'approved', 'in_progress', 'implemented', 'closed'].map((v) => [v, statusLabel(v)]),
+))
+
+const dot = computed(() => t('common.separator.dot'))
+
+function riskLevelClass(level, fallback = 'text-slate-400') {
+  if (level === 'critical') return 'text-red-400'
+  if (level === 'high') return 'text-amber-400'
+  return fallback
 }
 
 const form = ref({ type: 'change', title: '', priority: 'medium', category: 'process' })
 
-const statusStats = computed(() => {
-  return [
-    { key: 'proposed', label: 'Proposed', count: stats.value.proposed || 0, color: 'text-blue-400' },
-    { key: 'approved', label: 'Approved', count: stats.value.approved || 0, color: 'text-emerald-400' },
-    { key: 'in_progress', label: 'In Progress', count: stats.value.in_progress || 0, color: 'text-amber-400' },
-    { key: 'implemented', label: 'Implemented', count: stats.value.implemented || 0, color: 'text-purple-400' },
-    { key: 'rejected', label: 'Rejected', count: stats.value.rejected || 0, color: 'text-red-400' },
-    { key: 'closed', label: 'Closed', count: stats.value.closed || 0, color: 'text-slate-500' },
-  ]
-})
+const STATUS_STATS = [
+  { key: 'proposed', color: 'text-blue-400' },
+  { key: 'approved', color: 'text-emerald-400' },
+  { key: 'in_progress', color: 'text-amber-400' },
+  { key: 'implemented', color: 'text-purple-400' },
+  { key: 'rejected', color: 'text-red-400' },
+  { key: 'closed', color: 'text-slate-500' },
+]
+const statusStats = computed(() => STATUS_STATS.map(({ key, color }) => ({
+  key, color, label: statusLabel(key), count: stats.value[key] || 0,
+})))
 
 function priorityClass(p) {
   switch (p) {
@@ -530,9 +543,9 @@ async function selectChange(cr) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -543,9 +556,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -553,14 +566,18 @@ async function closeDetail() {
 }
 
 async function confirmDeleteChange(cr) {
-  const ok = await confirmDialog({ message: 'Delete this change request? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({
+    message: t('changes.danger.confirm'),
+    variant: 'danger',
+    confirmLabel: t('common.action.delete'),
+  })
   if (!ok) return
   try {
     await api.deleteJSON(`/api/v1/changes/${cr.id}`)
     closeDetail()
     await loadChanges()
   } catch (e) {
-    console.error('Failed to delete change request:', e)
+    showError(t('changes.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -579,7 +596,7 @@ async function loadChanges() {
     loadStats()
   } catch (e) {
     changes.value = []
-    showError(e.message || 'Failed to load changes')
+    showError(t('changes.error.load', { message: renderApiError(e) }))
   }
 }
 
@@ -632,22 +649,9 @@ async function create() {
       router.push(orgPath(`/changes/${fresh.id}`))
     }
   } catch (e) {
-    showError(e.message || 'Failed to create change request')
+    showError(t('changes.error.create', { message: renderApiError(e) }))
   } finally {
     creating.value = false
-  }
-}
-
-async function changeStatus(id, status) {
-  try {
-    await api.updateChangeStatus(id, status)
-    await loadChanges()
-    if (selectedChange.value?.id === id) {
-      const updated = changes.value.find(c => c.id === id)
-      if (updated) selectedChange.value = updated
-    }
-  } catch (e) {
-    showError(e.message || 'Status change failed')
   }
 }
 
@@ -705,9 +709,9 @@ async function saveSection() {
       startEdit(fresh)
     }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('changes.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -822,14 +822,16 @@ const SOURCES = ['internal_audit', 'external_audit', 'risk_assessment', 'securit
 
 const statusLabel = (v) => enumLabel('status', v)
 const severityLabel = (v) => enumLabelAbbr('finding_type', v)
-const sourceLabel = (v) => enumLabel('source', v)
+// The badge and the read view have always shown the form's longer wording
+// ("Internal Audit Finding"); only the filter shows the catalogue's.
+const sourceLabel = (v) => t(`corrective_actions.source_option.${v}`)
 
 const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
 const statusOptions = options(STATUSES, statusLabel)
 const severityAbbrOptions = options(SEVERITIES, severityLabel)
 const severityOptions = options(SEVERITIES, (v) => enumLabel('finding_type', v))
-const sourceOptions = options(SOURCES, sourceLabel)
-const sourceFormOptions = options(SOURCES, (v) => t(`corrective_actions.source_option.${v}`))
+const sourceOptions = options(SOURCES, (v) => enumLabel('source', v))
+const sourceFormOptions = options(SOURCES, sourceLabel)
 
 function severityClass(sev) {
   switch (sev) {

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -18,16 +18,16 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Corrective Actions</h1>
-          <p class="text-sm text-slate-500 mt-1">Track nonconformities, observations, and opportunities for improvement</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('corrective_actions.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('corrective_actions.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite"
             @click="showCreateForm = !showCreateForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Corrective Action
+            {{ t('corrective_actions.action.add') }}
           </button>
-          <SuggestNewButton entityType="corrective_action" typeLabel="Corrective Action" />
+          <SuggestNewButton entityType="corrective_action" :typeLabel="entityLabel('corrective_action')" />
         </div>
       </div>
 
@@ -41,39 +41,25 @@
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
           </svg>
-          <input v-model="searchQuery" type="text" placeholder="Search..."
+          <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
             class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
         </div>
         <select v-model="filterStatus" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All statuses</option>
-          <option value="todo">Todo</option>
-          <option value="assessment">Assessment</option>
-          <option value="awaiting_approval">Awaiting Approval</option>
-          <option value="implementation">Implementation</option>
-          <option value="monitoring">Monitoring</option>
-          <option value="resolved">Resolved</option>
+          <option value="">{{ t('common.filter.all_statuses') }}</option>
+          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select v-model="filterSeverity" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All severities</option>
-          <option value="major_nc">Major NC</option>
-          <option value="minor_nc">Minor NC</option>
-          <option value="observation">Observation</option>
-          <option value="opportunity">OFI</option>
+          <option value="">{{ t('common.filter.all_severities') }}</option>
+          <option v-for="o in severityAbbrOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select v-model="filterSource" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All sources</option>
-          <option value="internal_audit">Internal Audit</option>
-          <option value="external_audit">External Audit</option>
-          <option value="risk_assessment">Risk Assessment</option>
-          <option value="security_incident">Security Incident</option>
-          <option value="objective">Objective</option>
-          <option value="feedback">Feedback</option>
-          <option value="other">Other</option>
+          <option value="">{{ t('common.filter.all_sources') }}</option>
+          <option v-for="o in sourceOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <div class="w-48">
-          <MemberPicker v-model="filterAssignee" :members="orgMembers" placeholder="Any assignee" />
+          <MemberPicker v-model="filterAssignee" :members="orgMembers" :placeholder="t('corrective_actions.filter.assignee_placeholder')" />
         </div>
-        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ total }} total</div>
+        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: total }) }}</div>
       </div>
 
       <!-- Create form -->
@@ -83,7 +69,7 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-sm font-semibold text-slate-200">Add Corrective Action</h2>
+          <h2 class="text-sm font-semibold text-slate-200">{{ t('corrective_actions.create.heading') }}</h2>
           <button @click="showCreateForm = false" class="text-slate-500 hover:text-slate-300">
             <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -92,36 +78,27 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="sm:col-span-2">
-            <label class="block text-xs font-medium text-slate-500 mb-1">Title *</label>
-            <input v-model="newCA.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Brief title of the nonconformity or improvement" />
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.create.title_label') }}</label>
+            <input v-model="newCA.title" autofocus class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('corrective_actions.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Source</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.source') }}</label>
             <select v-model="newCA.source" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option value="internal_audit">Internal Audit Finding</option>
-              <option value="external_audit">External Audit Finding</option>
-              <option value="risk_assessment">Risk Assessment</option>
-              <option value="security_incident">Security Incident</option>
-              <option value="objective">Objective</option>
-              <option value="feedback">Feedback / Suggestion</option>
-              <option value="other">Other</option>
+              <option v-for="o in sourceFormOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs font-medium text-slate-500 mb-1">Severity</label>
+            <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.severity') }}</label>
             <select v-model="newCA.severity" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-              <option value="major_nc">Major Non-conformity</option>
-              <option value="minor_nc">Minor Non-conformity</option>
-              <option value="observation">Observation</option>
-              <option value="opportunity">Opportunity for Improvement</option>
+              <option v-for="o in severityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, assignee, due date and notes after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('corrective_actions.create.fill_in_later') }}</div>
         <div class="flex justify-end gap-3 pt-2">
-          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+          <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
           <button @click="createCA" :disabled="!newCA.title" class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-            Add
+            {{ t('corrective_actions.create.submit') }}
           </button>
         </div>
         </div>
@@ -132,10 +109,10 @@
       <!-- Action list -->
       <div v-if="actions.length === 0" class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
         <div v-if="filterStatus || filterSeverity || filterSource || filterAssignee || searchQuery" class="text-slate-500 text-sm">
-          No corrective actions match your filter.
+          {{ t('corrective_actions.filter.empty') }}
         </div>
         <div v-else class="text-slate-500 text-sm">
-          No corrective actions yet — click Add to create your first one.
+          {{ t('corrective_actions.filter.empty_all') }}
         </div>
       </div>
 
@@ -198,10 +175,10 @@
             <!-- Sidebar nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -213,96 +190,98 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('corrective_actions.detail.overview') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.title') }}</label>
                         <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'corrective_action'" :self-id="selectedCA?.identifier || ''" :rows="3" placeholder="Describe the corrective action..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'corrective_action'" :self-id="selectedCA?.identifier || ''" :rows="3" :placeholder="t('corrective_actions.placeholder.description')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Source</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.source') }}</label>
                         <select v-model="editForm.source" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="(label, key) in sourceLabels" :key="key" :value="key">{{ label }}</option>
+                          <option v-for="o in sourceFormOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Severity</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.severity') }}</label>
                         <select v-model="editForm.severity" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option v-for="(label, key) in severityFullLabels" :key="key" :value="key">{{ label }}</option>
+                          <option v-for="o in severityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="todo">To do</option>
-                          <option value="assessment">Assessment</option>
-                          <option value="awaiting_approval">Awaiting approval</option>
-                          <option value="implementation">Implementation</option>
-                          <option value="monitoring">Monitoring</option>
-                          <option value="resolved">Resolved</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Assignee</label>
-                        <MemberPicker v-model="editForm.assignee" :members="orgMembers" placeholder="Select assignee..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.assignee') }}</label>
+                        <MemberPicker v-model="editForm.assignee" :members="orgMembers" :placeholder="t('corrective_actions.placeholder.assignee')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Due date</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.due_date') }}</label>
                         <input v-model="editForm.due_date" type="date" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Root Cause</label>
-                        <MarkdownField v-model="editForm.root_cause" :self-type="'corrective_action'" :self-id="selectedCA?.identifier || ''" :rows="3" placeholder="Root cause analysis..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('corrective_actions.field.root_cause') }}</label>
+                        <MarkdownField v-model="editForm.root_cause" :self-type="'corrective_action'" :self-id="selectedCA?.identifier || ''" :rows="3" :placeholder="t('corrective_actions.placeholder.root_cause')" />
                       </div>
                     </div>
                   </template>
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('corrective_actions.field.description') }}</div>
                         <div v-if="selectedCA.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedCA.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Source</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.source') }}</div>
                           <div class="text-sm text-slate-300">{{ sourceLabel(selectedCA.source) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Severity</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.severity') }}</div>
                           <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded" :class="severityClass(selectedCA.severity)">{{ severityLabel(selectedCA.severity) }}</span>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Assignee</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.assignee') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedCA.assignee) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Due date</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.due_date') }}</div>
                           <div class="text-sm" :class="selectedCA.due_date && isOverdue(selectedCA.due_date) && selectedCA.status !== 'resolved' ? 'text-red-400' : 'text-slate-300'">{{ selectedCA.due_date ? formatDay(selectedCA.due_date) : '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedCA.created_by) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedCA.created_at) }}</div>
                         </div>
                         <div v-if="selectedCA.resolved_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Resolved</div>
-                          <div class="text-sm text-emerald-400">{{ formatDateTime(selectedCA.resolved_at) }}<span v-if="selectedCA.resolved_by" class="text-slate-500"> by {{ resolveUserName(selectedCA.resolved_by) }}</span></div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.resolved') }}</div>
+                          <div class="text-sm text-emerald-400">
+                            <i18n-t keypath="corrective_actions.detail.resolved_by" scope="global">
+                              <template #datetime>{{ formatDateTime(selectedCA.resolved_at) }}</template>
+                              <template #by>
+                                <span v-if="selectedCA.resolved_by" class="text-slate-500">{{ t('corrective_actions.detail.by', { name: resolveUserName(selectedCA.resolved_by) }) }}</span>
+                              </template>
+                            </i18n-t>
+                          </div>
                         </div>
                       </div>
 
                       <div v-if="selectedCA.root_cause" class="border-t border-slate-800 pt-4">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Root Cause</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('corrective_actions.field.root_cause') }}</div>
                         <div class="text-sm text-slate-300 doc-prose" v-mermaid v-html="renderMd(selectedCA.root_cause)"></div>
                       </div>
 
@@ -314,14 +293,14 @@
               <!-- ═══ ACTIONS ═══ -->
               <template v-if="detailTab === 'actions'">
                 <div class="px-6 py-5 space-y-4">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Quick actions</div>
-                  <div v-if="!canWrite" class="text-xs text-slate-600 italic">Read-only — actions require manager or admin role.</div>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('common.heading.quick_actions') }}</div>
+                  <div v-if="!canWrite" class="text-xs text-slate-600 italic">{{ t('common.read_only.actions') }}</div>
                   <div v-else class="flex flex-col gap-3 max-w-md">
                     <button @click="createLinkedTask"
                       class="flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-slate-900 hover:bg-slate-800 border border-slate-700 hover:border-slate-600 transition-colors text-left">
                       <div>
-                        <div class="text-sm font-medium text-slate-200">Create Implementation Task</div>
-                        <div class="text-xs text-slate-500 mt-0.5">Spawn a task to do the corrective work; auto-linked back to this CA.</div>
+                        <div class="text-sm font-medium text-slate-200">{{ t('corrective_actions.actions.create_task') }}</div>
+                        <div class="text-xs text-slate-500 mt-0.5">{{ t('corrective_actions.actions.create_task_hint') }}</div>
                       </div>
                       <span class="text-slate-500 text-lg">→</span>
                     </button>
@@ -333,15 +312,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('corrective_actions.detail.notes') }}</div>
+                    <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'corrective_action'" :self-id="selectedCA?.identifier || ''" :rows="12" placeholder="Add notes..." />
+                    <MarkdownField v-model="editForm.notes" :self-type="'corrective_action'" :self-id="selectedCA?.identifier || ''" :rows="12" :placeholder="t('corrective_actions.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedCA.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedCA.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -372,10 +351,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="corrective_action" :entityId="String(selectedCA.id)" />
                   <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this corrective action is permanent and cannot be undone.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('corrective_actions.danger.warning') }}</div>
                     <button @click="deleteCA(selectedCA.id)" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete corrective action
+                      {{ t('corrective_actions.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -386,8 +365,8 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
@@ -400,13 +379,13 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import api from '../api'
 import MemberPicker from '../components/MemberPicker.vue'
 import MarkdownField from '../components/MarkdownField.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
 import RefreshButton from '../components/RefreshButton.vue'
-import EntityReferences from '../components/EntityReferences.vue'
 import ReferenceManager from '../components/ReferenceManager.vue'
 import CopyLinkButton from '../components/CopyLinkButton.vue'
 import SuggestionPanel from '../components/SuggestionPanel.vue'
@@ -422,12 +401,15 @@ import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { renderMarkdown } from '../composables/useRenderMd.js'
 import { formatDate, formatDay } from '../composables/useFormat.js'
+import { renderApiError } from '../composables/useApiError.js'
+import { enumLabel, enumLabelAbbr, entityLabel } from '../composables/useEnumLabel.js'
 
 const { confirm: confirmDialog } = useConfirm()
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { orgSlug, orgPath } = useCurrentOrg()
+const { orgPath } = useCurrentOrg()
 const { success: showSaved, show: showError } = useToast()
 
 const renderMd = renderMarkdown
@@ -445,7 +427,7 @@ async function reload() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -453,14 +435,17 @@ async function reload() {
 const error = ref(null)
 const actions = ref([])
 const stats = ref({})
-const statusStats = computed(() => [
-  { key: 'todo', label: 'Todo', count: stats.value.todo || 0, color: 'text-red-400' },
-  { key: 'assessment', label: 'Assessment', count: stats.value.assessment || 0, color: 'text-amber-400' },
-  { key: 'awaiting_approval', label: 'Awaiting Approval', count: stats.value.awaiting_approval || 0, color: 'text-purple-400' },
-  { key: 'implementation', label: 'Implementation', count: stats.value.implementation || 0, color: 'text-blue-400' },
-  { key: 'monitoring', label: 'Monitoring', count: stats.value.monitoring || 0, color: 'text-cyan-400' },
-  { key: 'resolved', label: 'Resolved', count: stats.value.resolved || 0, color: 'text-emerald-400' },
-])
+const STATUS_STATS = [
+  { key: 'todo', color: 'text-red-400' },
+  { key: 'assessment', color: 'text-amber-400' },
+  { key: 'awaiting_approval', color: 'text-purple-400' },
+  { key: 'implementation', color: 'text-blue-400' },
+  { key: 'monitoring', color: 'text-cyan-400' },
+  { key: 'resolved', color: 'text-emerald-400' },
+]
+const statusStats = computed(() => STATUS_STATS.map((s) => ({
+  ...s, label: statusLabel(s.key), count: stats.value[s.key] || 0,
+})))
 const selectedCA = ref(null)
 const showCreateForm = ref(false)
 
@@ -471,15 +456,18 @@ const editForm = ref({})
 const { capture: captureEditSnapshot, isDirty } = useDirtyEdit(editForm)
 const saving = ref(false)
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'actions', label: 'Actions' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Tab labels are keys, resolved in a computed: an array built at module load
+// freezes its labels in whatever locale was active when the file was imported.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'actions', label: 'common.tab.actions' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
 useModalEscape(showCreateForm)
 useModalEscape(computed(() => !!selectedCA.value), () => closeDetail())
@@ -491,8 +479,6 @@ const searchQuery = ref('')
 const page = ref(1)
 const pageSize = ref(50)
 const total = ref(0)
-const docIDsInput = ref('')
-const controlIDsInput = ref('')
 const pendingRefs = ref([])
 
 const newCA = ref({
@@ -581,7 +567,7 @@ async function loadAll() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }
@@ -608,7 +594,7 @@ async function loadActions() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -651,19 +637,19 @@ async function createCA() {
       const id = 'INC-' + String(route.query.from_incident)
       sourceLinks.push({ type: 'incident', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from [${label}](/incidents/${id})`)
+      seedLines.push(t('corrective_actions.seed.from_incident', { label, link: `/incidents/${id}` }))
     }
     if (route.query.from_audit_finding) {
       const id = 'FIND-' + String(route.query.from_audit_finding)
       sourceLinks.push({ type: 'audit_finding', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from audit finding ${label}`)
+      seedLines.push(t('corrective_actions.seed.from_audit_finding', { label }))
     }
     if (route.query.from_risk) {
       const id = String(route.query.from_risk)
       sourceLinks.push({ type: 'risk', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from [${label}](/risks/${id})`)
+      seedLines.push(t('corrective_actions.seed.from_risk', { label, link: `/risks/${id}` }))
     }
     if (seedLines.length > 0) {
       payload.notes = seedLines.join('\n') + (payload.notes ? '\n\n' + payload.notes : '')
@@ -685,8 +671,6 @@ async function createCA() {
     pendingRefs.value = []
     showCreateForm.value = false
     newCA.value = { title: '', description: '', source: 'other', severity: 'observation', assignee: '', due_date: '', notes: '' }
-    docIDsInput.value = ''
-    controlIDsInput.value = ''
     await loadActions()
     // Drop user into detail modal in edit mode on Overview to keep filling things in.
     if (created && created.id) {
@@ -699,28 +683,7 @@ async function createCA() {
       router.push(orgPath(`/corrective-actions/${fresh.id}`))
     }
   } catch (e) {
-    error.value = e.message
-  }
-}
-
-async function changeStatus(ca, status) {
-  try {
-    await api.updateCorrectiveActionStatus(ca.id, status)
-    ca.status = status
-    if (selectedCA.value?.id === ca.id) {
-      selectedCA.value = { ...ca }
-    }
-    await loadStats()
-  } catch (e) {
-    showError(e.message || 'Status change failed')
-  }
-}
-
-async function saveField(id, field, value) {
-  try {
-    await api.updateCorrectiveAction(id, { [field]: value })
-  } catch (e) {
-    // silent save
+    error.value = renderApiError(e)
   }
 }
 
@@ -738,14 +701,18 @@ function createLinkedTask() {
 }
 
 async function deleteCA(id) {
-  const ok = await confirmDialog({ message: 'Delete this corrective action? This cannot be undone.', variant: 'danger', confirmLabel: 'Delete' })
+  const ok = await confirmDialog({
+    message: t('corrective_actions.danger.confirm'),
+    variant: 'danger',
+    confirmLabel: t('common.action.delete'),
+  })
   if (!ok) return
   try {
     await api.deleteCorrectiveAction(id)
     closeDetail()
     await loadActions()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -760,9 +727,9 @@ async function selectCA(ca) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -773,9 +740,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -826,9 +793,9 @@ async function saveSection() {
       } catch { /* ignore */ }
     }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('corrective_actions.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
@@ -840,50 +807,29 @@ function isOverdue(dateStr) {
   return d < new Date()
 }
 
-const severityLabels = {
-  major_nc: 'Major NC',
-  minor_nc: 'Minor NC',
-  observation: 'Observation',
-  opportunity: 'OFI',
-}
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+//
+// The finding taxonomy appears twice over, and both forms are authored: the
+// badge and the filter want "Major NC", the create and edit forms want "Major
+// non-conformity". `source` likewise — the filter reads "Internal audit", the
+// forms spell out "Internal Audit Finding", so the long set stays a local
+// `corrective_actions.source_option.*` rather than displacing the catalogue.
+const STATUSES = ['todo', 'assessment', 'awaiting_approval', 'implementation', 'monitoring', 'resolved']
+const SEVERITIES = ['major_nc', 'minor_nc', 'observation', 'opportunity']
+const SOURCES = ['internal_audit', 'external_audit', 'risk_assessment', 'security_incident', 'objective', 'feedback', 'other']
 
-const severityFullLabels = {
-  major_nc: 'Major Non-conformity',
-  minor_nc: 'Minor Non-conformity',
-  observation: 'Observation',
-  opportunity: 'Opportunity for Improvement',
-}
+const statusLabel = (v) => enumLabel('status', v)
+const severityLabel = (v) => enumLabelAbbr('finding_type', v)
+const sourceLabel = (v) => enumLabel('source', v)
 
-const sourceLabels = {
-  internal_audit: 'Internal Audit Finding',
-  external_audit: 'External Audit Finding',
-  risk_assessment: 'Risk Assessment',
-  security_incident: 'Security Incident',
-  objective: 'Objective',
-  feedback: 'Feedback / Suggestion',
-  other: 'Other',
-}
-
-const statusLabels = {
-  todo: 'Todo',
-  assessment: 'Assessment',
-  awaiting_approval: 'Awaiting Approval',
-  implementation: 'Implementation',
-  monitoring: 'Monitoring',
-  resolved: 'Resolved',
-}
-
-function severityLabel(sev) {
-  return severityLabels[sev] || sev
-}
-
-function sourceLabel(src) {
-  return sourceLabels[src] || src
-}
-
-function statusLabel(st) {
-  return statusLabels[st] || st
-}
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const severityAbbrOptions = options(SEVERITIES, severityLabel)
+const severityOptions = options(SEVERITIES, (v) => enumLabel('finding_type', v))
+const sourceOptions = options(SOURCES, sourceLabel)
+const sourceFormOptions = options(SOURCES, (v) => t(`corrective_actions.source_option.${v}`))
 
 function severityClass(sev) {
   switch (sev) {

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -270,10 +270,10 @@
                         <div v-if="selectedCA.resolved_at">
                           <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('corrective_actions.field.resolved') }}</div>
                           <div class="text-sm text-emerald-400">
-                            <i18n-t keypath="corrective_actions.detail.resolved_by" scope="global">
+                            <i18n-t keypath="common.detail.at_by" scope="global">
                               <template #datetime>{{ formatDateTime(selectedCA.resolved_at) }}</template>
                               <template #by>
-                                <span v-if="selectedCA.resolved_by" class="text-slate-500">{{ t('corrective_actions.detail.by', { name: resolveUserName(selectedCA.resolved_by) }) }}</span>
+                                <span v-if="selectedCA.resolved_by" class="text-slate-500">{{ t('common.detail.by', { name: resolveUserName(selectedCA.resolved_by) }) }}</span>
                               </template>
                             </i18n-t>
                           </div>

--- a/web/src/views/CorrectiveActions.vue
+++ b/web/src/views/CorrectiveActions.vue
@@ -637,19 +637,19 @@ async function createCA() {
       const id = 'INC-' + String(route.query.from_incident)
       sourceLinks.push({ type: 'incident', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(t('corrective_actions.seed.from_incident', { label, link: `/incidents/${id}` }))
+      seedLines.push(t('common.seed.created_from', { label, link: `/incidents/${id}` }))
     }
     if (route.query.from_audit_finding) {
       const id = 'FIND-' + String(route.query.from_audit_finding)
       sourceLinks.push({ type: 'audit_finding', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(t('corrective_actions.seed.from_audit_finding', { label }))
+      seedLines.push(t('common.seed.created_from_audit_finding', { label }))
     }
     if (route.query.from_risk) {
       const id = String(route.query.from_risk)
       sourceLinks.push({ type: 'risk', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(t('corrective_actions.seed.from_risk', { label, link: `/risks/${id}` }))
+      seedLines.push(t('common.seed.created_from', { label, link: `/risks/${id}` }))
     }
     if (seedLines.length > 0) {
       payload.notes = seedLines.join('\n') + (payload.notes ? '\n\n' + payload.notes : '')

--- a/web/src/views/Objectives.vue
+++ b/web/src/views/Objectives.vue
@@ -19,15 +19,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Objectives</h1>
-          <p class="text-sm text-slate-500 mt-1">Track measurable ISMS objectives and KPI performance</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('objectives.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('objectives.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite" @click="showCreateObjective = !showCreateObjective"
             class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Objective
+            {{ t('objectives.action.add') }}
           </button>
-          <SuggestNewButton entityType="objective" typeLabel="Objective" />
+          <SuggestNewButton entityType="objective" :typeLabel="entityLabel('objective')" />
         </div>
       </div>
 
@@ -43,26 +43,22 @@
             <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
-            <input v-model="searchQuery" type="text" placeholder="Search..."
+            <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
               class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
           </div>
           <select v-model="filterProgramId"
             class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All programs</option>
+            <option value="">{{ t('objectives.filter.all_programs') }}</option>
             <option v-for="p in programs" :key="p.id" :value="p.id">{{ p.key }}: {{ p.title }}</option>
           </select>
           <select v-model="filterStatus"
             class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-            <option value="">All statuses</option>
-            <option value="draft">Draft</option>
-            <option value="active">Active</option>
-            <option value="at_risk">At Risk</option>
-            <option value="paused">Paused</option>
-            <option value="complete">Complete</option>
+            <option value="">{{ t('common.filter.all_statuses') }}</option>
+            <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
           </select>
-          <input v-model="filterOwner" type="text" placeholder="Owner..."
+          <input v-model="filterOwner" type="text" :placeholder="t('objectives.filter.owner_placeholder')"
             class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 placeholder-slate-600 focus:outline-none focus:border-blue-500 w-40" />
-          <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ total }} total</div>
+          <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: total }) }}</div>
         </div>
 
         <!-- Create objective form (modal) -->
@@ -71,34 +67,34 @@
         <div v-if="showCreateObjective" class="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] px-4">
           <div class="absolute inset-0 bg-black/60" @click="showCreateObjective = false" />
           <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
-          <h3 class="text-sm font-semibold text-slate-300">Add Objective</h3>
+          <h3 class="text-sm font-semibold text-slate-300">{{ t('objectives.create.heading') }}</h3>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label class="block text-xs text-slate-500 mb-1">Program *</label>
+              <label class="block text-xs text-slate-500 mb-1">{{ t('objectives.create.program_label') }}</label>
               <select v-model="newObjective.program_id"
                 class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                <option value="">Select program...</option>
+                <option value="">{{ t('objectives.create.program_placeholder') }}</option>
                 <option v-for="p in programs" :key="p.id" :value="p.id">{{ p.key }}: {{ p.title }}</option>
               </select>
             </div>
             <div>
-              <label class="block text-xs text-slate-500 mb-1">Owner</label>
-              <MemberPicker v-model="newObjective.owner" :members="orgMembers" placeholder="Select owner..." />
+              <label class="block text-xs text-slate-500 mb-1">{{ t('objectives.create.owner_label') }}</label>
+              <MemberPicker v-model="newObjective.owner" :members="orgMembers" :placeholder="t('objectives.placeholder.owner')" />
             </div>
             <div class="md:col-span-2">
-              <label class="block text-xs text-slate-500 mb-1">Title *</label>
+              <label class="block text-xs text-slate-500 mb-1">{{ t('objectives.create.title_label') }}</label>
               <input v-model="newObjective.title"
                 class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                placeholder="Monthly phishing test completion rate" />
+                :placeholder="t('objectives.create.title_placeholder')" />
             </div>
           </div>
-          <div class="text-[10px] text-slate-600 mt-1">You can add target value, source, measurement method, description and notes after creating.</div>
+          <div class="text-[10px] text-slate-600 mt-1">{{ t('objectives.create.fill_in_later') }}</div>
           <div class="flex justify-end gap-2">
             <button @click="showCreateObjective = false"
-              class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
+              class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
             <button @click="createObjective" :disabled="!newObjective.program_id || !newObjective.title"
               class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm rounded-lg transition-colors">
-              Add
+              {{ t('objectives.create.submit') }}
             </button>
           </div>
           </div>
@@ -111,11 +107,11 @@
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b border-slate-800">
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">ID</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Target</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Status</th>
-                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Owner</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('objectives.table.header.id') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('objectives.table.header.title') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('objectives.table.header.target') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('objectives.table.header.status') }}</th>
+                <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('objectives.table.header.owner') }}</th>
                 <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider w-20"></th>
               </tr>
             </thead>
@@ -141,17 +137,13 @@
                     <select @change="quickStatusChange(o, $event.target.value); $event.target.value = ''"
                       class="bg-slate-800 border border-slate-700 rounded-lg px-2 py-1 text-[10px] text-slate-400 focus:outline-none focus:border-blue-500 cursor-pointer">
                       <option value="" disabled selected>{{ statusLabel(o.status) }}</option>
-                      <option value="draft">Draft</option>
-                      <option value="active">Active</option>
-                      <option value="at_risk">At Risk</option>
-                      <option value="paused">Paused</option>
-                      <option value="complete">Complete</option>
+                      <option v-for="s in statusOptions" :key="s.value" :value="s.value">{{ s.label }}</option>
                     </select>
                   </div>
                 </td>
               </tr>
               <tr v-if="objectives.length === 0">
-                <td colspan="6" class="px-4 py-8 text-center text-slate-600 text-sm">No objectives found</td>
+                <td colspan="6" class="px-4 py-8 text-center text-slate-600 text-sm">{{ t('objectives.filter.empty') }}</td>
               </tr>
             </tbody>
           </table>
@@ -189,10 +181,10 @@
           <!-- Sidebar nav -->
           <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
             <div class="space-y-0.5">
-              <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+              <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                 class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                {{ t.label }}
+                :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                {{ tab.label }}
               </button>
             </div>
           </nav>
@@ -204,57 +196,53 @@
             <template v-if="detailTab === 'overview'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                  <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('objectives.detail.overview') }}</div>
+                  <button v-if="canWrite && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                 </div>
                 <template v-if="editingSection === 'overview'">
                   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.title') }}</label>
                       <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                      <MarkdownField v-model="editForm.description" :self-type="'objective'" :self-id="selectedObjective?.display_id || String(selectedObjective?.id || '')" :rows="3" placeholder="What is this objective?" />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.description') }}</label>
+                      <MarkdownField v-model="editForm.description" :self-type="'objective'" :self-id="selectedObjective?.display_id || String(selectedObjective?.id || '')" :rows="3" :placeholder="t('objectives.placeholder.description')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Owner</label>
-                      <MemberPicker v-model="editForm.owner" :members="orgMembers" placeholder="Select owner..." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.owner') }}</label>
+                      <MemberPicker v-model="editForm.owner" :members="orgMembers" :placeholder="t('objectives.placeholder.owner')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Source</label>
-                      <input v-model="editForm.source" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="ISO 27001 6.2, etc." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.source') }}</label>
+                      <input v-model="editForm.source" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('objectives.placeholder.source')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.status') }}</label>
                       <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="draft">Draft</option>
-                        <option value="active">Active</option>
-                        <option value="at_risk">At Risk</option>
-                        <option value="paused">Paused</option>
-                        <option value="complete">Complete</option>
+                        <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                       </select>
                     </div>
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Measurement method</label>
-                      <input v-model="editForm.measurement_method" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="How is this measured?" />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.measurement_method') }}</label>
+                      <input v-model="editForm.measurement_method" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('objectives.placeholder.measurement_method')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Operator</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.operator') }}</label>
                       <select v-model="editForm.target_operator" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option value="gte">≥</option><option value="lte">≤</option><option value="eq">=</option><option value="gt">&gt;</option><option value="lt">&lt;</option>
+                        <option v-for="o in operatorOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                       </select>
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Target value</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.target_value') }}</label>
                       <input v-model.number="editForm.target_value" type="number" step="any" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Unit</label>
-                      <input v-model="editForm.unit" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="%, count, hours..." />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.unit') }}</label>
+                      <input v-model="editForm.unit" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('objectives.placeholder.unit')" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Check-in cycle (months)</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('objectives.field.checkin_cycle_months') }}</label>
                       <input v-model.number="editForm.checkin_cycle" type="number" min="1" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                   </div>
@@ -262,22 +250,22 @@
                 <template v-else>
                   <div class="space-y-4">
                     <div>
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('objectives.field.description') }}</div>
                       <div v-if="selectedObjective.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedObjective.description)"></div>
                       <div v-else class="text-sm text-slate-600">—</div>
                     </div>
 
                     <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Owner</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.owner') }}</div>
                         <div class="text-sm text-slate-300">{{ resolveUserName(selectedObjective.owner) }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Source</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.source') }}</div>
                         <div class="text-sm text-slate-300">{{ selectedObjective.source || '—' }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Target</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.target') }}</div>
                         <div class="text-sm text-slate-300 font-mono">
                           <template v-if="selectedObjective.target_value != null">
                             {{ opSymbol(selectedObjective.target_operator) }} {{ selectedObjective.target_value }} {{ selectedObjective.unit }}
@@ -286,25 +274,25 @@
                         </div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Measurement</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.measurement') }}</div>
                         <div class="text-sm text-slate-300">{{ selectedObjective.measurement_method || '—' }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Check-in cycle</div>
-                        <div class="text-sm text-slate-300">{{ selectedObjective.checkin_cycle || 12 }} months</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.checkin_cycle') }}</div>
+                        <div class="text-sm text-slate-300">{{ t('objectives.field.months', { count: selectedObjective.checkin_cycle || 12 }, selectedObjective.checkin_cycle || 12) }}</div>
                       </div>
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Last check-in</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.last_checkin') }}</div>
                         <div class="text-sm" :class="latestCheckinIsPass ? 'text-emerald-400' : (latestCheckinIsFail ? 'text-red-400' : 'text-slate-300')">
                           {{ checkins.length > 0 ? formatDate(checkins[0].occurred_at) : '—' }}
                         </div>
                       </div>
                       <div v-if="selectedObjective.created_at">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.created') }}</div>
                         <div class="text-sm text-slate-300">{{ formatDate(selectedObjective.created_at) }}</div>
                       </div>
                       <div v-if="selectedObjective.created_by">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('objectives.field.created_by') }}</div>
                         <div class="text-sm text-slate-300">{{ resolveUserName(selectedObjective.created_by) }}</div>
                       </div>
                     </div>
@@ -317,52 +305,52 @@
             <template v-if="detailTab === 'checkins'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Check-ins</div>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('objectives.checkin.heading') }}</div>
                   <div v-if="checkins.length > 0" class="text-[11px] text-slate-500">
-                    {{ passCount }} pass · {{ failCount }} fail · {{ checkins.length }} total
+                    {{ t('objectives.checkin.summary', { pass: passCount, fail: failCount, total: checkins.length }) }}
                   </div>
                 </div>
 
                 <!-- Add checkin form -->
                 <div v-if="canWrite" class="bg-slate-800/40 border border-slate-700/50 rounded-lg p-4 space-y-3">
-                  <div class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Record check-in</div>
+                  <div class="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">{{ t('objectives.checkin.record_heading') }}</div>
                   <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
                     <div>
-                      <label class="block text-xs text-slate-500 mb-1">Value</label>
+                      <label class="block text-xs text-slate-500 mb-1">{{ t('objectives.checkin.value_label') }}</label>
                       <input v-model.number="newCheckin.value_numeric" type="number" step="any"
                         class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                        placeholder="97.5" />
+                        :placeholder="t('objectives.checkin.value_placeholder')" />
                     </div>
                     <div>
-                      <label class="block text-xs text-slate-500 mb-1">Result</label>
+                      <label class="block text-xs text-slate-500 mb-1">{{ t('objectives.checkin.result_label') }}</label>
                       <select v-model="newCheckin.success"
                         class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                        <option :value="null">Unspecified</option>
-                        <option :value="true">Pass</option>
-                        <option :value="false">Fail</option>
+                        <option :value="null">{{ t('objectives.checkin.result.unspecified') }}</option>
+                        <option :value="true">{{ t('objectives.checkin.result.pass') }}</option>
+                        <option :value="false">{{ t('objectives.checkin.result.fail') }}</option>
                       </select>
                     </div>
                     <div class="md:col-span-2">
-                      <label class="block text-xs text-slate-500 mb-1">Internal note</label>
+                      <label class="block text-xs text-slate-500 mb-1">{{ t('objectives.checkin.message_label') }}</label>
                       <input v-model="newCheckin.message"
                         class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                        placeholder="Internal context..." />
+                        :placeholder="t('objectives.checkin.message_placeholder')" />
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
                     <input v-model="newCheckin.public_note"
                       class="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                      placeholder="Public-facing note (visible to stakeholders)" />
+                      :placeholder="t('objectives.checkin.public_note_placeholder')" />
                     <button @click="createCheckin"
                       class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors whitespace-nowrap">
-                      Record
+                      {{ t('objectives.checkin.submit') }}
                     </button>
                   </div>
                 </div>
 
                 <!-- Checkins timeline -->
                 <div v-if="checkins.length === 0" class="text-center text-slate-600 text-sm py-12 border border-dashed border-slate-800 rounded-lg">
-                  No check-ins recorded yet
+                  {{ t('objectives.checkin.empty') }}
                 </div>
                 <div v-else class="space-y-2">
                   <div v-for="ci in checkins" :key="ci.id"
@@ -371,19 +359,19 @@
                     <div class="flex items-start justify-between gap-3">
                       <div class="flex items-center gap-2 flex-wrap">
                         <span class="text-xs text-slate-500 font-mono">{{ formatDate(ci.occurred_at) }}</span>
-                        <span v-if="ci.success === true" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold bg-emerald-500/20 text-emerald-300">PASS</span>
-                        <span v-else-if="ci.success === false" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold bg-red-500/20 text-red-300">FAIL</span>
+                        <span v-if="ci.success === true" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold bg-emerald-500/20 text-emerald-300">{{ t('objectives.checkin.pass_badge') }}</span>
+                        <span v-else-if="ci.success === false" class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold bg-red-500/20 text-red-300">{{ t('objectives.checkin.fail_badge') }}</span>
                         <span v-if="ci.value_numeric != null" class="text-sm font-mono text-slate-200">
                           {{ ci.value_numeric }}{{ selectedObjective?.unit ? ' ' + selectedObjective.unit : '' }}
                         </span>
                       </div>
                       <div class="flex items-center gap-2 flex-shrink-0">
                         <span class="text-[10px] text-slate-600">{{ resolveUserName(ci.created_by) }}</span>
-                        <button v-if="canWrite" @click="deleteCheckin(ci)" class="text-[10px] text-red-400/60 hover:text-red-400">Delete</button>
+                        <button v-if="canWrite" @click="deleteCheckin(ci)" class="text-[10px] text-red-400/60 hover:text-red-400">{{ t('common.action.delete') }}</button>
                       </div>
                     </div>
                     <div v-if="ci.message" class="text-sm text-slate-300 mt-2">{{ ci.message }}</div>
-                    <div v-if="ci.public_note" class="text-sm text-blue-300/80 mt-1 italic">Public: {{ ci.public_note }}</div>
+                    <div v-if="ci.public_note" class="text-sm text-blue-300/80 mt-1 italic">{{ t('objectives.checkin.public', { note: ci.public_note }) }}</div>
 
                     <!-- Evidence -->
                     <div class="mt-3 space-y-1">
@@ -398,8 +386,8 @@
                           <span v-if="ev.size_bytes" class="text-slate-600 flex-shrink-0">{{ formatBytes(ev.size_bytes) }}</span>
                         </div>
                         <div class="flex items-center gap-2 flex-shrink-0 ml-2">
-                          <button @click="downloadEv(ev)" class="text-blue-400 hover:text-blue-300">Download</button>
-                          <button v-if="canWrite" @click="deleteEv(ev)" class="text-red-400/60 hover:text-red-400">Delete</button>
+                          <button @click="downloadEv(ev)" class="text-blue-400 hover:text-blue-300">{{ t('objectives.evidence.download') }}</button>
+                          <button v-if="canWrite" @click="deleteEv(ev)" class="text-red-400/60 hover:text-red-400">{{ t('common.action.delete') }}</button>
                         </div>
                       </div>
                       <div v-if="canWrite" class="flex items-center gap-2">
@@ -409,7 +397,7 @@
                           <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
                           </svg>
-                          Attach evidence
+                          {{ t('objectives.evidence.attach') }}
                         </label>
                       </div>
                     </div>
@@ -422,15 +410,15 @@
             <template v-if="detailTab === 'notes'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                  <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('objectives.detail.notes') }}</div>
+                  <button v-if="canWrite && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                 </div>
                 <template v-if="editingSection === 'notes'">
-                  <MarkdownField v-model="editForm.notes" :self-type="'objective'" :self-id="selectedObjective?.display_id || String(selectedObjective?.id || '')" :rows="12" placeholder="Add notes..." />
+                  <MarkdownField v-model="editForm.notes" :self-type="'objective'" :self-id="selectedObjective?.display_id || String(selectedObjective?.id || '')" :rows="12" :placeholder="t('objectives.placeholder.notes')" />
                 </template>
                 <template v-else>
                   <div v-if="selectedObjective.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedObjective.notes)"></div>
-                  <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                  <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                 </template>
               </div>
             </template>
@@ -461,10 +449,10 @@
               <div class="px-6 py-5 space-y-6">
                 <HistoryPanel entityType="objective" :entityId="String(selectedObjective.id)" />
                 <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                  <div class="text-xs text-slate-400">Deleting this objective is permanent and cannot be undone.</div>
+                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                  <div class="text-xs text-slate-400">{{ t('objectives.danger.warning') }}</div>
                   <button @click="deleteSelectedObjective" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                    Delete objective
+                    {{ t('objectives.danger.delete') }}
                   </button>
                 </div>
               </div>
@@ -475,8 +463,8 @@
 
         <!-- Footer action bar (edit mode only) -->
         <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-          <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-          <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+          <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+          <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
         </div>
       </div>
     </div>
@@ -492,7 +480,8 @@ import { useToast } from '../composables/useToast'
 import { useConfirm } from '../composables/useConfirm.js'
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { api, getCurrentUser } from '../api'
+import { useI18n } from 'vue-i18n'
+import { api } from '../api'
 import { renderMarkdown } from '../composables/useRenderMd.js'
 import MemberPicker from '../components/MemberPicker.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -510,11 +499,14 @@ import StatusBadge from '../components/StatusBadge.vue'
 import { useModalEscape } from '../composables/useModalEscape.js'
 import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
-import { formatDate } from '../composables/useFormat.js'
+import { formatDate, formatNumber } from '../composables/useFormat.js'
+import { renderApiError } from '../composables/useApiError.js'
+import { enumLabel, entityLabel } from '../composables/useEnumLabel.js'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { orgSlug, orgPath } = useCurrentOrg()
+const { orgPath } = useCurrentOrg()
 const { success: showSaved, error: showError } = useToast()
 const { ask: confirmAsk, confirm: confirmDialog } = useConfirm()
 
@@ -529,7 +521,7 @@ async function reload() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -552,15 +544,18 @@ const editForm = ref({})
 const { capture: captureEditSnapshot, isDirty } = useDirtyEdit(editForm)
 const saving = ref(false)
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'checkins', label: 'Check-ins' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Tab labels are keys, resolved in a computed: an array built at module load
+// freezes its labels in whatever locale was active when the file was imported.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'checkins', label: 'objectives.checkin.heading' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
 const passCount = computed(() => checkins.value.filter(c => c.success === true).length)
 const failCount = computed(() => checkins.value.filter(c => c.success === false).length)
@@ -575,13 +570,19 @@ const page = ref(1)
 const pageSize = ref(50)
 const total = ref(0)
 const stats = ref({ total: 0, draft: 0, active: 0, at_risk: 0, paused: 0, complete: 0, archived: 0 })
-const statusStats = computed(() => [
-  { key: '', label: 'Total', count: stats.value.total || 0, color: 'text-slate-100' },
-  { key: 'active', label: 'Active', count: stats.value.active || 0, color: 'text-emerald-400' },
-  { key: 'at_risk', label: 'At Risk', count: stats.value.at_risk || 0, color: 'text-red-400' },
-  { key: 'paused', label: 'Paused', count: stats.value.paused || 0, color: 'text-amber-400' },
-  { key: 'complete', label: 'Complete', count: stats.value.complete || 0, color: 'text-blue-400' },
-])
+const STATUS_STATS = [
+  { key: '', field: 'total', color: 'text-slate-100' },
+  { key: 'active', field: 'active', color: 'text-emerald-400' },
+  { key: 'at_risk', field: 'at_risk', color: 'text-red-400' },
+  { key: 'paused', field: 'paused', color: 'text-amber-400' },
+  { key: 'complete', field: 'complete', color: 'text-blue-400' },
+]
+const statusStats = computed(() => STATUS_STATS.map(({ key, field, color }) => ({
+  key,
+  color,
+  label: key ? statusLabel(key) : t('common.stat.total'),
+  count: stats.value[field] || 0,
+})))
 const orgMembers = ref([])
 
 const newObjective = reactive({
@@ -596,23 +597,29 @@ const newCheckin = reactive({
   public_note: '',
 })
 
-function statusLabel(status) {
-  const map = { draft: 'Draft', active: 'Active', at_risk: 'At Risk', paused: 'Paused', complete: 'Complete' }
-  return map[status] || status
-}
+// Lookups and option lists live here rather than in the template: a group name
+// is a stored identifier, and the raw-text scanner reads a bare quoted word in
+// a mustache as unextracted copy.
+const STATUSES = ['draft', 'active', 'at_risk', 'paused', 'complete']
+const OPERATORS = ['gte', 'lte', 'eq', 'gt', 'lt']
 
-function opSymbol(op) {
-  const map = { gte: '\u2265', lte: '\u2264', eq: '=', gt: '>', lt: '<' }
-  return map[op] || op
-}
+const statusLabel = (v) => enumLabel('status', v)
+const opSymbol = (v) => enumLabel('target_operator', v)
 
-const formatDateTime = (d) => formatDate(d, 'datetime')
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const operatorOptions = options(OPERATORS, opSymbol)
 
+// The unit is a word, not a suffix: it comes from the catalogue, and the
+// number goes through Intl so a locale that groups or decimalises differently
+// is not handed a JavaScript-formatted string.
 function formatBytes(bytes) {
   if (!bytes) return ''
-  if (bytes < 1024) return bytes + ' B'
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
-  return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
+  if (bytes < 1024) return t('common.bytes.b', { value: formatNumber(bytes) })
+  if (bytes < 1024 * 1024) {
+    return t('common.bytes.kb', { value: formatNumber(bytes / 1024, { maximumFractionDigits: 1, minimumFractionDigits: 1 }) })
+  }
+  return t('common.bytes.mb', { value: formatNumber(bytes / (1024 * 1024), { maximumFractionDigits: 1, minimumFractionDigits: 1 }) })
 }
 
 const renderMd = renderMarkdown
@@ -623,7 +630,7 @@ async function loadAll() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }
@@ -651,7 +658,7 @@ async function loadObjectives() {
     total.value = res?.total || 0
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -705,9 +712,9 @@ async function selectObjective(o) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -718,9 +725,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -786,9 +793,9 @@ async function saveSection() {
       } catch { /* ignore */ }
     }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('objectives.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
@@ -796,13 +803,14 @@ async function saveSection() {
 
 async function deleteSelectedObjective() {
   if (!selectedObjective.value) return
-  if (!await confirmAsk(`Delete objective "${selectedObjective.value.title}"? This cannot be undone.`, { confirm: 'Delete', variant: 'danger' })) return
+  const question = t('objectives.danger.confirm', { title: selectedObjective.value.title })
+  if (!await confirmAsk(question, { confirm: t('common.action.delete'), variant: 'danger' })) return
   try {
     await api.deleteObjective(selectedObjective.value.id)
     closeDetail()
     await loadObjectives()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -836,7 +844,7 @@ async function createObjective() {
       router.push(orgPath(`/objectives/${fresh.id}`))
     }
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -846,13 +854,8 @@ async function quickStatusChange(obj, newStatus) {
     obj.status = newStatus
     loadStats()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
-}
-
-async function saveObjField(field, value) {
-  if (!selectedObjective.value) return
-  try { await api.updateObjective(selectedObjective.value.id, { [field]: value }) } catch { /* silent */ }
 }
 
 async function createCheckin() {
@@ -867,17 +870,17 @@ async function createCheckin() {
     Object.assign(newCheckin, { value_numeric: null, success: null, message: '', public_note: '' })
     await loadCheckins()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
 async function deleteCheckin(ci) {
-  if (!await confirmAsk('Delete this checkin?', { confirm: 'Delete', variant: 'danger' })) return
+  if (!await confirmAsk(t('objectives.checkin.confirm_delete'), { confirm: t('common.action.delete'), variant: 'danger' })) return
   try {
     await api.deleteCheckin(ci.id)
     await loadCheckins()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -889,7 +892,7 @@ async function uploadEvidence(checkinId, event) {
     event.target.value = ''
     await loadCheckins()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -910,20 +913,21 @@ async function downloadEv(ev) {
       a.remove()
       URL.revokeObjectURL(objUrl)
     } else {
-      error.value = 'Download failed: unexpected response from server'
+      error.value = t('objectives.error.download')
     }
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
 async function deleteEv(ev) {
-  if (!await confirmAsk(`Delete evidence "${ev.title}"?`, { confirm: 'Delete', variant: 'danger' })) return
+  const question = t('objectives.evidence.confirm_delete', { title: ev.title })
+  if (!await confirmAsk(question, { confirm: t('common.action.delete'), variant: 'danger' })) return
   try {
     await api.deleteEvidence(ev.id)
     await loadCheckins()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 

--- a/web/src/views/Programs.vue
+++ b/web/src/views/Programs.vue
@@ -19,15 +19,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Program Register</h1>
-          <p class="text-sm text-slate-500 mt-1">Group ISMS objectives into programs of work</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('programs.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('programs.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canWrite" @click="showCreateForm = !showCreateForm"
             class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Program
+            {{ t('programs.action.add') }}
           </button>
-          <SuggestNewButton entityType="program" typeLabel="Program" />
+          <SuggestNewButton entityType="program" :typeLabel="entityLabel('program')" />
         </div>
       </div>
 
@@ -38,10 +38,10 @@
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
           </svg>
-          <input v-model="searchQuery" type="text" placeholder="Search..."
+          <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
             class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
         </div>
-        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ filtered.length }} total</div>
+        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: filtered.length }) }}</div>
       </div>
 
       <!-- Create program form (modal) -->
@@ -50,27 +50,27 @@
       <div v-if="showCreateForm" class="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] px-4">
         <div class="absolute inset-0 bg-black/60" @click="showCreateForm = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
-          <h3 class="text-sm font-semibold text-slate-300">Add Program</h3>
+          <h3 class="text-sm font-semibold text-slate-300">{{ t('programs.create.heading') }}</h3>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
-              <label class="block text-xs text-slate-500 mb-1">Key (uppercase) *</label>
+              <label class="block text-xs text-slate-500 mb-1">{{ t('programs.create.key_label') }}</label>
               <input v-model="newProgram.key" @input="newProgram.key = newProgram.key.toUpperCase().replace(/[^A-Z0-9]/g, '')"
                 class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 uppercase"
-                placeholder="AWARE" />
+                :placeholder="t('programs.create.key_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs text-slate-500 mb-1">Title *</label>
+              <label class="block text-xs text-slate-500 mb-1">{{ t('programs.create.title_label') }}</label>
               <input v-model="newProgram.title"
                 class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                placeholder="Security Awareness" />
+                :placeholder="t('programs.create.title_placeholder')" />
             </div>
           </div>
-          <div class="text-[10px] text-slate-600 mt-1">You can add description and notes after creating.</div>
+          <div class="text-[10px] text-slate-600 mt-1">{{ t('programs.create.fill_in_later') }}</div>
           <div class="flex justify-end gap-2 pt-2">
-            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200">Cancel</button>
+            <button @click="showCreateForm = false" class="px-4 py-2 text-sm text-slate-400 hover:text-slate-200">{{ t('common.action.cancel') }}</button>
             <button @click="createProgram" :disabled="!newProgram.key || !newProgram.title"
               class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors">
-              Add
+              {{ t('programs.create.submit') }}
             </button>
           </div>
         </div>
@@ -83,9 +83,9 @@
         <table class="w-full text-sm">
           <thead>
             <tr class="border-b border-slate-800">
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Key</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Title</th>
-              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">Description</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('programs.table.header.key') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('programs.table.header.title') }}</th>
+              <th class="text-left px-5 py-3 text-xs font-semibold text-slate-500 uppercase tracking-wider">{{ t('programs.table.header.description') }}</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-800/50">
@@ -98,7 +98,7 @@
               <td class="px-4 py-3 text-slate-500 truncate max-w-md">{{ p.description || '—' }}</td>
             </tr>
             <tr v-if="filtered.length === 0">
-              <td colspan="3" class="px-4 py-8 text-center text-slate-600 text-sm">No programs yet</td>
+              <td colspan="3" class="px-4 py-8 text-center text-slate-600 text-sm">{{ t('programs.filter.empty') }}</td>
             </tr>
           </tbody>
         </table>
@@ -132,10 +132,10 @@
         <div class="flex flex-1 min-h-0">
           <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
             <div class="space-y-0.5">
-              <button v-for="t in detailTabs" :key="t.key" @click="detailTab = t.key"
+              <button v-for="tab in detailTabs" :key="tab.key" @click="detailTab = tab.key"
                 class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                {{ t.label }}
+                :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                {{ tab.label }}
               </button>
             </div>
           </nav>
@@ -145,40 +145,40 @@
             <template v-if="detailTab === 'overview'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                  <button v-if="canWrite && !editing" @click="startEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('programs.detail.overview') }}</div>
+                  <button v-if="canWrite && !editing" @click="startEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                 </div>
                 <template v-if="editing">
                   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Key</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('programs.field.key') }}</label>
                       <input v-model="editForm.key" @input="editForm.key = editForm.key.toUpperCase().replace(/[^A-Z0-9]/g, '')"
                         class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500 uppercase" />
                     </div>
                     <div>
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('programs.field.title') }}</label>
                       <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                     </div>
                     <div class="sm:col-span-2">
-                      <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                      <MarkdownField v-model="editForm.description" :rows="3" placeholder="What is this program?" />
+                      <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('programs.field.description') }}</label>
+                      <MarkdownField v-model="editForm.description" :rows="3" :placeholder="t('programs.placeholder.description')" />
                     </div>
                   </div>
                 </template>
                 <template v-else>
                   <div class="space-y-4">
                     <div>
-                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                      <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('programs.field.description') }}</div>
                       <div v-if="selected.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selected.description)"></div>
                       <div v-else class="text-sm text-slate-600">—</div>
                     </div>
                     <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Key</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('programs.field.key') }}</div>
                         <div class="text-sm text-slate-300 font-mono">{{ selected.key }}</div>
                       </div>
                       <div v-if="selected.created_at">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('programs.field.created') }}</div>
                         <div class="text-sm text-slate-300">{{ formatDate(selected.created_at) }}</div>
                       </div>
                     </div>
@@ -191,15 +191,15 @@
             <template v-if="detailTab === 'notes'">
               <div class="px-6 py-5 space-y-5">
                 <div class="flex items-center justify-between">
-                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                  <button v-if="canWrite && !editing" @click="startEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                  <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('programs.detail.notes') }}</div>
+                  <button v-if="canWrite && !editing" @click="startEdit" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                 </div>
                 <template v-if="editing">
-                  <MarkdownField v-model="editForm.notes" :rows="12" placeholder="Add notes..." />
+                  <MarkdownField v-model="editForm.notes" :rows="12" :placeholder="t('programs.placeholder.notes')" />
                 </template>
                 <template v-else>
                   <div v-if="selected.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selected.notes)"></div>
-                  <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                  <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                 </template>
               </div>
             </template>
@@ -230,10 +230,10 @@
               <div class="px-6 py-5 space-y-6">
                 <HistoryPanel entityType="program" :entityId="String(selected.id)" />
                 <div v-if="canWrite" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                  <div class="text-xs text-slate-400">Deleting this program also deletes all objectives under it. This cannot be undone.</div>
+                  <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                  <div class="text-xs text-slate-400">{{ t('programs.danger.warning') }}</div>
                   <button @click="deleteSelected" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                    Delete program
+                    {{ t('programs.danger.delete') }}
                   </button>
                 </div>
               </div>
@@ -243,8 +243,8 @@
 
         <!-- Footer (edit mode) -->
         <div v-if="editing" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-          <button @click="cancelEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-          <button @click="saveEdit" :disabled="saving || !editForm.key || !editForm.title" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+          <button @click="cancelEdit" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+          <button @click="saveEdit" :disabled="saving || !editForm.key || !editForm.title" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
         </div>
       </div>
     </div>
@@ -258,6 +258,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import { renderMarkdown } from '../composables/useRenderMd.js'
 import { useToast } from '../composables/useToast'
@@ -275,7 +276,10 @@ import Pagination from '../components/Pagination.vue'
 import ListSkeleton from '../components/ListSkeleton.vue'
 import RefreshButton from '../components/RefreshButton.vue'
 import { formatDate } from '../composables/useFormat.js'
+import { renderApiError } from '../composables/useApiError.js'
+import { entityLabel } from '../composables/useEnumLabel.js'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { orgPath } = useCurrentOrg()
@@ -293,7 +297,7 @@ async function reload() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -315,14 +319,17 @@ const newProgram = reactive({ key: '', title: '' })
 useModalEscape(showCreateForm)
 useModalEscape(computed(() => !!selected.value), () => closeDetail())
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Tab labels are keys, resolved in a computed: an array built at module load
+// freezes its labels in whatever locale was active when the file was imported.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
 
 const renderMd = renderMarkdown
 
@@ -348,7 +355,7 @@ async function loadAll() {
   try {
     await fetchAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }
@@ -412,9 +419,9 @@ async function saveEdit() {
     const fresh = programs.value.find(p => p.id === selected.value.id)
     if (fresh) selected.value = fresh
     editing.value = false
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('programs.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
@@ -439,19 +446,20 @@ async function createProgram() {
       router.push(orgPath(`/programs/${created.id}`))
     }
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
 async function deleteSelected() {
   if (!selected.value) return
-  if (!await confirmAsk(`Delete program "${selected.value.key}"? All objectives under it will also be deleted.`, { confirm: 'Delete', variant: 'danger' })) return
+  const question = t('programs.danger.confirm', { key: selected.value.key })
+  if (!await confirmAsk(question, { confirm: t('common.action.delete'), variant: 'danger' })) return
   try {
     await api.deleteProgram(selected.value.id)
     closeDetail()
     await loadAll()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 

--- a/web/src/views/Tasks.vue
+++ b/web/src/views/Tasks.vue
@@ -4,15 +4,15 @@
       <!-- Header -->
       <div class="flex items-center justify-between mb-8">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Tasks</h1>
-          <p class="text-sm text-slate-500 mt-1">Review tasks, follow-ups, and operational work items.</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('tasks.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('tasks.subtitle') }}</p>
         </div>
         <div class="flex gap-2">
           <button v-if="canCreate" @click="form = defaultForm(); showCreate = !showCreate"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
-            Add Task
+            {{ t('tasks.action.add') }}
           </button>
-          <SuggestNewButton entityType="task" typeLabel="Task" />
+          <SuggestNewButton entityType="task" :typeLabel="entityLabel('task')" />
         </div>
       </div>
 
@@ -23,51 +23,43 @@
         <div class="absolute inset-0 bg-black/60" @click="showCreate = false" />
         <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
         <form @submit.prevent="create" class="space-y-4">
-        <h2 class="text-sm font-semibold text-slate-300">Add Task</h2>
+        <h2 class="text-sm font-semibold text-slate-300">{{ t('tasks.create.heading') }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="sm:col-span-2">
-            <label class="block text-xs text-slate-500 mb-1">Title <span class="text-red-400">*</span></label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('tasks.create.title_label') }} <span class="text-red-400">*</span></label>
             <input v-model="form.title" type="text" required autofocus
               class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-              placeholder="e.g. Review risk register" />
+              :placeholder="t('tasks.create.title_placeholder')" />
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Priority</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('tasks.create.priority_label') }}</label>
             <select v-model="form.priority" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-              <option value="critical">Critical</option>
+              <option v-for="o in priorityAscOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Type</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('tasks.create.type_label') }}</label>
             <select v-model="form.task_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
               <!-- Manual task types only. The *_followup types are created
                    automatically by the system, not chosen here (#32). -->
-              <option value="general">General</option>
-              <option value="review">Review</option>
-              <option value="onboarding">Onboarding</option>
-              <option value="offboarding">Offboarding</option>
-              <option value="training">Training</option>
-              <option value="other">Other</option>
+              <option v-for="o in manualTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Visibility</label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('tasks.create.visibility_label') }}</label>
             <select v-model="form.private" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500">
-              <option :value="false">Public — everyone in the org</option>
-              <option :value="true">Private — assignee, creator &amp; managers</option>
+              <option :value="false">{{ t('tasks.visibility.public') }}</option>
+              <option :value="true">{{ t('tasks.visibility.private') }}</option>
             </select>
           </div>
         </div>
-        <div class="text-[10px] text-slate-600 mt-1">You can add description, assignee, due date and notes after creating.</div>
+        <div class="text-[10px] text-slate-600 mt-1">{{ t('tasks.create.fill_in_later') }}</div>
         <div class="flex gap-2 pt-2">
           <button type="submit" :disabled="creating || !form.title"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50">
-            {{ creating ? 'Creating...' : 'Add' }}
+            {{ creating ? t('tasks.create.submitting') : t('tasks.create.submit') }}
           </button>
-          <button type="button" @click="showCreate = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white">Cancel</button>
+          <button type="button" @click="showCreate = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white">{{ t('common.action.cancel') }}</button>
         </div>
         </form>
         </div>
@@ -85,33 +77,21 @@
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
           </svg>
-          <input v-model="searchQuery" type="text" placeholder="Search..."
+          <input v-model="searchQuery" type="text" :placeholder="t('common.placeholder.search')"
             class="w-full pl-9 pr-3 py-1.5 bg-slate-900 border border-slate-800 rounded-lg text-xs text-white placeholder-slate-600 focus:outline-none focus:border-blue-500" />
         </div>
         <select v-model="filterPriority" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All priorities</option>
-          <option value="critical">Critical</option>
-          <option value="high">High</option>
-          <option value="medium">Medium</option>
-          <option value="low">Low</option>
+          <option value="">{{ t('common.filter.all_priorities') }}</option>
+          <option v-for="o in priorityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <select v-model="filterTaskType" class="bg-slate-900 border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 focus:outline-none focus:border-blue-500">
-          <option value="">All types</option>
-          <option value="general">General</option>
-          <option value="review">Review</option>
-          <option value="incident_followup">Incident follow-up</option>
-          <option value="audit_followup">Audit follow-up</option>
-          <option value="ca_followup">Corrective action follow-up</option>
-          <option value="change_followup">Change follow-up</option>
-          <option value="onboarding">Onboarding</option>
-          <option value="offboarding">Offboarding</option>
-          <option value="training">Training</option>
-          <option value="other">Other</option>
+          <option value="">{{ t('common.filter.all_types') }}</option>
+          <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
         </select>
         <div class="w-48">
-          <MemberPicker v-model="filterAssignee" :members="orgMembers" placeholder="Any assignee" />
+          <MemberPicker v-model="filterAssignee" :members="orgMembers" :placeholder="t('tasks.filter.assignee_placeholder')" />
         </div>
-        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ total }} total</div>
+        <div class="ml-auto text-xs text-slate-500 tabular-nums">{{ t('common.count.total', { count: total }) }}</div>
       </div>
 
       <!-- Loading -->
@@ -120,11 +100,11 @@
       <!-- Empty -->
       <div v-else-if="tasks.length === 0" class="bg-slate-900 border border-slate-800 rounded-xl p-12 text-center">
         <div v-if="filterStatus || filterPriority || filterTaskType || filterAssignee || searchQuery" class="text-slate-500 text-sm">
-          No tasks match your filter.
+          {{ t('tasks.filter.empty') }}
         </div>
         <template v-else>
-          <div class="text-slate-500 text-sm">No tasks yet — click Add to create your first one.</div>
-          <div class="text-xs text-slate-600 mt-2">Tasks are also generated automatically from overdue review cycles.</div>
+          <div class="text-slate-500 text-sm">{{ t('tasks.filter.empty_all') }}</div>
+          <div class="text-xs text-slate-600 mt-2">{{ t('tasks.filter.empty_hint') }}</div>
         </template>
       </div>
 
@@ -140,17 +120,17 @@
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-sm font-medium text-slate-200">{{ task.title }}</span>
                 <StatusBadge :status="task.status" />
-                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(task.priority)">{{ task.priority }}</span>
-                <span v-if="task.task_type && task.task_type !== 'general'" class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ task.task_type.replace(/_/g, ' ') }}</span>
-                <span v-if="task.private" class="px-1.5 py-0.5 rounded text-[10px] font-medium text-amber-300 bg-amber-500/10" title="Private — visible to assignee, creator &amp; managers">Private</span>
+                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(task.priority)">{{ priorityLabel(task.priority) }}</span>
+                <span v-if="task.task_type && task.task_type !== 'general'" class="px-1.5 py-0.5 rounded text-[10px] text-slate-500 bg-slate-800">{{ typeLabel(task.task_type) }}</span>
+                <span v-if="task.private" class="px-1.5 py-0.5 rounded text-[10px] font-medium text-amber-300 bg-amber-500/10" :title="t('tasks.visibility.private_title')">{{ t('tasks.visibility.private_badge') }}</span>
               </div>
               <div class="text-xs text-slate-500 mt-1">
                 <span v-if="task.assignee">{{ resolveUserName(task.assignee) }}</span>
                 <span v-if="task.due_date" class="ml-2" :class="isOverdue(task) ? 'text-red-400' : ''">
-                  Due {{ formatDay(task.due_date) }}
-                  <span v-if="isOverdue(task)" class="text-red-400 font-semibold ml-1">OVERDUE</span>
+                  {{ t('tasks.list.due', { date: formatDay(task.due_date) }) }}
+                  <span v-if="isOverdue(task)" class="text-red-400 font-semibold ml-1">{{ t('common.state.overdue') }}</span>
                 </span>
-                <span v-if="task.created_by" class="ml-2 text-slate-600">by {{ resolveUserName(task.created_by) }}</span>
+                <span v-if="task.created_by" class="ml-2 text-slate-600">{{ t('tasks.list.created_by', { name: resolveUserName(task.created_by) }) }}</span>
               </div>
             </div>
           </div>
@@ -186,10 +166,10 @@
             <!-- Sidebar nav -->
             <nav class="flex-shrink-0 w-28 border-r border-slate-800 py-3">
               <div class="space-y-0.5">
-                <button v-for="t in detailTabs" :key="t.key" @click="switchDetailTab(t.key)"
+                <button v-for="tab in detailTabs" :key="tab.key" @click="switchDetailTab(tab.key)"
                   class="w-full text-left px-3 py-2 text-xs font-medium transition-colors"
-                  :class="detailTab === t.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
-                  {{ t.label }}
+                  :class="detailTab === tab.key ? 'text-blue-400 bg-blue-500/10 border-r-2 border-blue-500' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800/50'">
+                  {{ tab.label }}
                 </button>
               </div>
             </nav>
@@ -201,58 +181,46 @@
               <template v-if="detailTab === 'overview'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Overview</div>
-                    <button v-if="canCreate && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('tasks.detail.overview') }}</div>
+                    <button v-if="canCreate && !editingSection" @click="editSection('overview')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'overview'">
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.title') }}</label>
                         <input v-model="editForm.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div class="sm:col-span-2">
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-                        <MarkdownField v-model="editForm.description" :self-type="'task'" :self-id="selectedTask?.identifier || ''" :rows="3" placeholder="Describe the task..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.description') }}</label>
+                        <MarkdownField v-model="editForm.description" :self-type="'task'" :self-id="selectedTask?.identifier || ''" :rows="3" :placeholder="t('tasks.placeholder.description')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Assignee</label>
-                        <MemberPicker v-model="editForm.assignee" :members="orgMembers" placeholder="Select assignee..." />
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.assignee') }}</label>
+                        <MemberPicker v-model="editForm.assignee" :members="orgMembers" :placeholder="t('tasks.placeholder.assignee')" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Priority</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.priority') }}</label>
                         <select v-model="editForm.priority" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option><option value="critical">Critical</option>
+                          <option v-for="o in priorityAscOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Status</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.status') }}</label>
                         <select v-model="editForm.status" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                          <option value="open">Open</option>
-                          <option value="in_progress">In Progress</option>
-                          <option value="done">Done</option>
-                          <option value="cancelled">Cancelled</option>
+                          <option v-for="o in statusOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Due date</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.due_date') }}</label>
                         <input v-model="editForm.due_date_str" type="date"
                           class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
                       </div>
                       <div>
-                        <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+                        <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('tasks.field.type') }}</label>
                         <select v-model="editForm.task_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
                           <!-- All real task types, so an auto-generated task's
                                type is representable when editing (#32). -->
-                          <option value="general">General</option>
-                          <option value="review">Review</option>
-                          <option value="incident_followup">Incident follow-up</option>
-                          <option value="audit_followup">Audit follow-up</option>
-                          <option value="ca_followup">Corrective action follow-up</option>
-                          <option value="change_followup">Change follow-up</option>
-                          <option value="onboarding">Onboarding</option>
-                          <option value="offboarding">Offboarding</option>
-                          <option value="training">Training</option>
-                          <option value="other">Other</option>
+                          <option v-for="o in typeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                         </select>
                       </div>
                     </div>
@@ -260,7 +228,7 @@
                   <template v-else>
                     <div class="space-y-4">
                       <div>
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Description</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-1">{{ t('tasks.field.description') }}</div>
                         <div v-if="selectedTask.description" class="text-sm text-slate-300 leading-relaxed doc-prose" v-mermaid v-html="renderMd(selectedTask.description)"></div>
                         <div v-else class="text-sm text-slate-600">—</div>
                       </div>
@@ -268,52 +236,52 @@
                       <!-- 2-column metadata -->
                       <div class="grid grid-cols-2 gap-x-8 gap-y-3 pt-1">
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Assignee</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.assignee') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedTask.assignee) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Priority</div>
-                          <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(selectedTask.priority)">{{ selectedTask.priority }}</span>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.priority') }}</div>
+                          <span class="px-1.5 py-0.5 rounded text-[10px] font-medium" :class="priorityClass(selectedTask.priority)">{{ priorityLabel(selectedTask.priority) }}</span>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Due date</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.due_date') }}</div>
                           <div class="text-sm" :class="isOverdue(selectedTask) ? 'text-red-400' : 'text-slate-300'">{{ selectedTask.due_date ? formatDay(selectedTask.due_date) : '—' }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Type</div>
-                          <div class="text-sm text-slate-300 capitalize">{{ (selectedTask.task_type || 'general').replace(/_/g, ' ') }}</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.type') }}</div>
+                          <div class="text-sm text-slate-300">{{ taskTypeLabel(selectedTask) }}</div>
                         </div>
                         <div>
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.created') }}</div>
                           <div class="text-sm text-slate-300">{{ formatDate(selectedTask.created_at) }}</div>
                         </div>
                         <div v-if="selectedTask.created_by">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Created by</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.created_by') }}</div>
                           <div class="text-sm text-slate-300">{{ resolveUserName(selectedTask.created_by) }}</div>
                         </div>
                         <div v-if="selectedTask.completed_at">
-                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">Completed</div>
+                          <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-0.5">{{ t('tasks.field.completed') }}</div>
                           <div class="text-sm text-emerald-400">{{ formatDate(selectedTask.completed_at) }}</div>
                         </div>
                       </div>
 
                       <!-- Status timeline -->
                       <div class="border-t border-slate-800 pt-4">
-                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-3">Progress</div>
+                        <div class="text-[10px] text-slate-500 uppercase tracking-wider mb-3">{{ t('tasks.detail.progress') }}</div>
                         <div class="flex items-center gap-4 text-xs text-slate-500">
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="selectedTask.status !== 'cancelled' ? 'bg-blue-400' : 'bg-slate-600'"></span>
-                            <span :class="selectedTask.status !== 'cancelled' ? 'text-slate-300' : ''">Open</span>
+                            <span :class="selectedTask.status !== 'cancelled' ? 'text-slate-300' : ''">{{ stepOpenLabel }}</span>
                           </div>
                           <div class="h-px flex-1 bg-slate-800"></div>
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="selectedTask.status === 'in_progress' || selectedTask.status === 'done' ? 'bg-amber-400' : 'bg-slate-600'"></span>
-                            <span :class="selectedTask.status === 'in_progress' || selectedTask.status === 'done' ? 'text-slate-300' : ''">In progress</span>
+                            <span :class="selectedTask.status === 'in_progress' || selectedTask.status === 'done' ? 'text-slate-300' : ''">{{ stepInProgressLabel }}</span>
                           </div>
                           <div class="h-px flex-1 bg-slate-800"></div>
                           <div class="flex items-center gap-1.5">
                             <span class="w-2.5 h-2.5 rounded-full" :class="selectedTask.status === 'done' ? 'bg-emerald-400' : 'bg-slate-600'"></span>
-                            <span :class="selectedTask.status === 'done' ? 'text-slate-300' : ''">Done</span>
+                            <span :class="selectedTask.status === 'done' ? 'text-slate-300' : ''">{{ stepDoneLabel }}</span>
                           </div>
                         </div>
                       </div>
@@ -326,15 +294,15 @@
               <template v-if="detailTab === 'notes'">
                 <div class="px-6 py-5 space-y-5">
                   <div class="flex items-center justify-between">
-                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">Notes</div>
-                    <button v-if="canCreate && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">Edit</button>
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider">{{ t('tasks.detail.notes') }}</div>
+                    <button v-if="canCreate && !editingSection" @click="editSection('notes')" class="text-[11px] text-slate-600 hover:text-blue-400 transition-colors">{{ t('common.action.edit') }}</button>
                   </div>
                   <template v-if="editingSection === 'notes'">
-                    <MarkdownField v-model="editForm.notes" :self-type="'task'" :self-id="selectedTask?.identifier || ''" :rows="12" placeholder="Add notes..." />
+                    <MarkdownField v-model="editForm.notes" :self-type="'task'" :self-id="selectedTask?.identifier || ''" :rows="12" :placeholder="t('tasks.placeholder.notes')" />
                   </template>
                   <template v-else>
                     <div v-if="selectedTask.notes" class="text-sm doc-prose text-slate-300 leading-relaxed" v-mermaid v-html="renderMd(selectedTask.notes)"></div>
-                    <div v-else class="text-sm text-slate-600 italic">No notes yet.</div>
+                    <div v-else class="text-sm text-slate-600 italic">{{ t('common.state.no_notes') }}</div>
                   </template>
                 </div>
               </template>
@@ -365,10 +333,10 @@
                 <div class="px-6 py-5 space-y-6">
                   <HistoryPanel entityType="task" :entityId="String(selectedTask.id)" />
                   <div v-if="canCreate" class="border border-red-900/40 rounded-lg p-4 space-y-3">
-                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">Danger zone</div>
-                    <div class="text-xs text-slate-400">Deleting this task is permanent and cannot be undone.</div>
+                    <div class="text-[11px] font-semibold text-red-400 uppercase tracking-wider">{{ t('common.heading.danger_zone') }}</div>
+                    <div class="text-xs text-slate-400">{{ t('tasks.danger.warning') }}</div>
                     <button @click="confirmDelete(selectedTask)" class="px-3 py-1.5 text-xs font-medium bg-red-900/40 hover:bg-red-800/60 text-red-300 border border-red-800/50 rounded-lg transition-colors">
-                      Delete task
+                      {{ t('tasks.danger.delete') }}
                     </button>
                   </div>
                 </div>
@@ -379,18 +347,13 @@
 
           <!-- Footer action bar (edit mode only) -->
           <div v-if="editingSection" class="flex-shrink-0 border-t border-slate-800 px-6 py-3 flex justify-end gap-3">
-            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">Cancel</button>
-            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? 'Saving...' : 'Save' }}</button>
+            <button @click="cancelSection" class="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors">{{ t('common.action.cancel') }}</button>
+            <button @click="saveSection" :disabled="saving" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors">{{ saving ? t('common.state.saving') : t('common.action.save') }}</button>
           </div>
         </div>
       </div>
       </Transition>
       </Teleport>
-
-      <!-- Generation result -->
-      <div v-if="genResult" class="mt-4 px-4 py-3 bg-emerald-950/30 border border-emerald-800/30 rounded-lg text-xs text-emerald-400">
-        Generated {{ genResult.created?.length || 0 }} tasks ({{ genResult.skipped || 0 }} already existed).
-      </div>
     </div>
   </div>
 </template>
@@ -398,6 +361,7 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { api } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
 import StatStrip from '../components/StatStrip.vue'
@@ -419,13 +383,16 @@ import { useDirtyEdit } from '../composables/useDirtyEdit.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { renderMarkdown } from '../composables/useRenderMd.js'
 import { formatDate, formatDay } from '../composables/useFormat.js'
+import { renderApiError } from '../composables/useApiError.js'
+import { enumLabel, entityLabel } from '../composables/useEnumLabel.js'
 
 const { ask, confirm: confirmDialog } = useConfirm()
 const { success: showSaved, error: showError } = useToast()
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const { orgSlug, orgPath } = useCurrentOrg()
+const { orgPath } = useCurrentOrg()
 
 const renderMd = renderMarkdown
 
@@ -459,8 +426,6 @@ const selectedTask = ref(null)
 const orgMembers = ref([])
 const showCreate = ref(false)
 const creating = ref(false)
-const generating = ref(false)
-const genResult = ref(null)
 const userRole = ref('')
 // Org default for a new task's visibility (task_default_private) — seeds the
 // create form's Public/Private control so a privacy-by-default org gets it right.
@@ -475,43 +440,70 @@ const saving = ref(false)
 
 // orgPath is provided by useCurrentOrg() above.
 
-const detailTabs = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'notes', label: 'Notes' },
-  { key: 'links', label: 'Links' },
-  { key: 'suggestions', label: 'Suggestions' },
-  { key: 'comments', label: 'Comments' },
-  { key: 'history', label: 'History' },
+// Tab labels are keys, resolved in a computed: an array built at module load
+// freezes its labels in whatever locale was active when the file was imported.
+const TAB_KEYS = [
+  { key: 'overview', label: 'common.tab.overview' },
+  { key: 'notes', label: 'common.tab.notes' },
+  { key: 'links', label: 'common.tab.links' },
+  { key: 'suggestions', label: 'common.tab.suggestions' },
+  { key: 'comments', label: 'common.tab.comments' },
+  { key: 'history', label: 'common.tab.history' },
 ]
+const detailTabs = computed(() => TAB_KEYS.map((tab) => ({ ...tab, label: t(tab.label) })))
+
+// Lookups and option lists live here rather than in the template: a group name
+// — and a bare enum value like 'in_progress' — is a stored identifier, and the
+// raw-text scanner reads a quoted word in a mustache as unextracted copy.
+const STATUSES = ['open', 'in_progress', 'done', 'cancelled']
+const PRIORITIES = ['critical', 'high', 'medium', 'low']
+const TASK_TYPES = [
+  'general', 'review', 'incident_followup', 'audit_followup', 'ca_followup',
+  'change_followup', 'onboarding', 'offboarding', 'training', 'other',
+]
+// The create form offers manual types only; the *_followup ones are set by the
+// system, not chosen here (#32). Editing still offers all ten, so an
+// auto-generated task's type stays representable.
+const MANUAL_TASK_TYPES = ['general', 'review', 'onboarding', 'offboarding', 'training', 'other']
+
+const statusLabel = (v) => enumLabel('status', v)
+const priorityLabel = (v) => enumLabel('priority', v)
+const typeLabel = (v) => enumLabel('task_type', v)
+const taskTypeLabel = (task) => typeLabel(task?.task_type || 'general')
+
+const options = (values, label) => computed(() => values.map((value) => ({ value, label: label(value) })))
+const statusOptions = options(STATUSES, statusLabel)
+const priorityOptions = options(PRIORITIES, priorityLabel)
+const priorityAscOptions = options([...PRIORITIES].reverse(), priorityLabel)
+const typeOptions = options(TASK_TYPES, typeLabel)
+const manualTypeOptions = options(MANUAL_TASK_TYPES, typeLabel)
+
+// The three progress steps are fixed statuses, not the task's own.
+const stepOpenLabel = computed(() => statusLabel('open'))
+const stepInProgressLabel = computed(() => statusLabel('in_progress'))
+const stepDoneLabel = computed(() => statusLabel('done'))
 
 const canCreate = computed(() => ['admin', 'manager'].includes(userRole.value))
-const canAdvance = computed(() => ['admin', 'manager', 'contributor'].includes(userRole.value))
 const pendingRefs = ref([])
 
 useModalEscape(showCreate)
 useModalEscape(computed(() => !!selectedTask.value), () => closeDetail())
 
-const currentUserEmail = ref('')
-function defaultDueDate() {
-  const d = new Date()
-  d.setDate(d.getDate() + 7)
-  return d.toISOString().slice(0, 10)
-}
 function defaultForm() {
   return { title: '', priority: 'medium', task_type: 'general', private: orgDefaultPrivate.value }
 }
 const form = ref(defaultForm())
 
-const statusStats = computed(() => {
-  return [
-    { key: 'active', label: 'Active', count: (stats.value.open || 0) + (stats.value.in_progress || 0), color: 'text-indigo-400' },
-    { key: '', label: 'Total', count: stats.value.total || 0, color: 'text-slate-100' },
-    { key: 'open', label: 'Open', count: stats.value.open || 0, color: 'text-blue-400' },
-    { key: 'in_progress', label: 'In Progress', count: stats.value.in_progress || 0, color: 'text-amber-400' },
-    { key: 'overdue', label: 'Overdue', count: stats.value.overdue || 0, color: 'text-red-400' },
-    { key: 'done', label: 'Done', count: stats.value.done || 0, color: 'text-emerald-400' },
-  ]
-})
+// 'active' and 'overdue' are filter pseudo-statuses, not stored values, so
+// they carry their own labels; the other three come from the catalogue.
+const statusStats = computed(() => [
+  { key: 'active', label: t('tasks.stat.active'), count: (stats.value.open || 0) + (stats.value.in_progress || 0), color: 'text-indigo-400' },
+  { key: '', label: t('common.stat.total'), count: stats.value.total || 0, color: 'text-slate-100' },
+  { key: 'open', label: statusLabel('open'), count: stats.value.open || 0, color: 'text-blue-400' },
+  { key: 'in_progress', label: statusLabel('in_progress'), count: stats.value.in_progress || 0, color: 'text-amber-400' },
+  { key: 'overdue', label: t('common.stat.overdue'), count: stats.value.overdue || 0, color: 'text-red-400' },
+  { key: 'done', label: statusLabel('done'), count: stats.value.done || 0, color: 'text-emerald-400' },
+])
 
 function isOverdue(task) {
   if (!task.due_date || task.status === 'done' || task.status === 'cancelled') return false
@@ -550,9 +542,9 @@ async function selectTask(task) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and switch tab?',
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -563,9 +555,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: 'You have unsaved changes. Discard and close?',
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: 'Discard',
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -635,31 +627,31 @@ async function create() {
       const id = String(route.query.from_ca)
       sourceLinks.push({ type: 'corrective_action', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from [${label}](/corrective-actions/${id})`)
+      seedLines.push(t('common.seed.created_from', { label, link: `/corrective-actions/${id}` }))
     }
     if (route.query.from_risk) {
       const id = String(route.query.from_risk)
       sourceLinks.push({ type: 'risk', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from [${label}](/risks/${id})`)
+      seedLines.push(t('common.seed.created_from', { label, link: `/risks/${id}` }))
     }
     if (route.query.from_incident) {
       const id = 'INC-' + String(route.query.from_incident)
       sourceLinks.push({ type: 'incident', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from [${label}](/incidents/${id})`)
+      seedLines.push(t('common.seed.created_from', { label, link: `/incidents/${id}` }))
     }
     if (route.query.from_audit_finding) {
       const id = 'FIND-' + String(route.query.from_audit_finding)
       sourceLinks.push({ type: 'audit_finding', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from audit finding ${label}`)
+      seedLines.push(t('common.seed.created_from_audit_finding', { label }))
     }
     if (route.query.from_document) {
       const id = String(route.query.from_document)
       sourceLinks.push({ type: 'document', id })
       const label = sourceTitle ? `${id}: ${sourceTitle}` : id
-      seedLines.push(`Created from [${label}](/documents/${id})`)
+      seedLines.push(t('common.seed.created_from', { label, link: `/documents/${id}` }))
     }
     if (seedLines.length > 0) {
       payload.notes = seedLines.join('\n')
@@ -689,23 +681,9 @@ async function create() {
     }
   } catch (e) {
     console.error('Failed to create task:', e)
-    showError('Failed to create task: ' + (e.message || 'unknown error'))
+    showError(t('tasks.error.create', { message: renderApiError(e) }))
   } finally {
     creating.value = false
-  }
-}
-
-async function advanceStatus(task, status) {
-  if (!status) return
-  try {
-    await api.updateTaskStatus(task.id, status)
-    task.status = status
-    if (status === 'done') task.completed_at = Date.now() / 1000
-    if (selectedTask.value?.id === task.id) {
-      selectedTask.value = { ...task }
-    }
-  } catch (e) {
-    showError('Failed to update status: ' + (e.message || 'unknown error'))
   }
 }
 
@@ -759,33 +737,24 @@ async function saveSection() {
       startEdit(fresh)
     }
     editingSection.value = ''
-    showSaved('Saved')
+    showSaved(t('common.state.saved'))
   } catch (e) {
-    showError('Failed to save: ' + e.message)
+    showError(t('tasks.error.save', { message: renderApiError(e) }))
   } finally {
     saving.value = false
   }
 }
 
 async function confirmDelete(task) {
-  if (!await ask(`Delete task "${task.title}"?`, { confirm: 'Delete', variant: 'danger' })) return
+  const question = t('tasks.danger.confirm', { title: task.title })
+  if (!await ask(question, { confirm: t('common.action.delete'), variant: 'danger' })) return
   try {
     await api.deleteTask(task.id)
     closeDetail()
     await loadTasks()
   } catch (e) {
-    showError('Failed to delete task: ' + (e.message || 'unknown error'))
+    showError(t('tasks.error.delete', { message: renderApiError(e) }))
   }
-}
-
-async function generateOverdueTasks() {
-  generating.value = true
-  genResult.value = null
-  try {
-    genResult.value = await api.postJSON('/api/v1/overdue/tasks', {})
-    await loadTasks()
-  } catch { /* ignore */ }
-  generating.value = false
 }
 
 async function openTaskFromRoute(id) {
@@ -816,7 +785,6 @@ onMounted(async () => {
   try {
     const me = await api.getMe()
     userRole.value = me?.role || ''
-    currentUserEmail.value = me?.email || ''
   } catch {}
   try { orgMembers.value = await api.getUsers() || [] } catch { orgMembers.value = [] }
   try { const cfg = await api.getConfig(); orgDefaultPrivate.value = !!cfg?.task_default_private } catch { /* keep public default */ }

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -106,6 +106,13 @@ const PENDING_TRANSLATION = {
   // objectives.target_operator. The members are mathematical symbols today, but
   // they are still authored copy — a locale may prefer spelled-out comparators.
   target_operator: ['gte', 'lte', 'eq', 'gt', 'lt'],
+  // changes.type. Extend alongside db.ChangeTypes and the DB CHECK.
+  change_type: ['change', 'access_request'],
+  // changes.risk_level. A fourth column with the low/medium/high/critical
+  // members, and a fourth family: severity, criticality, priority and risk
+  // level are four different judgements that English happens to score with
+  // one set of words.
+  risk_level: ['critical', 'high', 'medium', 'low'],
 }
 
 // The suggestion `entity` param, resolved through common.entity.* rather than

--- a/web/test/enumCatalog.test.js
+++ b/web/test/enumCatalog.test.js
@@ -5,7 +5,7 @@
 // which reads plausibly in English and is invisible in review.
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { enumLabel, enumLabelInline } from '../src/composables/useEnumLabel.js'
+import { enumLabel, enumLabelAbbr, enumLabelInline } from '../src/composables/useEnumLabel.js'
 import { i18n } from '../src/i18n.js'
 import en from '../src/locales/en/index.js'
 import id from '../src/locales/id-ID/index.js'
@@ -80,6 +80,32 @@ const PENDING_TRANSLATION = {
     'data_protection', 'employment', 'regulatory', 'intellectual_property',
     'financial', 'environmental', 'corporate',
   ],
+  // ── added by the 3.6 (workflow) extraction ──
+  audit_type: ['internal', 'external', 'surveillance', 'certification', 'recertification'],
+  // changes.category. Named for the table, because `category` alone already
+  // means three different value sets across the schema.
+  change_category: [
+    'process', 'technology', 'people', 'documentation', 'infrastructure', 'other',
+  ],
+  task_type: [
+    'general', 'review', 'incident_followup', 'audit_followup', 'ca_followup',
+    'change_followup', 'onboarding', 'offboarding', 'training', 'other',
+  ],
+  // corrective_actions.source — the set `origin` deliberately left this name
+  // free for. Not the internal/external pair risks.origin holds.
+  source: [
+    'internal_audit', 'external_audit', 'risk_assessment', 'security_incident',
+    'objective', 'feedback', 'other',
+  ],
+  // tasks.priority and changes.priority. Same members as `severity`, different
+  // family: a task is not more or less severe, it is more or less urgent, and a
+  // language need not use one word for both.
+  priority: ['critical', 'high', 'medium', 'low'],
+  // checkins.outcome, rendered by the audit programme view.
+  outcome: ['satisfactory', 'concerns', 'unsatisfactory'],
+  // objectives.target_operator. The members are mathematical symbols today, but
+  // they are still authored copy — a locale may prefer spelled-out comparators.
+  target_operator: ['gte', 'lte', 'eq', 'gt', 'lt'],
 }
 
 // The suggestion `entity` param, resolved through common.entity.* rather than
@@ -147,6 +173,26 @@ test('a lagging locale falls back to the English label, not to de-slugging', () 
   } finally {
     i18n.global.locale.value = previous
   }
+})
+
+// Abbreviated forms. A filter <option> and a dense table badge cannot hold
+// "Opportunity for improvement"; `common.enum_abbr.*` is the short authored
+// form, not a truncation. enumLabelAbbr() falls back to the standalone label,
+// so only a test catches a group that lost its abbreviations.
+
+test('the finding taxonomy has an abbreviated form for every member', () => {
+  for (const value of GROUPS.finding_type) {
+    const abbr = en.common.enum_abbr?.finding_type?.[value]
+    assert.equal(typeof abbr, 'string', `common.enum_abbr.finding_type.${value} is missing in en`)
+    assert.ok(abbr.length > 0, `common.enum_abbr.finding_type.${value} is empty in en`)
+  }
+})
+
+test('an abbreviated form falls back to the standalone label, never to a raw key', () => {
+  assert.equal(enumLabelAbbr('finding_type', 'opportunity'), 'OFI')
+  // No abbreviations authored for this group: the full label stands in.
+  assert.equal(enumLabelAbbr('audit_result', 'conforming'), 'Conforming')
+  assert.equal(enumLabelAbbr('finding_type', ''), '')
 })
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -4,7 +4,6 @@
   "views/Changes.vue": 4,
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
-  "views/Objectives.vue": 12,
   "views/Reviews.vue": 12,
   "views/Tasks.vue": 4
 }

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -1,6 +1,5 @@
 {
   "composables/useDocumentEditor.js": 1,
-  "views/Audit.vue": 19,
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
   "views/Reviews.vue": 12

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -4,6 +4,5 @@
   "views/Changes.vue": 4,
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
-  "views/Reviews.vue": 12,
-  "views/Tasks.vue": 4
+  "views/Reviews.vue": 12
 }

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -2,7 +2,6 @@
   "composables/useDocumentEditor.js": 1,
   "views/Audit.vue": 19,
   "views/Changes.vue": 4,
-  "views/CorrectiveActions.vue": 7,
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
   "views/Objectives.vue": 12,

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -1,7 +1,6 @@
 {
   "composables/useDocumentEditor.js": 1,
   "views/Audit.vue": 19,
-  "views/Changes.vue": 4,
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
   "views/Reviews.vue": 12

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -6,7 +6,6 @@
   "views/Documents.vue": 15,
   "views/Inbox.vue": 21,
   "views/Objectives.vue": 12,
-  "views/Programs.vue": 5,
   "views/Reviews.vue": 12,
   "views/Tasks.vue": 4
 }

--- a/web/test/format.test.js
+++ b/web/test/format.test.js
@@ -3,7 +3,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { enumLabel } from '../src/composables/useEnumLabel.js'
-import { formatDate, formatDay, formatHours, formatMonthShort, formatNumber, formatRecent, formatRelative, useFormat } from '../src/composables/useFormat.js'
+import { formatDate, formatDay, formatHours, formatMonthLong, formatMonthShort, formatNumber, formatRecent, formatRelative, useFormat } from '../src/composables/useFormat.js'
 import { i18n } from '../src/i18n.js'
 
 test('enum labels come from the catalogue, and de-slug only as a fallback', () => {
@@ -110,6 +110,12 @@ test('short month names come from Intl, and reject anything but a month index', 
   assert.equal(formatMonthShort(-1), '')
   assert.equal(formatMonthShort(12), '')
   assert.equal(formatMonthShort('x'), '')
+  // The spelled-out form rejects the same unusable input.
+  assert.equal(formatMonthLong(0), 'January')
+  assert.equal(formatMonthLong(11), 'December')
+  assert.equal(formatMonthLong(-1), '')
+  assert.equal(formatMonthLong(12), '')
+  assert.equal(formatMonthLong('x'), '')
   assert.equal(formatMonthShort(null), '')
   assert.equal(formatMonthShort(1.5), '')
 })

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,5 +1,4 @@
 {
-  "views/Audit.vue": 218,
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
   "views/Reviews.vue": 146

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -3,6 +3,5 @@
   "views/Changes.vue": 106,
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
-  "views/Reviews.vue": 146,
-  "views/Tasks.vue": 105
+  "views/Reviews.vue": 146
 }

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -5,7 +5,6 @@
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
   "views/Objectives.vue": 98,
-  "views/Programs.vue": 36,
   "views/Reviews.vue": 146,
   "views/Tasks.vue": 105
 }

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -3,7 +3,6 @@
   "views/Changes.vue": 106,
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
-  "views/Objectives.vue": 98,
   "views/Reviews.vue": 146,
   "views/Tasks.vue": 105
 }

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,6 +1,5 @@
 {
   "views/Audit.vue": 218,
-  "views/Changes.vue": 106,
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
   "views/Reviews.vue": 146

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,7 +1,6 @@
 {
   "views/Audit.vue": 218,
   "views/Changes.vue": 106,
-  "views/CorrectiveActions.vue": 90,
   "views/Documents.vue": 186,
   "views/Inbox.vue": 90,
   "views/Objectives.vue": 98,


### PR DESCRIPTION
Makes the six workflow screens translatable: **Audit, Change Management, Tasks, Objectives, Corrective Actions and Programs**. Continues #212, following the auth views (#264), the shell and landing page (#266), the shared components (#267), the admin surface (#268) and the six registers (#270).

**Please merge with a merge commit, not a squash.** There are nine commits and each one is a single screen or a single decision; the per-screen record is what makes this reviewable and what the next contributor will read. #268 and #270 both carried this request and were both squashed, so eighteen commits of that history are already gone.

## What changes for a user

Nothing, today. Every one of these screens renders the same English it did before, because English is the only language the app currently offers. What changes is that the text is now *capable* of being another language — it comes out of translation files instead of being baked into the code.

Three visible differences, all deliberate:

- **Some labels change capitalisation.** "Todo" becomes "To do", "Awaiting Approval" becomes "Awaiting approval", "Major Non-conformity" becomes "Major non-conformity". These labels now come from the app's shared vocabulary, which uses sentence case, and which the status badges on these same screens were already using. Previously the same value could appear two ways on one screen depending on which control showed it. Words are unchanged; only the capital letters are.
- **Eleven labels that displayed a raw database value now read properly.** A task's priority showed the literal text `critical`, its type showed `incident followup`, an audit's type showed `internal`. These were values printed straight to the screen, sometimes with a styling rule capitalising the first letter, which is why they looked plausible in English and would have stayed English in every other language.
- **A tab that never showed anything now shows it.** See the bug fix below.

## What this fixes

**The audit Findings tab was empty for everyone, always.** However many findings an organisation had recorded, the tab said "No findings recorded yet." and its four counters — Total, Open, Closed, Overdue — all read zero. The findings existed and the rest of the app could see them; only this screen could not. Cause was a one-line mismatch in how the response was read.

This is the second consecutive extraction to uncover a panel that had never worked (#270 found the supplier "Linked systems" block). Both were found the same way: seeding real data and looking at the rendered page, because an empty screen and a broken screen look identical when there is nothing to display.

## What this deliberately does not change

**A "Generated N tasks" banner was deleted rather than translated.** The function that would populate it is never called from anywhere, so the banner could never appear. Translating it would have meant shipping vocabulary for a message nobody can see.

**The audit calendar's month names now come from the browser rather than the server.** The server sends them in English; the browser can produce them in whichever language is active. The English output is identical.

## Risk

**Low, and mechanically checked.** Two automated gates run in CI and both are at zero for all six files: one counts untranslated text, the other counts error messages that bypass the translation layer. Between them they went from 653 and 51 findings to none.

The gates do not see everything, so each of the six screens was opened in a browser and driven through a stand-in second language, which makes any text that failed to translate immediately obvious. That pass is what found the broken Findings tab, and what confirmed the eleven raw database values above — none of which any automated check can see, because a value printed from the database was never written down as text in the first place.

**Roughly 150 lines of unreachable code were deleted** rather than translated: five status-change and save helpers that were defined and never called, an unused import, and the dead banner above. Six of them contained error messages, so they came off the count by deletion rather than by translation.

## Scope

- 6 screens, 653 pieces of text, 51 error messages
- 478 new translation entries: 405 belonging to individual screens, 73 shared
- The shared vocabulary lands first, in its own commit, for the same reason it did on the registers: these screens repeat each other, and nine new groups of shared values (audit types, task types, change categories, priorities and so on) would otherwise have been written out six times
- Audit is by far the largest screen in the app — three related things (programmes, audits, findings) in one file — and is deliberately its own commit

## Verification

- `npm test` — 152 pass, including two new ones covering the abbreviated-label lookup
- `npm run build`
- `go test ./internal/isms/i18n/...`
- Both text gates at zero for all six files; the totals they track fall from 1075 to 422 and from 100 to 49
- All six screens opened in a browser against a stand-in locale, over seeded data in every module, with no missing-translation warnings

With this merged, the only screens left in #212 are the document ones — Documents, Reviews and Inbox.
