### PR TITLE
feat(i18n): extract Documents, Reviews and Inbox (#212)

### DIFF
--- a/internal/isms/i18n/release_gate_test.go
+++ b/internal/isms/i18n/release_gate_test.go
@@ -16,14 +16,15 @@ const rawTextBaseline = "../../../web/test/rawText.baseline.json"
 //
 // It is not zero, and it should not be. The scanner over-reports — brand names,
 // punctuation, and attribute values it cannot distinguish from copy — so a
-// fully extracted tree still carries a residue, and 100 is an estimate of it.
+// fully extracted tree may still carry a residue, and 100 was an estimate of it.
 //
-// For scale: the tree started at 2488 and sits at 422 now that the auth,
-// shell, component, admin, register and workflow surfaces are extracted — so
-// roughly 4x above the threshold, with only the document views left. The estimate
-// still wants revisiting once a fully extracted tree shows what the residue
-// actually is; the threshold is a judgement, and says so. The coupling it
-// enforces is not.
+// For scale: the tree started at 2488 and sits at 0, every surface — auth,
+// shell, component, admin, register, workflow and document — now extracted. So
+// the residue this threshold estimates turned out to be nothing the scanner can
+// still see: 100 is now headroom for a future unextracted view rather than an
+// estimate of an unmeasured remainder. Revisiting the number is therefore a
+// judgement about how much new raw text a release may carry, and says so. The
+// coupling it enforces is not.
 const extractionGateThreshold = 100
 
 // TestSecondLocaleRequiresExtraction is a release gate, not a unit test.

--- a/web/src/composables/useDocumentEditor.js
+++ b/web/src/composables/useDocumentEditor.js
@@ -1,4 +1,10 @@
 import { ref, onBeforeUnmount } from 'vue'
+// `t` from the module, not useI18n(): a composable called from setup could use
+// either, but this one is also reachable outside a component instance, and the
+// module export is the seam every plain .js module in the tree already uses
+// (useApiError.js says the same about its own import).
+import { t } from '../i18n.js'
+import { renderApiError } from './useApiError.js'
 
 /**
  * Composable for document editing state and draft autosave.
@@ -148,7 +154,7 @@ export function useDocumentEditor({ activeId, activeDoc, activeType, rawContent,
       loadNeedsReview()
       setTimeout(() => { editSaveMsg.value = '' }, 3000)
     } catch (e) {
-      editSaveMsg.value = 'Failed to save: ' + e.message
+      editSaveMsg.value = t('documents.error.save', { message: renderApiError(e) })
       editSaveError.value = true
     } finally {
       savingEdit.value = false

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -38,7 +38,8 @@ loader — see [`docs/i18n.md`](../../../docs/i18n.md).
 | Enum values | `common.enum.<enum>.<db_value>` → `common.enum.status.changes_requested` |
 | Validation messages | `common.validation.required` |
 | Entity names | `common.entity.risk` |
-| Field names | `common.field.title` |
+| Field names, lowercase, for splicing into a sentence | `common.field.title` → "title is required" |
+| Shared standalone labels, capitalised | `common.label.version` |
 | API error codes | `common.error.not_found` |
 | Group by UI structure, not by phrasing | `risks.table.header.likelihood` |
 | Keys are `snake_case`, and enum keys mirror the DB value verbatim | `changes_requested`, never `changesRequested` |
@@ -133,6 +134,28 @@ Copy reused across two or more areas, plus the four cross-cutting groups
 (`enum`, `entity`, `field`, `error`). Everything else belongs to its area, even
 if the English happens to read the same in two places — the translations may
 diverge.
+
+### `field.*` vs `label.*` vs `<area>.table.header.*`
+
+Three groups hold what looks like the same word, and the difference is where the
+word is used, not what it says.
+
+- **`common.field.*` is lowercase** because it is never rendered alone.
+  `renderApiError` splices it into a frame — `common.error.required` is
+  `"{field} is required"` — so the value has to read as a noun mid-sentence. A
+  language that capitalises differently mid-sentence changes the value here, and
+  the frame stays untouched.
+- **`common.label.*` is capitalised** and stands on its own: a form label above
+  an input, a badge, an inline caption. It earns its place in `common.json` only
+  when two or more areas show the same label; `version`, `round` and `reviewers`
+  are there because the document, review and inbox surfaces all show them.
+- **`<area>.table.header.*` stays in the area** even when the English matches
+  another area's, which it very often does — "Status", "Type", "Owner". A column
+  header is abbreviated to fit a column, and how far a language can abbreviate a
+  word differs per table. Do not lift these into `common.label.*`.
+
+The test for a new `common.label.*` key is the second area, not the second call
+site: the same label twice inside one view belongs to that view.
 
 ## ISO terminology
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -375,6 +375,16 @@
       "high": "High",
       "medium": "Medium",
       "low": "Low"
+    },
+    "document_type": {
+      "document": "Document",
+      "policy": "Policy",
+      "procedure": "Procedure",
+      "control": "Control",
+      "guideline": "Guideline",
+      "record": "Record",
+      "clause": "Clause",
+      "requirement": "Requirement"
     }
   },
   "enum_inline": {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -17,7 +17,10 @@
     "add_comment": "Add comment",
     "comment": "Comment",
     "reply": "Reply",
-    "resolve": "Resolve"
+    "resolve": "Resolve",
+    "approve": "Approve",
+    "add": "Add",
+    "discard_draft": "Discard draft"
   },
   "state": {
     "loading": "Loading…",
@@ -31,7 +34,9 @@
     "copied": "Copied",
     "saved": "Saved",
     "overdue": "OVERDUE",
-    "no_notes": "No notes yet."
+    "no_notes": "No notes yet.",
+    "sending": "Sending...",
+    "creating": "Creating..."
   },
   "validation": {
     "required": "This field is required"
@@ -494,6 +499,14 @@
   "heading": {
     "quick_actions": "Quick actions",
     "danger_zone": "Danger zone"
+  },
+  "label": {
+    "version": "Version",
+    "version_number": "Version {version}",
+    "round": "Round {round}",
+    "round_paren": "(Round {round})",
+    "reviewers": "Reviewers",
+    "approved_prefix": "Approved:"
   },
   "read_only": {
     "actions": "Read-only — actions require manager or admin role."

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -20,7 +20,8 @@
     "resolve": "Resolve",
     "approve": "Approve",
     "add": "Add",
-    "discard_draft": "Discard draft"
+    "discard_draft": "Discard draft",
+    "discard": "Discard"
   },
   "state": {
     "loading": "Loading…",

--- a/web/src/locales/en/documents.json
+++ b/web/src/locales/en/documents.json
@@ -1,0 +1,216 @@
+{
+  "tree": {
+    "heading": "Documents",
+    "new": "New",
+    "new_folder": "New Folder",
+    "new_document": "New Document",
+    "empty": "No documents yet",
+    "import_template": "Import template",
+    "new_folder_placeholder": "new folder name...",
+    "folder_name_placeholder": "folder name...",
+    "hide": "Hide tree",
+    "show": "Show tree"
+  },
+  "empty": {
+    "heading": "No documents yet",
+    "body": "Import a template to scaffold your document structure, then use the tree menu to add documents and folders.",
+    "import_template": "Import template"
+  },
+  "dash": {
+    "tab": {
+      "review": "Needs Review",
+      "recent": "Recently Changed",
+      "search": "Search",
+      "templates": "Templates"
+    }
+  },
+  "needs_review": {
+    "include_never_approved": "Include never approved ({count})",
+    "up_to_date": "All documents are up to date.",
+    "never_approved": "Never approved",
+    "changed": "Changed",
+    "current": "Current: {commit} ({time})",
+    "approved": "Approved: {commit}",
+    "review": "Review",
+    "diff": "Diff"
+  },
+  "recent": {
+    "refresh": "Refresh",
+    "empty": "No recent changes.",
+    "meta": "{time} by {author} — {hash} {message}"
+  },
+  "search": {
+    "placeholder": "Search all documents...",
+    "hint": "Type at least 2 characters to search across all documents.",
+    "searching": "Searching...",
+    "no_results": "No results for \"{query}\""
+  },
+  "templates": {
+    "heading": "Templates",
+    "subtitle": "Add or remove document scaffolding for standards.",
+    "installed": "Installed",
+    "add": "Add",
+    "remove": "Remove",
+    "remove_heading": "Remove Template",
+    "remove_body": "Are you sure you want to remove {name}? This will delete all documents under {path} from the repository.",
+    "picker_heading": "Import template",
+    "picker_subtitle": "Choose a standard to scaffold your document structure.",
+    "picker_placeholder": "Search templates...",
+    "picker_empty": "No templates found.",
+    "import": "Import",
+    "added": "{name} template added successfully.",
+    "removed": "{name} template removed.",
+    "add_failed": "Failed to add template: {message}",
+    "remove_failed": "Failed to remove template: {message}"
+  },
+  "toolbar": {
+    "edit": "Edit",
+    "save": "Save",
+    "send_for_review": "Send for review",
+    "version_history": "Version history",
+    "comments": "Comments",
+    "print": "Print document",
+    "delete": "Delete document"
+  },
+  "print": {
+    "version": "Version {version}",
+    "author": "Author: {name}",
+    "printed": "Printed {date}"
+  },
+  "tab": {
+    "content": "Content",
+    "info": "Info",
+    "versions": "Versions",
+    "links": "Links",
+    "discussion": "Discussion",
+    "history": "History"
+  },
+  "meta": {
+    "status": "Status",
+    "go_to_active_review": "Go to active review",
+    "go_to_reviews": "Go to reviews",
+    "type": "Type",
+    "author": "Author",
+    "author_placeholder": "Set author...",
+    "version": "Version",
+    "owner": "Owner",
+    "not_set": "Not set",
+    "review_cycle": "Review Cycle",
+    "review_cycle_months": "Every {count} month | Every {count} months",
+    "last_approved": "Last Approved",
+    "approved_version": "Approved Version",
+    "next_review": "Next Review",
+    "due_soon": "DUE SOON"
+  },
+  "banner": {
+    "round_complete": "Round {round} complete — changes requested",
+    "pending_suggestions": "{count} pending suggestion to address. | {count} pending suggestions to address.",
+    "feedback_waiting": "Reviewer feedback is waiting on the conversation.",
+    "then_resubmit": "Address the feedback, then resubmit for the next round.",
+    "open_review": "Open review",
+    "in_review": "This document is in review.",
+    "in_review_round": "This document is in review (Round {round}).",
+    "view_review": "View review →",
+    "retired": "This document is retired.",
+    "never_approved": "This document has never been approved.",
+    "send_for_review": "Send for review →",
+    "changed_since_approval": "Changed since last approval",
+    "last_approved": "— last approved",
+    "last_approved_version": "— last approved {version}",
+    "last_approved_on": "— last approved on {date}",
+    "last_approved_version_on": "— last approved {version} on {date}",
+    "hide_diff": "Hide diff",
+    "view_diff": "View diff"
+  },
+  "versions": {
+    "heading": "Version History",
+    "empty": "No version history available",
+    "unknown_version": "v?",
+    "meta": "{author} — {date}"
+  },
+  "panel": {
+    "discussion": "Document discussion",
+    "changelog": "Document changelog"
+  },
+  "content": {
+    "inline_comment_count": "{count} inline comment on this document | {count} inline comments on this document",
+    "draft_recovered": "Unsaved draft recovered",
+    "mark_unreviewed": "Mark as unreviewed",
+    "mark_reviewed": "Mark as reviewed",
+    "comment_count": "{count} comment | {count} comments",
+    "add_comment": "Add comment",
+    "resolved": "Resolved",
+    "resolved_by": "Resolved by {name} {date}",
+    "resolved_by_unknown": "unknown",
+    "inline_placeholder": "Add a comment on this paragraph... (type {'@'} to mention)",
+    "no_users": "No users found",
+    "empty": "No content available for this document."
+  },
+  "comments": {
+    "no_document": "Select a document to view comments",
+    "heading": "Comments",
+    "resolved_count": "{count} resolved",
+    "general_placeholder": "Add a general comment... (type {'@'} to mention)",
+    "author_placeholder": "Your name",
+    "send": "Send",
+    "inline_label": "Inline comment",
+    "inline_label_short": "Inline",
+    "document_label": "Document comment",
+    "quote": "— \"{quote}\"",
+    "reply": "Reply",
+    "reply_placeholder": "Write a reply...",
+    "resolved_toggle": "{count} resolved comment | {count} resolved comments",
+    "empty": "No comments yet"
+  },
+  "review_modal": {
+    "heading": "Send for review",
+    "reviewers": "Reviewers",
+    "search_members": "Search members...",
+    "version_note": "Version note",
+    "version_note_placeholder": "e.g. Updated risk assessment criteria. Added data classification table.",
+    "version_note_hint": "This becomes part of the document's permanent version history after approval.",
+    "send": "Send to {count} reviewer | Send to {count} reviewers"
+  },
+  "new_doc": {
+    "heading": "New Document",
+    "title": "Title",
+    "title_placeholder": "e.g. Data Classification Policy",
+    "type": "Type",
+    "no_folder": "No folder selected",
+    "change_folder": "change",
+    "pick_folder": "pick folder",
+    "folder_placeholder": "Type or select folder",
+    "show_advanced": "Show advanced options",
+    "hide_advanced": "Hide advanced options",
+    "document_id": "Document ID",
+    "document_id_placeholder": "auto from title",
+    "document_id_exists": "This ID already exists",
+    "filename": "Filename",
+    "filename_placeholder": "auto from ID",
+    "author": "Author",
+    "author_placeholder": "Select author...",
+    "create": "Create Document"
+  },
+  "confirm": {
+    "embedded_html_title": "Embedded HTML will be lost",
+    "embedded_html_body": "This document contains embedded HTML/SVG the editor can't preserve — editing here will drop it on save. Edit the source via the CLI to keep it. Edit anyway?",
+    "delete_title": "Delete Document",
+    "delete_body": "Delete \"{name}\"? This cannot be undone."
+  },
+  "error": {
+    "load_diff": "Failed to load diff",
+    "set_author": "Failed to set author: {message}",
+    "set_type": "Failed to set type: {message}",
+    "set_version": "Failed to set version: {message}",
+    "create_folder": "Failed to create folder: {message}",
+    "create_document": "Failed to create document: {message}",
+    "delete": "Failed to delete: {message}",
+    "send_for_review": "Failed to send for review: {message}",
+    "load_content": "**Error loading content:** {message}",
+    "submit_reply": "Failed to submit reply: {message}",
+    "submit_comment": "Failed to submit comment: {message}",
+    "resolve_comment": "Failed to resolve comment: {message}",
+    "load_documents": "Failed to load documents: {message}",
+    "save": "Failed to save: {message}"
+  }
+}

--- a/web/src/locales/en/documents.json
+++ b/web/src/locales/en/documents.json
@@ -192,9 +192,7 @@
     "create": "Create Document"
   },
   "confirm": {
-    "embedded_html_title": "Embedded HTML will be lost",
     "embedded_html_body": "This document contains embedded HTML/SVG the editor can't preserve — editing here will drop it on save. Edit the source via the CLI to keep it. Edit anyway?",
-    "delete_title": "Delete Document",
     "delete_body": "Delete \"{name}\"? This cannot be undone."
   },
   "error": {

--- a/web/src/locales/en/inbox.json
+++ b/web/src/locales/en/inbox.json
@@ -1,0 +1,141 @@
+{
+  "title": "Inbox",
+  "subtitle": "{count} action item requiring attention | {count} action items requiring attention",
+  "mark_all_read": "Mark all read",
+  "tab": {
+    "comments": "Comments",
+    "reviews": "Reviews",
+    "tasks": "Tasks",
+    "incidents": "Incidents",
+    "changes": "Changes",
+    "corrective_actions": "CAs",
+    "suggestions": "Suggestions"
+  },
+  "comments": {
+    "empty": "No open comments",
+    "suggestion_badge": "suggestion",
+    "scope_inline": "Inline",
+    "scope_document": "Document",
+    "view_in_document": "View in document →"
+  },
+  "reviews": {
+    "empty": "No reviews pending",
+    "untitled": "Untitled review",
+    "requested_by": "Requested by {name}",
+    "unknown_requester": "Unknown",
+    "meta": {
+      "status": "Status",
+      "document": "Document",
+      "version": "Version",
+      "requested_by": "Requested By"
+    },
+    "assigned_reviewers": "Assigned Reviewers",
+    "recent_comments": "Recent Comments",
+    "open_review": "Open Review #{id}"
+  },
+  "tasks": {
+    "add": "Add Task",
+    "empty": "No tasks found",
+    "start": "Start task",
+    "mark_done": "Mark done",
+    "form": {
+      "title": "Title",
+      "title_placeholder": "Task title",
+      "description": "Description",
+      "description_placeholder": "Optional description",
+      "type": "Type",
+      "priority": "Priority",
+      "assignee": "Assignee",
+      "assignee_placeholder": "Select assignee...",
+      "due_date": "Due Date"
+    }
+  },
+  "incidents": {
+    "empty": "No incidents assigned to you"
+  },
+  "corrective_actions": {
+    "empty": "No corrective actions assigned to you"
+  },
+  "changes": {
+    "add": "Add Change Request",
+    "empty": "No change requests",
+    "requested_by": "Requested by {name}",
+    "unknown_requester": "Unknown",
+    "form": {
+      "title": "Title",
+      "title_placeholder": "Change request title",
+      "description": "Description",
+      "description_placeholder": "Describe the proposed change",
+      "justification": "Justification",
+      "justification_placeholder": "Why is this change needed?",
+      "impact": "Impact Assessment",
+      "impact_placeholder": "Expected impact on ISMS",
+      "assign_to": "Assign To",
+      "assignee_placeholder": "Select assignee..."
+    },
+    "detail": {
+      "description": "Description",
+      "justification": "Justification",
+      "impact": "Impact Assessment",
+      "affected_documents": "Affected Documents"
+    },
+    "action": {
+      "approve": "Approve",
+      "reject": "Reject",
+      "mark_implemented": "Mark Implemented",
+      "close": "Close"
+    }
+  },
+  "suggestions": {
+    "empty": "No suggestions with this status.",
+    "filter": {
+      "open": "open",
+      "applied": "applied",
+      "rejected": "rejected"
+    },
+    "agent_badge": "AI",
+    "suggested_by": "Suggested by {name} · {date}",
+    "apply": "Apply",
+    "reject": "Reject",
+    "withdraw": "Withdraw",
+    "reject_placeholder": "Reason for rejection...",
+    "rejected_reason": "Rejected: {reason}",
+    "applied_result": "Applied → {entity} {id}",
+    "payload_field": {
+      "title": "Title",
+      "name": "Name",
+      "description": "Description",
+      "category": "Category",
+      "risk_type": "Risk type",
+      "origin": "Origin",
+      "severity": "Severity",
+      "priority": "Priority",
+      "status": "Status",
+      "type": "Type",
+      "criticality": "Criticality",
+      "jurisdiction": "Jurisdiction",
+      "classification": "Classification",
+      "finding_type": "Finding type",
+      "risk_level": "Risk level",
+      "source": "Source",
+      "incident_type": "Incident type",
+      "current_likelihood": "Likelihood",
+      "current_impact": "Impact"
+    }
+  },
+  "error": {
+    "resolve_comment": "Failed to resolve comment: {message}",
+    "mark_all_read": "Failed to mark all notifications read: {message}",
+    "approve_review": "Failed to approve review: {message}",
+    "request_changes": "Failed to request changes: {message}",
+    "forward_review": "Failed to forward review: {message}",
+    "claim_suggestion": "Failed to claim suggestion: {message}",
+    "apply_suggestion": "Failed to apply suggestion: {message}",
+    "reject_suggestion": "Failed to reject suggestion: {message}",
+    "withdraw_suggestion": "Failed to withdraw suggestion: {message}"
+  },
+  "confirm": {
+    "apply_stale_title": "Apply anyway",
+    "apply_stale_body": "Entity has changed since this suggestion was created. Apply anyway?"
+  }
+}

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -21,6 +21,7 @@ import correctiveActions from './corrective_actions.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
 import components from './components.json' with { type: 'json' }
 import incidents from './incidents.json' with { type: 'json' }
+import inbox from './inbox.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
 import legal from './legal.json' with { type: 'json' }
 import notifications from './notifications.json' with { type: 'json' }
@@ -45,6 +46,7 @@ export default {
   corrective_actions: correctiveActions,
   components,
   dashboard,
+  inbox,
   incidents,
   landing,
   legal,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -27,6 +27,7 @@ import notifications from './notifications.json' with { type: 'json' }
 import objectives from './objectives.json' with { type: 'json' }
 import organizations from './organizations.json' with { type: 'json' }
 import programs from './programs.json' with { type: 'json' }
+import reviews from './reviews.json' with { type: 'json' }
 import risks from './risks.json' with { type: 'json' }
 import settings from './settings.json' with { type: 'json' }
 import shell from './shell.json' with { type: 'json' }
@@ -51,6 +52,7 @@ export default {
   objectives,
   organizations,
   programs,
+  reviews,
   risks,
   settings,
   shell,

--- a/web/src/locales/en/index.js
+++ b/web/src/locales/en/index.js
@@ -20,6 +20,7 @@ import common from './common.json' with { type: 'json' }
 import correctiveActions from './corrective_actions.json' with { type: 'json' }
 import dashboard from './dashboard.json' with { type: 'json' }
 import components from './components.json' with { type: 'json' }
+import documents from './documents.json' with { type: 'json' }
 import incidents from './incidents.json' with { type: 'json' }
 import inbox from './inbox.json' with { type: 'json' }
 import landing from './landing.json' with { type: 'json' }
@@ -46,6 +47,7 @@ export default {
   corrective_actions: correctiveActions,
   components,
   dashboard,
+  documents,
   inbox,
   incidents,
   landing,

--- a/web/src/locales/en/reviews.json
+++ b/web/src/locales/en/reviews.json
@@ -14,7 +14,7 @@
     "step_decide": "Approve or request changes"
   },
   "tab": {
-    "changes": "Changes ({round})",
+    "changes": "Changes (Round {round})",
     "document": "Document",
     "conversation": "Conversation"
   },

--- a/web/src/locales/en/reviews.json
+++ b/web/src/locales/en/reviews.json
@@ -1,0 +1,200 @@
+{
+  "title": "Reviews",
+  "subtitle": "Document review requests",
+  "back": "Back to reviews",
+  "not_found": "Review not found",
+  "opened_ago": "opened {time}",
+  "ai": {
+    "active": "AI review in progress",
+    "escalated": "Escalated — AI review stalled"
+  },
+  "guide": {
+    "step_review": "Review the document and changes",
+    "step_comment": "Add comments or suggest edits",
+    "step_decide": "Approve or request changes"
+  },
+  "tab": {
+    "changes": "Changes ({round})",
+    "document": "Document",
+    "conversation": "Conversation"
+  },
+  "timeline": {
+    "suggested_edit": "suggested an edit",
+    "commented": "commented",
+    "approved": "approved this review",
+    "proposed_revision": "proposed a revision",
+    "requested_changes": "requested changes",
+    "assigned": "{reviewer} was assigned as reviewer",
+    "empty": "No activity yet.",
+    "round_short": "R{round}",
+    "decision": {
+      "merged": "merged this review",
+      "approved": "approved (decision record)",
+      "proposed_revision": "proposed revision (decision record)",
+      "changes_requested": "requested changes (decision record)"
+    },
+    "content_hash": "SHA-256 content hash for tamper evidence",
+    "hide_changes": "Hide changes",
+    "view_changes": "View changes",
+    "diff_loading": "Loading changes…",
+    "diff_error": "Couldn't load this revision's diff."
+  },
+  "updated": {
+    "heading": "Document updated since review was sent",
+    "last_modified_by": "Last modified by {name}",
+    "last_modified_by_with_message": "Last modified by {name} — {message}",
+    "note": "The diff below shows all changes since the last approved version."
+  },
+  "diff": {
+    "summary_heading": "Changes in this review",
+    "never_approved_inline": "Full review — this document has never been approved. Review the full document in the Document tab.",
+    "none_inline": "No diff available — the document may not have been modified since the review base.",
+    "loading": "Loading changes...",
+    "scope_round": "Changes in this round",
+    "scope_all": "All changes in review",
+    "mode_split": "Split",
+    "mode_unified": "Unified",
+    "never_approved_heading": "Full review — this document has never been approved",
+    "never_approved_body": "There is no prior approved version to diff against. Review the full document in the Document tab.",
+    "none_in_round": "No changes found in this round."
+  },
+  "comment": {
+    "heading": "Add a comment",
+    "placeholder": "Leave a comment..."
+  },
+  "edit": {
+    "save_and_resubmit": "Save & Resubmit",
+    "send_revision": "Send proposed revision",
+    "draft_saved": "Draft saved",
+    "note_placeholder": "What did you change and why?",
+    "draft_recovered": "Draft recovered from previous session."
+  },
+  "summary": {
+    "resubmitted": "Resubmitted after requested changes",
+    "initial": "Initial review",
+    "approved_count": "{approved} of {total}",
+    "waiting_on": "Waiting on:",
+    "ready_to_merge": "All reviewers have approved. Ready to merge.",
+    "changes_requested_you": "Changes requested. Waiting for you to respond.",
+    "changes_requested_author": "Changes requested. Waiting for {author} to respond."
+  },
+  "suggestion": {
+    "count": "{count} suggestion | {count} suggestions",
+    "pending": "{count} pending",
+    "accepted": "{count} accepted",
+    "rejected": "{count} rejected"
+  },
+  "assignment": {
+    "empty": "No reviewers assigned",
+    "status": {
+      "approved": "approved",
+      "pending": "pending",
+      "changes_requested": "changes",
+      "proposed_revision": "revision"
+    }
+  },
+  "policy": {
+    "heading": "Approval Requirements",
+    "approvals": "{current}/{min} approvals",
+    "missing_roles": "Missing: {roles} role",
+    "missing_users": "Awaiting: {users}",
+    "blocked": "Merge blocked until all requirements are met",
+    "will_auto_merge": "Will auto-merge when all approvals are in",
+    "require_human": "At least one human approval required",
+    "auto_merge": "Auto-merge enabled for this policy"
+  },
+  "actions": {
+    "heading": "Actions",
+    "requirements_not_met": "Requirements not met",
+    "publish": "Publish",
+    "publish_version": "Publish {version}",
+    "publish_note": "This will make {version} the accepted document.",
+    "publish_note_this_version": "This will make this version the accepted document.",
+    "awaiting_manager": "All reviewers approved. Waiting for a manager to publish.",
+    "revision_proposed_by": "{name} proposed a revision to this document.",
+    "publishing": "Publishing...",
+    "accept_and_publish": "Accept & Publish",
+    "request_another_review": "Request Another Review",
+    "propose_new_revision": "Propose New Revision",
+    "changes_were_requested": "Changes were requested. Edit the document and resubmit.",
+    "edit_and_resubmit": "Edit & Resubmit",
+    "you_sent_this": "You sent this review.",
+    "waiting_for_feedback": "Waiting for reviewer feedback.",
+    "you_approved": "You approved this round.",
+    "you_proposed_revision": "You proposed a revision.",
+    "you_requested_changes": "You requested changes.",
+    "waiting_for_author": "Waiting for {author} to respond.",
+    "waiting_for_reviewers": "Waiting for other reviewers.",
+    "stale_warning": "Document was updated after this review was sent. Review the latest changes before approving.",
+    "request_changes": "Request Changes",
+    "propose_revision": "Propose Revision",
+    "approve_heading": "Approve this document",
+    "approve_placeholder": "Optional comment...",
+    "approving": "Approving...",
+    "confirm_approve": "Confirm Approve",
+    "changes_heading": "Request changes",
+    "changes_placeholder": "Describe what needs to change... (required)",
+    "submitting": "Submitting...",
+    "submit_request": "Submit Request",
+    "withdraw": "Withdraw Review",
+    "close_without_merging": "Close Without Merging",
+    "not_a_reviewer": "You are not a reviewer on this request."
+  },
+  "closed_state": {
+    "merged": "Merged",
+    "closed": "Closed"
+  },
+  "document": {
+    "heading": "Document",
+    "id": "ID",
+    "comments": "Comments",
+    "open_comments": "Open"
+  },
+  "stat": {
+    "open": "Open",
+    "approved": "Approved",
+    "changes_requested": "Changes Requested",
+    "closed": "Closed",
+    "merged": "Merged"
+  },
+  "filter": {
+    "open": "Open",
+    "closed": "Closed"
+  },
+  "list": {
+    "empty_open": "No open reviews",
+    "empty_closed": "No closed reviews",
+    "item_title": "Review #{id} -- {title}",
+    "opened_by": "Opened by {name}",
+    "reviewer_status": "{name} ({status})"
+  },
+  "author_fallback": "author",
+  "reviewer_fallback": "A reviewer",
+  "revision_note_fallback": "Author edits",
+  "toast": {
+    "revision_published": "Revision accepted and published.",
+    "revision_accepted": "Accepted proposed revision",
+    "decision_recorded": "Your approval has been recorded{round}. Waiting on {count} more reviewer. | Your approval has been recorded{round}. Waiting on {count} more reviewers.",
+    "decision_recorded_changes": "Your request for changes has been recorded{round}. Waiting on {count} more reviewer. | Your request for changes has been recorded{round}. Waiting on {count} more reviewers.",
+    "all_approved": "All reviewers have approved{round}. Ready to merge.",
+    "changes_requested": "Changes requested{round}. The author will be notified.",
+    "for_round": " for Round {round}"
+  },
+  "confirm": {
+    "approve_stale_title": "Approve anyway",
+    "approve_stale_body": "The document was modified after this review was sent. Approve based on the current version?",
+    "discard_changes": "Discard unsaved changes?"
+  },
+  "error": {
+    "save_and_resubmit": "Save & resubmit failed: {message}",
+    "publish": "Failed to publish: {message}",
+    "accept_revision": "Failed to accept revision: {message}",
+    "submit_revision": "Failed to submit revision: {message}",
+    "load_list": "Failed to load reviews: {message}",
+    "load_one": "Failed to load review: {message}",
+    "add_comment": "Failed to add comment: {message}",
+    "submit_decision": "Failed to submit decision: {message}",
+    "merge": "Failed to merge review: {message}",
+    "close": "Failed to close review: {message}"
+  }
+}

--- a/web/src/locales/en/reviews.json
+++ b/web/src/locales/en/reviews.json
@@ -150,17 +150,6 @@
     "comments": "Comments",
     "open_comments": "Open"
   },
-  "stat": {
-    "open": "Open",
-    "approved": "Approved",
-    "changes_requested": "Changes Requested",
-    "closed": "Closed",
-    "merged": "Merged"
-  },
-  "filter": {
-    "open": "Open",
-    "closed": "Closed"
-  },
   "list": {
     "empty_open": "No open reviews",
     "empty_closed": "No closed reviews",

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -9,9 +9,9 @@
           <svg class="w-4 h-4 text-slate-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.121a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776" />
           </svg>
-          <span class="text-xs font-semibold text-slate-400 uppercase tracking-wider flex-1">Documents</span>
+          <span class="text-xs font-semibold text-slate-400 uppercase tracking-wider flex-1">{{ t('documents.tree.heading') }}</span>
           <div v-if="canEditMetadata" class="relative">
-            <button @click.stop="showNewMenu = !showNewMenu" class="p-1 rounded hover:bg-slate-700 text-slate-500 hover:text-slate-300 transition-colors" title="New">
+            <button @click.stop="showNewMenu = !showNewMenu" class="p-1 rounded hover:bg-slate-700 text-slate-500 hover:text-slate-300 transition-colors" :title="t('documents.tree.new')">
               <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
               </svg>
@@ -22,7 +22,7 @@
                 <svg class="w-3.5 h-3.5 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
                 </svg>
-                New Folder
+                {{ t('documents.tree.new_folder') }}
               </button>
               <button @click="openNewDocModal(); showNewMenu = false"
                 :disabled="folders.length === 0"
@@ -30,7 +30,7 @@
                 <svg class="w-3.5 h-3.5 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
                 </svg>
-                New Document
+                {{ t('documents.tree.new_document') }}
               </button>
             </div>
           </div>
@@ -45,13 +45,13 @@
       <!-- Empty state: sidebar -->
       <div v-else-if="folders.length === 0" class="flex-1 overflow-y-auto px-4 py-6">
         <div class="text-center">
-          <div class="text-xs text-slate-500 mb-4">No documents yet</div>
+          <div class="text-xs text-slate-500 mb-4">{{ t('documents.tree.empty') }}</div>
           <div class="space-y-2">
             <button @click="showTemplatePicker = true" class="w-full text-left flex items-center gap-2.5 px-3 py-2.5 bg-blue-600/10 hover:bg-blue-600/20 border border-blue-500/20 rounded-lg text-xs text-blue-400 transition-colors">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
               </svg>
-              Import template
+              {{ t('documents.tree.import_template') }}
             </button>
           </div>
         </div>
@@ -66,7 +66,7 @@
             @keydown.enter="confirmRootNewFolder"
             @keydown.escape="rootNewFolder.active = false"
             class="root-folder-input flex-1 bg-slate-800 border border-blue-500/50 rounded px-2 py-1 text-xs text-white focus:outline-none"
-            placeholder="new folder name..." />
+            :placeholder="t('documents.tree.new_folder_placeholder')" />
       </div>
 
       <!-- Recursive folder tree -->
@@ -95,7 +95,7 @@
                 @keydown.escape="cancelInlineNewFolder"
                 @blur="cancelInlineNewFolder"
                 class="inline-folder-input flex-1 bg-slate-800 border border-blue-500/50 rounded px-2 py-1 text-xs text-white focus:outline-none"
-                placeholder="folder name..." />
+                :placeholder="t('documents.tree.folder_name_placeholder')" />
             </div>
           </template>
         </DocTreeNode>
@@ -110,13 +110,13 @@
               <svg class="w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m3.75 9v6m3-3H9m1.5-12H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
               </svg>
-              New Document
+              {{ t('documents.tree.new_document') }}
             </button>
             <button @click="startInlineNewFolder(folderMenu.path)" class="w-full flex items-center gap-2 px-3 py-2 text-sm text-slate-300 hover:bg-slate-700 transition-colors text-left">
               <svg class="w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
               </svg>
-              New Folder
+              {{ t('documents.tree.new_folder') }}
             </button>
           </div>
         </div>
@@ -130,7 +130,7 @@
     <!-- Left panel toggle -->
     <button @click="showTreePanel = !showTreePanel"
       class="w-5 flex-shrink-0 bg-slate-900/50 border-r border-slate-800 flex items-center justify-center hover:bg-slate-800 transition-colors group"
-      :title="showTreePanel ? 'Hide tree' : 'Show tree'">
+      :title="showTreePanel ? t('documents.tree.hide') : t('documents.tree.show')">
       <svg class="w-3 h-3 text-slate-600 group-hover:text-slate-400 transition-transform" :class="{ 'rotate-180': !showTreePanel }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
       </svg>
@@ -146,15 +146,15 @@
             <svg class="w-16 h-16 text-slate-700 mb-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="0.75">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
             </svg>
-            <h2 class="text-xl font-semibold text-slate-200 mb-2">No documents yet</h2>
-            <p class="text-sm text-slate-500 mb-8 max-w-md">Import a template to scaffold your document structure, then use the tree menu to add documents and folders.</p>
+            <h2 class="text-xl font-semibold text-slate-200 mb-2">{{ t('documents.empty.heading') }}</h2>
+            <p class="text-sm text-slate-500 mb-8 max-w-md">{{ t('documents.empty.body') }}</p>
             <div class="flex gap-3">
               <button @click="showTemplatePicker = true"
                 class="flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
                 </svg>
-                Import template
+                {{ t('documents.empty.import_template') }}
               </button>
             </div>
           </div>
@@ -164,21 +164,21 @@
           <div class="flex items-center gap-1 mb-6 border-b border-slate-800">
             <button @click="docDashTab = 'review'" class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px"
               :class="docDashTab === 'review' ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'">
-              Needs Review
+              {{ t('documents.dash.tab.review') }}
               <span v-if="needsReviewChangedCount > 0" class="ml-1.5 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-500/20 text-amber-300 tabular-nums">{{ needsReviewChangedCount }}</span>
             </button>
             <button @click="docDashTab = 'recent'" class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px"
               :class="docDashTab === 'recent' ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'">
-              Recently Changed
+              {{ t('documents.dash.tab.recent') }}
               <span v-if="changedDocs.length > 0" class="ml-1.5 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-slate-700 text-slate-400 tabular-nums">{{ changedDocs.length }}</span>
             </button>
             <button @click="docDashTab = 'search'" class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px"
               :class="docDashTab === 'search' ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'">
-              Search
+              {{ t('documents.dash.tab.search') }}
             </button>
             <button v-if="canEditMetadata" @click="docDashTab = 'templates'" class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px"
               :class="docDashTab === 'templates' ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-500 hover:text-slate-300'">
-              Templates
+              {{ t('documents.dash.tab.templates') }}
             </button>
           </div>
 
@@ -187,7 +187,7 @@
             <div class="flex items-center justify-between mb-4">
               <label class="flex items-center gap-2 text-xs text-slate-500 cursor-pointer select-none">
                 <input v-model="includeNeverApproved" type="checkbox" class="rounded border-slate-600 bg-slate-800 text-blue-500 focus:ring-blue-500 focus:ring-offset-0 w-3.5 h-3.5" />
-                Include never approved ({{ allNeedsReviewDocs.filter(d => d.never_approved).length }})
+                {{ t('documents.needs_review.include_never_approved', { count: neverApprovedCount }) }}
               </label>
             </div>
             <div v-if="loadingNeedsReview" class="space-y-2">
@@ -197,7 +197,7 @@
               <svg class="w-10 h-10 text-emerald-500/30 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              <div class="text-sm text-slate-500">All documents are up to date.</div>
+              <div class="text-sm text-slate-500">{{ t('documents.needs_review.up_to_date') }}</div>
             </div>
             <div v-else class="space-y-2">
               <div v-for="doc in needsReviewDocs" :key="doc.document_id"
@@ -213,13 +213,18 @@
                     <div class="flex items-center gap-2 mb-1">
                       <span class="text-sm font-medium text-blue-400">{{ doc.document_id }}</span>
                       <span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-800 text-slate-500">{{ doc.folder }}</span>
-                      <span v-if="doc.never_approved" class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-red-500/20 text-red-400">Never approved</span>
-                      <span v-else class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-amber-500/20 text-amber-400">Changed</span>
+                      <span v-if="doc.never_approved" class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-red-500/20 text-red-400">{{ t('documents.needs_review.never_approved') }}</span>
+                      <span v-else class="text-[10px] px-1.5 py-0.5 rounded font-medium bg-amber-500/20 text-amber-400">{{ t('documents.needs_review.changed') }}</span>
                     </div>
                     <div v-if="doc.title" class="text-xs text-slate-300 mb-2 truncate">{{ doc.title }}</div>
                     <div class="flex items-center gap-4 text-[10px] text-slate-500">
-                      <span>Current: <span class="font-mono text-slate-400">{{ doc.current_commit }}</span> ({{ doc.current_commit_time }})</span>
-                      <span v-if="doc.approved_commit !== 'never'">Approved: <span class="font-mono text-slate-400">{{ doc.approved_commit }}</span></span>
+                      <i18n-t keypath="documents.needs_review.current" tag="span" scope="global">
+                        <template #commit><span class="font-mono text-slate-400">{{ doc.current_commit }}</span></template>
+                        <template #time>{{ doc.current_commit_time }}</template>
+                      </i18n-t>
+                      <i18n-t v-if="doc.approved_commit !== 'never'" keypath="documents.needs_review.approved" tag="span" scope="global">
+                        <template #commit><span class="font-mono text-slate-400">{{ doc.approved_commit }}</span></template>
+                      </i18n-t>
                     </div>
                     <div v-if="doc.change_summary && doc.change_summary.length > 0" class="mt-2 space-y-0.5">
                       <div v-for="(msg, i) in doc.change_summary.slice(0, 3)" :key="i" class="text-[10px] text-slate-600 truncate">{{ msg }}</div>
@@ -231,11 +236,11 @@
                       <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
                       </svg>
-                      Review
+                      {{ t('documents.needs_review.review') }}
                     </button>
                     <button v-if="!doc.never_approved" @click="viewNeedsReviewDiff(doc)"
                       class="inline-flex items-center gap-1 px-2.5 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-300 text-[11px] font-medium rounded-lg transition-colors border border-slate-700">
-                      Diff
+                      {{ t('documents.needs_review.diff') }}
                     </button>
                   </div>
                 </div>
@@ -253,21 +258,26 @@
                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" />
                 </svg>
-                Refresh
+                {{ t('documents.recent.refresh') }}
               </button>
             </div>
-            <div v-if="changedDocs.length === 0" class="text-center py-12 text-sm text-slate-600">No recent changes.</div>
+            <div v-if="changedDocs.length === 0" class="text-center py-12 text-sm text-slate-600">{{ t('documents.recent.empty') }}</div>
             <div v-else class="space-y-1">
               <button v-for="doc in changedDocs" :key="doc.path" @click="openChangedDoc(doc)"
                 class="w-full flex items-center gap-3 px-4 py-3 bg-slate-900 border border-slate-800 rounded-lg hover:border-blue-500/30 hover:bg-slate-900/80 transition-all text-left group">
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2">
-                    <span class="text-sm font-medium text-blue-400 group-hover:text-blue-300">{{ doc.document_id || doc.path.split('/').pop().replace('.md', '') }}</span>
+                    <span class="text-sm font-medium text-blue-400 group-hover:text-blue-300">{{ changedDocLabel(doc) }}</span>
                     <span class="text-[10px] px-1.5 py-0.5 rounded bg-slate-800 text-slate-500">{{ doc.folder }}</span>
                   </div>
                   <div v-if="doc.title" class="text-xs text-slate-400 mt-0.5 truncate">{{ doc.title }}</div>
                   <div class="text-[10px] text-slate-600 mt-1">
-                    {{ doc.commit_time }} by {{ doc.author }} — <span class="font-mono">{{ doc.commit_hash }}</span> {{ doc.commit_message }}
+                    <i18n-t keypath="documents.recent.meta" tag="span" scope="global">
+                      <template #time>{{ doc.commit_time }}</template>
+                      <template #author>{{ doc.author }}</template>
+                      <template #hash><span class="font-mono">{{ doc.commit_hash }}</span></template>
+                      <template #message>{{ doc.commit_message }}</template>
+                    </i18n-t>
                   </div>
                 </div>
                 <svg class="w-4 h-4 text-slate-700 group-hover:text-blue-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -287,7 +297,7 @@
                 v-model="searchQuery"
                 @input="onSearchInput"
                 type="text"
-                placeholder="Search all documents..."
+                :placeholder="t('documents.search.placeholder')"
                 class="w-full pl-10 pr-8 py-2.5 bg-slate-900 border border-slate-800 rounded-xl text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500"
               />
               <button v-if="searchQuery" @click="clearSearch" class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300">
@@ -297,10 +307,10 @@
               </button>
             </div>
             <div v-if="!searchQuery || searchQuery.length < 2" class="text-center py-12 text-sm text-slate-600">
-              Type at least 2 characters to search across all documents.
+              {{ t('documents.search.hint') }}
             </div>
-            <div v-else-if="searchLoading" class="text-center py-8 text-xs text-slate-600">Searching...</div>
-            <div v-else-if="searchResults.length === 0" class="text-center py-8 text-xs text-slate-600">No results for "{{ searchQuery }}"</div>
+            <div v-else-if="searchLoading" class="text-center py-8 text-xs text-slate-600">{{ t('documents.search.searching') }}</div>
+            <div v-else-if="searchResults.length === 0" class="text-center py-8 text-xs text-slate-600">{{ t('documents.search.no_results', { query: searchQuery }) }}</div>
             <div v-else class="space-y-1">
               <button v-for="result in searchResults" :key="result.path" @click="openSearchResult(result)"
                 class="w-full px-4 py-3 bg-slate-900 border border-slate-800 rounded-lg text-left hover:border-blue-500/30 hover:bg-slate-900/80 transition-all group">
@@ -317,8 +327,8 @@
           <!-- TAB: Templates (admin/manager only) -->
           <div v-else-if="docDashTab === 'templates' && canEditMetadata">
             <div class="flex items-center justify-between mb-4">
-              <h3 class="text-sm font-semibold text-slate-400">Templates</h3>
-              <p class="text-[11px] text-slate-600">Add or remove document scaffolding for standards.</p>
+              <h3 class="text-sm font-semibold text-slate-400">{{ t('documents.templates.heading') }}</h3>
+              <p class="text-[11px] text-slate-600">{{ t('documents.templates.subtitle') }}</p>
             </div>
             <div class="space-y-2">
               <div v-for="fw in templateList" :key="fw.id"
@@ -332,7 +342,7 @@
                   </div>
                 </div>
                 <div class="flex items-center gap-2 flex-shrink-0">
-                  <button v-if="fw.installed" @click="navigateToTemplate(fw.id)" class="text-[10px] text-emerald-500/70 font-medium px-2 py-0.5 bg-emerald-500/10 hover:bg-emerald-500/20 rounded transition-colors">Installed</button>
+                  <button v-if="fw.installed" @click="navigateToTemplate(fw.id)" class="text-[10px] text-emerald-500/70 font-medium px-2 py-0.5 bg-emerald-500/10 hover:bg-emerald-500/20 rounded transition-colors">{{ t('documents.templates.installed') }}</button>
                   <button v-if="!fw.installed" @click="addTemplate(fw.id)"
                     :disabled="templateLoading === fw.id"
                     class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors bg-blue-600/10 text-blue-400 hover:bg-blue-600/20 border border-blue-500/20 disabled:opacity-50">
@@ -340,7 +350,7 @@
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                       <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                     </svg>
-                    Add
+                    {{ t('documents.templates.add') }}
                   </button>
                   <button v-if="fw.installed" @click="confirmRemoveTemplate(fw)"
                     :disabled="templateLoading === fw.id"
@@ -349,7 +359,7 @@
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                       <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                     </svg>
-                    Remove
+                    {{ t('documents.templates.remove') }}
                   </button>
                 </div>
               </div>
@@ -363,20 +373,22 @@
           <!-- Remove template confirm dialog -->
           <div v-if="showRemoveConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" @click.self="showRemoveConfirm = false">
             <div class="bg-slate-900 border border-slate-700 rounded-xl p-6 max-w-sm w-full mx-4 shadow-xl">
-              <h3 class="text-sm font-semibold text-slate-200 mb-2">Remove Template</h3>
+              <h3 class="text-sm font-semibold text-slate-200 mb-2">{{ t('documents.templates.remove_heading') }}</h3>
               <p class="text-xs text-slate-400 mb-4">
-                Are you sure you want to remove <span class="font-semibold text-slate-200">{{ removeTarget?.label }}</span>?
-                This will delete all documents under <code class="text-[11px] bg-slate-800 px-1 py-0.5 rounded">documents/{{ removeTarget?.id }}/</code> from the repository.
+                <i18n-t keypath="documents.templates.remove_body" scope="global">
+                  <template #name><span class="font-semibold text-slate-200">{{ removeTarget?.label }}</span></template>
+                  <template #path><code class="text-[11px] bg-slate-800 px-1 py-0.5 rounded">documents/{{ removeTarget?.id }}/</code></template>
+                </i18n-t>
               </p>
               <div class="flex justify-end gap-2">
                 <button @click="showRemoveConfirm = false"
                   class="px-3 py-1.5 text-xs font-medium rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 border border-slate-700">
-                  Cancel
+                  {{ t('common.action.cancel') }}
                 </button>
                 <button @click="removeTemplate(removeTarget.id)"
                   :disabled="templateLoading === removeTarget?.id"
                   class="px-3 py-1.5 text-xs font-medium rounded-lg bg-red-600 hover:bg-red-500 text-white disabled:opacity-50">
-                  Remove
+                  {{ t('documents.templates.remove') }}
                 </button>
               </div>
             </div>
@@ -403,35 +415,35 @@
                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
                 </svg>
-                Edit
+                {{ t('documents.toolbar.edit') }}
               </button>
               <template v-if="editMode">
                 <button @click="saveEdit" :disabled="savingEdit"
                   class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded-md transition-colors bg-emerald-600 hover:bg-emerald-500 text-white disabled:opacity-50">
-                  {{ savingEdit ? 'Saving...' : 'Save' }}
+                  {{ savingEdit ? t('common.state.saving') : t('documents.toolbar.save') }}
                 </button>
                 <button @click="cancelEdit"
                   class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors text-slate-400 hover:text-slate-200 hover:bg-slate-800">
-                  Cancel
+                  {{ t('common.action.cancel') }}
                 </button>
               </template>
               <!-- Send for review (icon only) -->
               <button v-if="!editMode && canEditMetadata" @click="showReviewModal = true"
-                class="p-1.5 rounded-md transition-colors text-blue-400 hover:bg-blue-600/15" title="Send for review">
+                class="p-1.5 rounded-md transition-colors text-blue-400 hover:bg-blue-600/15" :title="t('documents.toolbar.send_for_review')">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
                 </svg>
               </button>
               <!-- History (icon only) — toggles Versions tab -->
               <button v-if="!editMode" @click="toggleHistory"
-                class="p-1.5 rounded-md transition-colors" :class="docTab === 'versions' ? 'text-blue-400 bg-blue-600/15' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'" title="Version history">
+                class="p-1.5 rounded-md transition-colors" :class="docTab === 'versions' ? 'text-blue-400 bg-blue-600/15' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'" :title="t('documents.toolbar.version_history')">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
               </button>
               <!-- Comments (icon only with count badge) -->
               <button @click="showRightPanel = !showRightPanel"
-                class="relative p-1.5 rounded-md transition-colors" :class="showRightPanel ? 'text-blue-400 bg-blue-600/15' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'" title="Comments">
+                class="relative p-1.5 rounded-md transition-colors" :class="showRightPanel ? 'text-blue-400 bg-blue-600/15' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'" :title="t('documents.toolbar.comments')">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 011.037-.443 48.282 48.282 0 005.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
                 </svg>
@@ -439,14 +451,14 @@
               </button>
               <!-- Print (icon only) -->
               <button v-if="!editMode" @click="printDocument"
-                class="p-1.5 rounded-md transition-colors text-slate-500 hover:text-slate-300 hover:bg-slate-800 no-print" title="Print document">
+                class="p-1.5 rounded-md transition-colors text-slate-500 hover:text-slate-300 hover:bg-slate-800 no-print" :title="t('documents.toolbar.print')">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0110.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0l.229 2.523a1.125 1.125 0 01-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0021 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 00-1.913-.247M6.34 18H5.25A2.25 2.25 0 013 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 011.913-.247m10.5 0a48.536 48.536 0 00-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18.25 7.034V3.375" />
                 </svg>
               </button>
               <!-- Delete (icon only) -->
               <button v-if="!editMode && canEditMetadata" @click="deleteCurrentDocument"
-                class="p-1.5 rounded-md transition-colors text-slate-600 hover:text-red-400 hover:bg-red-500/10" title="Delete document">
+                class="p-1.5 rounded-md transition-colors text-slate-600 hover:text-red-400 hover:bg-red-500/10" :title="t('documents.toolbar.delete')">
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                 </svg>
@@ -457,14 +469,7 @@
           <!-- Print-only header (hidden on screen, visible when printing) -->
           <div class="print-header hidden">
             <div class="print-title">{{ activeDoc.title || activeDoc.Title }}</div>
-            <div class="print-meta">
-              <span v-if="activeDoc.version">Version {{ activeDoc.version }}</span>
-              <span v-if="activeDoc.version && activeDoc.status"> &mdash; </span>
-              <span v-if="activeDoc.status">{{ activeDoc.status }}</span>
-              <span v-if="activeDoc.author"> &mdash; Author: {{ resolveUserName(activeDoc.author) || activeDoc.author }}</span>
-              <span> &mdash; {{ activeId }}</span>
-              <span> &mdash; Printed {{ formatDateValue(Date.now()) }}</span>
-            </div>
+            <div class="print-meta">{{ printMeta }}</div>
           </div>
 
           <!-- Title + status pill (always visible at top of pane) -->
@@ -477,14 +482,14 @@
           <div v-if="!editMode" class="border-b border-slate-800 no-print">
             <div class="flex gap-1">
               <button
-                v-for="t in docTabs"
-                :key="t.key"
-                @click="switchDocTab(t.key)"
+                v-for="tab in docTabs"
+                :key="tab.key"
+                @click="switchDocTab(tab.key)"
                 class="px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px"
-                :class="docTab === t.key
+                :class="docTab === tab.key
                   ? 'border-blue-500 text-blue-400'
                   : 'border-transparent text-slate-500 hover:text-slate-300'"
-              >{{ t.label }}</button>
+              >{{ tab.label }}</button>
             </div>
           </div>
 
@@ -492,53 +497,46 @@
           <div v-if="docTab === 'info' || editMode" class="bg-slate-900 border border-slate-800 rounded-xl p-6 no-print">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
               <div>
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Status</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.status') }}</div>
                 <router-link v-if="activeDoc.status === 'in_review' && activeDoc.active_review_id"
                   :to="orgPath(`/reviews/${activeDoc.active_review_id}`)"
-                  class="inline-block hover:opacity-80 transition-opacity" title="Go to active review">
+                  class="inline-block hover:opacity-80 transition-opacity" :title="t('documents.meta.go_to_active_review')">
                   <StatusBadge :status="activeDoc.status" />
                 </router-link>
                 <router-link v-else-if="activeDoc.status === 'in_review'"
                   :to="orgPath('/reviews')"
-                  class="inline-block hover:opacity-80 transition-opacity" title="Go to reviews">
+                  class="inline-block hover:opacity-80 transition-opacity" :title="t('documents.meta.go_to_reviews')">
                   <StatusBadge :status="activeDoc.status" />
                 </router-link>
                 <StatusBadge v-else-if="activeDoc.status" :status="activeDoc.status" />
                 <span v-else class="text-sm text-slate-400">--</span>
               </div>
               <div>
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Type</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.type') }}</div>
                 <div v-if="editMode">
                   <select :value="activeDoc.type || ''" @change="setDocType($event.target.value)"
                     class="w-full px-2 py-1 bg-slate-800 border border-slate-700 rounded text-sm text-slate-300 focus:outline-none focus:border-blue-500">
-                    <option value="">Document</option>
-                    <option value="policy">Policy</option>
-                    <option value="procedure">Procedure</option>
-                    <option value="control">Control</option>
-                    <option value="guideline">Guideline</option>
-                    <option value="record">Record</option>
-                    <option value="clause">Clause</option>
-                    <option value="requirement">Requirement</option>
+                    <option v-for="o in docTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
                   </select>
                 </div>
-                <div v-else class="text-sm text-slate-300 capitalize">{{ activeDoc.type || 'Document' }}</div>
+                <div v-else class="text-sm text-slate-300">{{ docTypeLabel(activeDoc.type) }}</div>
               </div>
               <div>
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Author</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.author') }}</div>
                 <div v-if="editMode" class="mt-0.5">
                   <MemberPicker
                     :modelValue="activeDoc.author || ''"
                     :members="allUsers"
-                    placeholder="Set author..."
+                    :placeholder="t('documents.meta.author_placeholder')"
                     @update:modelValue="setDocAuthor"
                   />
                 </div>
                 <div v-else class="text-sm" :class="activeDoc.author ? 'text-slate-300' : 'text-slate-600 italic'">
-                  {{ resolveUserName(activeDoc.author) || 'Not set' }}
+                  {{ resolveUserName(activeDoc.author) || t('documents.meta.not_set') }}
                 </div>
               </div>
               <div>
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Version</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.version') }}</div>
                 <div v-if="editMode">
                   <input v-model="editVersion"
                     class="w-20 px-2 py-1 bg-slate-800 border border-slate-700 rounded text-sm text-slate-300 focus:outline-none focus:border-blue-500" />
@@ -546,16 +544,16 @@
                 <div v-else class="text-sm text-slate-300">{{ activeDoc.version || '--' }}</div>
               </div>
               <div>
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Owner</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.owner') }}</div>
                 <div v-if="editMode">
                   <select v-model="editOwner"
                     class="w-full px-2 py-1 bg-slate-800 border border-slate-700 rounded text-sm text-slate-300 focus:outline-none focus:border-blue-500">
-                    <option value="">Not set</option>
+                    <option value="">{{ t('documents.meta.not_set') }}</option>
                     <option v-for="u in allUsers" :key="u.email" :value="u.email">{{ u.name || u.email }}</option>
                   </select>
                 </div>
                 <div v-else class="text-sm" :class="activeDoc.owner ? 'text-slate-300' : 'text-slate-600 italic'">
-                  {{ resolveUserName(activeDoc.owner) || resolveUserName(activeDoc.author) || 'Not set' }}
+                  {{ resolveUserName(activeDoc.owner) || resolveUserName(activeDoc.author) || t('documents.meta.not_set') }}
                 </div>
               </div>
             </div>
@@ -563,23 +561,23 @@
             <!-- Review cadence -->
             <div v-if="activeDoc.review_cycle || approvedAt" class="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-3 pt-3 border-t border-slate-800">
               <div v-if="activeDoc.review_cycle">
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Review Cycle</div>
-                <div class="text-sm text-slate-400">Every {{ activeDoc.review_cycle }} months</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.review_cycle') }}</div>
+                <div class="text-sm text-slate-400">{{ t('documents.meta.review_cycle_months', { count: activeDoc.review_cycle }, activeDoc.review_cycle) }}</div>
               </div>
               <div v-if="approvedAt">
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Last Approved</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.last_approved') }}</div>
                 <div class="text-sm text-slate-400">{{ approvedAt }}</div>
               </div>
               <div v-if="approvedVersion">
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Approved Version</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.approved_version') }}</div>
                 <div class="text-sm text-slate-400">{{ approvedVersion }}</div>
               </div>
               <div v-if="docNextReview">
-                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Next Review</div>
+                <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('documents.meta.next_review') }}</div>
                 <div class="text-sm" :class="docReviewOverdue ? 'text-red-400 font-medium' : docReviewDueSoon ? 'text-amber-400' : 'text-slate-400'">
                   {{ docNextReview }}
-                  <span v-if="docReviewOverdue" class="text-[10px] ml-1 px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-300 font-semibold">OVERDUE</span>
-                  <span v-else-if="docReviewDueSoon" class="text-[10px] ml-1 px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-300 font-semibold">DUE SOON</span>
+                  <span v-if="docReviewOverdue" class="text-[10px] ml-1 px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-300 font-semibold">{{ t('common.state.overdue') }}</span>
+                  <span v-else-if="docReviewDueSoon" class="text-[10px] ml-1 px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-300 font-semibold">{{ t('documents.meta.due_soon') }}</span>
                 </div>
               </div>
             </div>
@@ -595,20 +593,21 @@
                   <span class="w-2 h-2 mt-1.5 rounded-full bg-amber-500 animate-pulse flex-shrink-0" />
                   <div class="flex-1 min-w-0">
                     <div class="text-sm text-amber-300 font-medium">
-                      Round {{ activeDoc.active_review_round || 1 }} complete — changes requested
+                      {{ t('documents.banner.round_complete', { round: activeDoc.active_review_round || 1 }) }}
                     </div>
                     <div class="text-xs text-amber-400/80 mt-0.5">
                       <span v-if="activeDoc.active_review_pending_suggestions > 0">
-                        {{ activeDoc.active_review_pending_suggestions }}
-                        pending suggestion{{ activeDoc.active_review_pending_suggestions === 1 ? '' : 's' }} to address.
+                        {{ t('documents.banner.pending_suggestions',
+                             { count: activeDoc.active_review_pending_suggestions },
+                             activeDoc.active_review_pending_suggestions) }}
                       </span>
-                      <span v-else>Reviewer feedback is waiting on the conversation.</span>
-                      Address the feedback, then resubmit for the next round.
+                      <span v-else>{{ t('documents.banner.feedback_waiting') }}</span>
+                      {{ t('documents.banner.then_resubmit') }}
                     </div>
                   </div>
                   <router-link :to="orgPath(`/reviews/${activeDoc.active_review_id}`)"
                     class="text-xs px-3 py-1.5 rounded-md bg-amber-600 hover:bg-amber-500 text-white font-medium transition-colors flex-shrink-0">
-                    Open review
+                    {{ t('documents.banner.open_review') }}
                   </router-link>
                 </div>
               </div>
@@ -616,10 +615,12 @@
               <div v-else class="flex items-center gap-2 text-xs">
                 <span class="w-2 h-2 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
                 <span class="text-blue-400">
-                  This document is in review<template v-if="activeDoc.active_review_round"> (Round {{ activeDoc.active_review_round }})</template>.
+                  {{ activeDoc.active_review_round
+                    ? t('documents.banner.in_review_round', { round: activeDoc.active_review_round })
+                    : t('documents.banner.in_review') }}
                 </span>
                 <router-link :to="orgPath(`/reviews/${activeDoc.active_review_id}`)"
-                  class="text-blue-400 hover:text-blue-300 ml-auto">View review →</router-link>
+                  class="text-blue-400 hover:text-blue-300 ml-auto">{{ t('documents.banner.view_review') }}</router-link>
               </div>
             </div>
 
@@ -629,26 +630,26 @@
               <!-- Retired -->
               <div v-if="activeDoc.status === 'retired'" class="flex items-center gap-2 text-xs">
                 <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0" />
-                <span class="text-slate-500">This document is retired.</span>
+                <span class="text-slate-500">{{ t('documents.banner.retired') }}</span>
               </div>
 
               <!-- 3. Never approved, not in review -->
               <div v-else-if="isDocNeverApproved" class="flex items-center gap-2 text-xs">
                 <span class="w-2 h-2 rounded-full bg-slate-600 flex-shrink-0" />
-                <span class="text-slate-500">This document has never been approved.</span>
-                <button v-if="canEditMetadata" @click="showReviewModal = true" class="text-blue-400 hover:text-blue-300 ml-auto">Send for review →</button>
+                <span class="text-slate-500">{{ t('documents.banner.never_approved') }}</span>
+                <button v-if="canEditMetadata" @click="showReviewModal = true" class="text-blue-400 hover:text-blue-300 ml-auto">{{ t('documents.banner.send_for_review') }}</button>
               </div>
 
               <!-- 4. Approved but has changes since -->
               <div v-else-if="isDocDirty" class="flex items-center gap-2 text-xs flex-wrap">
                 <span class="w-2 h-2 rounded-full bg-amber-500 animate-pulse flex-shrink-0" />
-                <span class="text-amber-400">Changed since last approval</span>
-                <span class="text-slate-600">— last approved{{ approvedVersion ? ` ${approvedVersion}` : '' }}<span v-if="approvedAt"> on {{ approvedAt }}</span></span>
+                <span class="text-amber-400">{{ t('documents.banner.changed_since_approval') }}</span>
+                <span class="text-slate-600">{{ lastApprovedLabel }}</span>
                 <div class="ml-auto flex gap-2">
                   <button @click="viewApprovedVersion" class="text-slate-500 hover:text-slate-300">
-                    {{ showApprovedDiff ? 'Hide diff' : 'View diff' }}
+                    {{ showApprovedDiff ? t('documents.banner.hide_diff') : t('documents.banner.view_diff') }}
                   </button>
-                  <button v-if="canEditMetadata" @click="showReviewModal = true" class="text-blue-400 hover:text-blue-300">Send for review →</button>
+                  <button v-if="canEditMetadata" @click="showReviewModal = true" class="text-blue-400 hover:text-blue-300">{{ t('documents.banner.send_for_review') }}</button>
                 </div>
               </div>
               <!-- Diff since approval -->
@@ -662,13 +663,13 @@
           <!-- Version history panel (Versions tab) -->
           <div v-if="docTab === 'versions' && !editMode" class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
             <div class="px-4 py-3 border-b border-slate-800">
-              <span class="text-sm font-semibold text-slate-300">Version History</span>
+              <span class="text-sm font-semibold text-slate-300">{{ t('documents.versions.heading') }}</span>
             </div>
             <div v-if="loadingVersions" class="p-4 space-y-2">
               <div v-for="i in 3" :key="i" class="h-4 bg-slate-800 rounded animate-pulse" />
             </div>
             <div v-else-if="versions.length === 0" class="p-4 text-xs text-slate-600 text-center">
-              No version history available
+              {{ t('documents.versions.empty') }}
             </div>
             <div v-else class="divide-y divide-slate-800 max-h-48 overflow-y-auto">
               <button
@@ -681,11 +682,11 @@
                 <div class="w-2 h-2 rounded-full flex-shrink-0" :class="idx === 0 ? 'bg-emerald-500' : 'bg-slate-600'" />
                 <div class="flex-1 min-w-0">
                   <div class="text-xs text-slate-300 truncate">
-                    <span class="font-semibold">{{ ver.version || 'v?' }}</span>
+                    <span class="font-semibold">{{ ver.version || t('documents.versions.unknown_version') }}</span>
                     <span v-if="ver.message" class="text-slate-400 ml-1.5">{{ ver.message }}</span>
                   </div>
                   <div class="text-[10px] text-slate-600">
-                    {{ ver.created_by }} — {{ formatDate(ver.created_at) }}
+                    {{ t('documents.versions.meta', { author: ver.created_by, date: formatDate(ver.created_at) }) }}
                   </div>
                 </div>
               </button>
@@ -706,13 +707,13 @@
 
           <!-- Discussion tab — document-level comments (paragraph-level inline comments stay on Content) -->
           <div v-if="docTab === 'discussion' && !editMode && activeDoc && activeId" class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-            <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">Document discussion</div>
+            <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">{{ t('documents.panel.discussion') }}</div>
             <CommentsPanel entityType="document" :entityId="activeId" />
           </div>
 
           <!-- History tab — entity changelog -->
           <div v-if="docTab === 'history' && !editMode && activeDoc && activeId" class="bg-slate-900 border border-slate-800 rounded-xl p-4">
-            <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">Document changelog</div>
+            <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">{{ t('documents.panel.changelog') }}</div>
             <HistoryPanel entityType="document" :entityId="activeId" />
           </div>
 
@@ -720,7 +721,7 @@
           <div v-if="docTab === 'content' && inlineCommentCount > 0 && !editMode" class="flex items-center gap-2 px-1">
             <div class="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
             <span class="text-xs text-slate-500">
-              {{ inlineCommentCount }} inline comment{{ inlineCommentCount === 1 ? '' : 's' }} on this document
+              {{ t('documents.content.inline_comment_count', { count: inlineCommentCount }, inlineCommentCount) }}
             </span>
           </div>
 
@@ -729,8 +730,8 @@
             <svg class="w-4 h-4 text-amber-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
             </svg>
-            <span class="text-amber-300 flex-1">Unsaved draft recovered</span>
-            <button @click="discardDraft" class="text-xs text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800">Discard draft</button>
+            <span class="text-amber-300 flex-1">{{ t('documents.content.draft_recovered') }}</span>
+            <button @click="discardDraft" class="text-xs text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800">{{ t('common.action.discard_draft') }}</button>
           </div>
 
           <!-- Document editor (edit mode) -->
@@ -776,7 +777,7 @@
                 :class="reviewedBlocks.has(block.index)
                   ? 'bg-emerald-500 text-white scale-100 shadow-md shadow-emerald-900/40'
                   : 'border border-slate-700 text-transparent opacity-0 group-hover:opacity-60 hover:!opacity-100 hover:border-slate-500'"
-                :title="reviewedBlocks.has(block.index) ? 'Mark as unreviewed' : 'Mark as reviewed'"
+                :title="reviewedBlocks.has(block.index) ? t('documents.content.mark_unreviewed') : t('documents.content.mark_reviewed')"
               >
                 <svg class="w-3 h-3 transition-transform duration-300" :class="reviewedBlocks.has(block.index) ? 'scale-100' : 'scale-0'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
@@ -791,7 +792,7 @@
                 v-if="hasOpenComments(block.index)"
                 @click="toggleBlockComments(block.index)"
                 class="absolute -right-10 top-1 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center cursor-pointer hover:bg-blue-500 transition-colors shadow-lg shadow-blue-900/30"
-                :title="commentCountForBlock(block.index) + ' comment' + (commentCountForBlock(block.index) === 1 ? '' : 's')"
+                :title="blockCommentTitle(block.index)"
               >
                 {{ commentCountForBlock(block.index) }}
               </div>
@@ -801,7 +802,7 @@
                 v-if="!hasOpenComments(block.index)"
                 @click.stop="startInlineComment(block.index)"
                 class="absolute -right-10 top-1 w-6 h-6 rounded-full bg-slate-700 text-slate-400 text-xs flex items-center justify-center cursor-pointer opacity-0 group-hover:opacity-100 transition-all duration-200 hover:bg-blue-600 hover:text-white hover:shadow-lg hover:shadow-blue-900/30 hover:scale-110"
-                title="Add comment"
+                :title="t('documents.content.add_comment')"
               >
                 +
               </button>
@@ -830,18 +831,18 @@
                         <svg class="w-3 h-3 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                           <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                         </svg>
-                        <span class="text-[10px] text-emerald-500 font-medium">Resolved</span>
+                        <span class="text-[10px] text-emerald-500 font-medium">{{ t('documents.content.resolved') }}</span>
                       </div>
                       <button
                         v-else
                         @click="resolveComment(comment.id)"
                         class="ml-auto text-[10px] text-slate-500 hover:text-emerald-400 transition-colors"
-                      >Resolve</button>
+                      >{{ t('common.action.resolve') }}</button>
                     </div>
                     <!-- Resolved: show collapsed or expanded body -->
                     <template v-if="comment.status === 'resolved'">
                       <div class="text-[10px] text-emerald-500/70 flex items-center gap-1 mb-1">
-                        Resolved by {{ comment.resolved_by || 'unknown' }} {{ formatDate(comment.resolved_at) }}
+                        {{ resolvedByLabel(comment) }}
                       </div>
                       <div
                         v-if="!expandedResolvedInline.has(comment.id)"
@@ -864,7 +865,7 @@
                     <textarea
                       ref="inlineTextareaRef"
                       v-model="inlineCommentText"
-                      placeholder="Add a comment on this paragraph... (type @ to mention)"
+                      :placeholder="t('documents.content.inline_placeholder')"
                       class="w-full bg-transparent border border-slate-700 rounded-md p-2 text-sm text-slate-300 placeholder-slate-600 resize-none focus:outline-none focus:ring-1 focus:border-blue-500 focus:ring-blue-500/30"
                       rows="2"
                       @input="e => handleCommentInput(e, 'inline')"
@@ -887,19 +888,19 @@
                           <div class="text-[10px] text-slate-600 truncate">{{ u.email }}</div>
                         </div>
                       </button>
-                      <div v-if="mentionUsers.length === 0" class="px-3 py-2 text-xs text-slate-500">No users found</div>
+                      <div v-if="mentionUsers.length === 0" class="px-3 py-2 text-xs text-slate-500">{{ t('documents.content.no_users') }}</div>
                     </div>
                     <div class="flex items-center justify-end mt-2">
                       <div class="flex gap-2">
                         <button
                           @click="expandedBlock = null; inlineCommentText = ''"
                           class="text-xs text-slate-500 hover:text-slate-300 px-2 py-1 rounded transition-colors cursor-pointer"
-                        >Cancel</button>
+                        >{{ t('common.action.cancel') }}</button>
                         <button
                           @click="submitInlineComment(expandedBlock)"
                           :disabled="!inlineCommentText.trim() || submittingInline"
                           class="text-xs bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white px-3 py-1 rounded font-medium transition-colors cursor-pointer"
-                        >{{ submittingInline ? 'Saving...' : 'Comment' }}
+                        >{{ submittingInline ? t('common.state.saving') : t('common.action.comment') }}
                         </button>
                       </div>
                     </div>
@@ -911,7 +912,7 @@
 
           <!-- No content -->
           <div v-else-if="!editMode && !loadingContent" class="py-8 text-center text-sm text-slate-600">
-            No content available for this document.
+            {{ t('documents.content.empty') }}
           </div>
           </template>
         </div>
@@ -922,7 +923,7 @@
     <aside v-if="showRightPanel" class="w-[340px] flex-shrink-0 bg-slate-900 border-l border-slate-800 flex flex-col overflow-hidden">
       <!-- No doc selected -->
       <div v-if="!activeDoc" class="flex items-center justify-center h-full">
-        <div class="text-xs text-slate-600">Select a document to view comments</div>
+        <div class="text-xs text-slate-600">{{ t('documents.comments.no_document') }}</div>
       </div>
 
       <template v-else>
@@ -933,11 +934,11 @@
             <svg class="w-3.5 h-3.5 text-slate-500 transition-transform" :class="{ 'rotate-90': showCommentPanel }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
             </svg>
-            <h3 class="text-sm font-semibold text-slate-300">Comments</h3>
+            <h3 class="text-sm font-semibold text-slate-300">{{ t('documents.comments.heading') }}</h3>
           </div>
           <div class="flex items-center gap-2">
             <span v-if="openCommentCount > 0" class="text-xs font-bold bg-blue-600 text-white px-1.5 py-0.5 rounded-full">{{ openCommentCount }}</span>
-            <span v-if="resolvedCommentCount > 0" class="text-xs text-slate-600">{{ resolvedCommentCount }} resolved</span>
+            <span v-if="resolvedCommentCount > 0" class="text-xs text-slate-600">{{ t('documents.comments.resolved_count', { count: resolvedCommentCount }) }}</span>
           </div>
         </button>
 
@@ -945,7 +946,7 @@
         <div v-show="showCommentPanel" class="px-5 py-4 border-b border-slate-800 space-y-3 flex-shrink-0 relative">
           <textarea
             v-model="newComment"
-            placeholder="Add a general comment... (type @ to mention)"
+            :placeholder="t('documents.comments.general_placeholder')"
             rows="3"
             class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 resize-none"
             @input="e => handleCommentInput(e, 'panel')"
@@ -966,12 +967,12 @@
                 <div class="text-[10px] text-slate-600 truncate">{{ u.email }}</div>
               </div>
             </button>
-            <div v-if="mentionUsers.length === 0" class="px-3 py-2 text-xs text-slate-500">No users found</div>
+            <div v-if="mentionUsers.length === 0" class="px-3 py-2 text-xs text-slate-500">{{ t('documents.content.no_users') }}</div>
           </div>
           <div class="flex items-center gap-2">
             <input
               v-model="commentAuthor"
-              placeholder="Your name"
+              :placeholder="t('documents.comments.author_placeholder')"
               class="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
             />
             <button
@@ -979,7 +980,7 @@
               :disabled="!newComment.trim() || submitting"
               class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors"
             >
-              {{ submitting ? 'Sending...' : 'Send' }}
+              {{ submitting ? t('common.state.sending') : t('documents.comments.send') }}
             </button>
           </div>
         </div>
@@ -1007,16 +1008,16 @@
                 <svg class="w-3 h-3 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
                 </svg>
-                <span class="text-[10px] text-blue-400 font-medium">Inline comment</span>
+                <span class="text-[10px] text-blue-400 font-medium">{{ t('documents.comments.inline_label') }}</span>
                 <span v-if="comment.quote" class="text-[10px] text-slate-600 truncate max-w-[180px]">
-                  — "{{ comment.quote }}"
+                  {{ t('documents.comments.quote', { quote: comment.quote }) }}
                 </span>
               </div>
               <div v-else class="flex items-center gap-1.5 mb-2">
                 <svg class="w-3 h-3 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>
-                <span class="text-[10px] text-slate-500 font-medium">Document comment</span>
+                <span class="text-[10px] text-slate-500 font-medium">{{ t('documents.comments.document_label') }}</span>
               </div>
               <div class="flex items-baseline gap-2 mb-1.5">
                 <span class="text-[13px] font-semibold text-slate-300">{{ comment.author }}</span>
@@ -1028,13 +1029,13 @@
                   @click.stop="startPanelReply(comment)"
                   class="text-[11px] text-slate-500 hover:text-blue-400 transition-colors cursor-pointer"
                 >
-                  Reply
+                  {{ t('documents.comments.reply') }}
                 </button>
                 <button
                   @click.stop="resolveComment(comment.id)"
                   class="text-[11px] text-slate-500 hover:text-emerald-400 transition-colors cursor-pointer"
                 >
-                  Resolve
+                  {{ t('common.action.resolve') }}
                 </button>
               </div>
 
@@ -1051,7 +1052,7 @@
               <div v-if="panelReplyingTo === comment.id" class="mt-2 ml-4 pl-3 border-l-2 border-blue-600">
                 <textarea
                   v-model="panelReplyText"
-                  placeholder="Write a reply..."
+                  :placeholder="t('documents.comments.reply_placeholder')"
                   rows="2"
                   class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
                   @keydown.meta.enter="submitPanelReply"
@@ -1059,9 +1060,9 @@
                 />
                 <div class="flex gap-2 mt-1">
                   <button @click="submitPanelReply" :disabled="!panelReplyText.trim()"
-                    class="px-2 py-1 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-[10px] font-medium rounded cursor-pointer">Reply</button>
+                    class="px-2 py-1 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-[10px] font-medium rounded cursor-pointer">{{ t('documents.comments.reply') }}</button>
                   <button @click="panelReplyingTo = null"
-                    class="px-2 py-1 text-[10px] text-slate-500 hover:text-slate-300 cursor-pointer">Cancel</button>
+                    class="px-2 py-1 text-[10px] text-slate-500 hover:text-slate-300 cursor-pointer">{{ t('common.action.cancel') }}</button>
                 </div>
               </div>
             </div>
@@ -1083,7 +1084,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                 </svg>
                 <span class="text-[11px] font-medium text-slate-600">
-                  {{ resolvedComments.length }} resolved comment{{ resolvedComments.length === 1 ? '' : 's' }}
+                  {{ t('documents.comments.resolved_toggle', { count: resolvedComments.length }, resolvedComments.length) }}
                 </span>
               </button>
               <template v-if="showResolvedPanel">
@@ -1096,9 +1097,9 @@
                     <svg class="w-3 h-3 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
                     </svg>
-                    <span class="text-[10px] text-slate-600 font-medium">Inline</span>
+                    <span class="text-[10px] text-slate-600 font-medium">{{ t('documents.comments.inline_label_short') }}</span>
                     <span v-if="comment.quote" class="text-[10px] text-slate-700 truncate max-w-[180px]">
-                      &mdash; "{{ comment.quote }}"
+                      {{ t('documents.comments.quote', { quote: comment.quote }) }}
                     </span>
                   </div>
                   <div class="flex items-baseline gap-2 mb-1">
@@ -1110,7 +1111,7 @@
                     <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                     </svg>
-                    Resolved by {{ comment.resolved_by || 'unknown' }} {{ formatDate(comment.resolved_at) }}
+                    {{ resolvedByLabel(comment) }}
                   </div>
                 </div>
               </template>
@@ -1118,7 +1119,7 @@
           </template>
 
           <div v-else class="p-5 text-center">
-            <div class="text-xs text-slate-600 mt-4">No comments yet</div>
+            <div class="text-xs text-slate-600 mt-4">{{ t('documents.comments.empty') }}</div>
           </div>
         </div>
       </template>
@@ -1129,11 +1130,11 @@
       <div v-if="showReviewModal" class="fixed inset-0 z-50 flex items-center justify-center">
         <div class="absolute inset-0 bg-black/60" @click="showReviewModal = false" />
         <div class="relative bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl w-full max-w-md p-6 space-y-4">
-          <h2 class="text-lg font-bold text-white">Send for review</h2>
+          <h2 class="text-lg font-bold text-white">{{ t('documents.review_modal.heading') }}</h2>
           <p class="text-sm text-slate-400">{{ activeDoc?.title || activeId }}</p>
 
           <div>
-            <label class="block text-xs text-slate-500 mb-2">Reviewers</label>
+            <label class="block text-xs text-slate-500 mb-2">{{ t('documents.review_modal.reviewers') }}</label>
             <!-- Selected reviewers -->
             <div v-if="selectedReviewers.length > 0" class="flex flex-wrap gap-1.5 mb-2">
               <span
@@ -1154,7 +1155,7 @@
               <input
                 v-model="reviewerSearch"
                 type="text"
-                placeholder="Search members..."
+                :placeholder="t('documents.review_modal.search_members')"
                 class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500"
                 @focus="showReviewerDropdown = true"
               />
@@ -1174,21 +1175,21 @@
                   </div>
                   <span class="text-[10px] px-1.5 py-0.5 rounded-full"
                     :class="member.role === 'admin' ? 'bg-purple-500/20 text-purple-300' : member.role === 'manager' ? 'bg-blue-500/20 text-blue-300' : 'bg-slate-500/20 text-slate-400'">
-                    {{ member.role }}
+                    {{ roleLabel(member.role) }}
                   </span>
                 </button>
               </div>
             </div>
           </div>
           <div>
-            <label class="block text-xs text-slate-500 mb-1">Version note <span class="text-red-400">*</span></label>
+            <label class="block text-xs text-slate-500 mb-1">{{ t('documents.review_modal.version_note') }} <span class="text-red-400">*</span></label>
             <textarea
               v-model="reviewMessage"
               rows="3"
-              placeholder="e.g. Updated risk assessment criteria. Added data classification table."
+              :placeholder="t('documents.review_modal.version_note_placeholder')"
               class="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500 resize-none"
             />
-            <div class="text-[10px] text-slate-600 mt-1">This becomes part of the document's permanent version history after approval.</div>
+            <div class="text-[10px] text-slate-600 mt-1">{{ t('documents.review_modal.version_note_hint') }}</div>
           </div>
 
           <div v-if="reviewError" class="text-xs text-red-400">{{ reviewError }}</div>
@@ -1199,10 +1200,12 @@
               :disabled="reviewSending || selectedReviewers.length === 0 || !reviewMessage.trim()"
               class="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
             >
-              {{ reviewSending ? 'Sending...' : `Send to ${selectedReviewers.length} reviewer${selectedReviewers.length !== 1 ? 's' : ''}` }}
+              {{ reviewSending
+                ? t('common.state.sending')
+                : t('documents.review_modal.send', { count: selectedReviewers.length }, selectedReviewers.length) }}
             </button>
             <button @click="showReviewModal = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">
-              Cancel
+              {{ t('common.action.cancel') }}
             </button>
           </div>
         </div>
@@ -1216,27 +1219,22 @@
       <div v-if="showNewDocModal" class="fixed inset-0 z-50 flex items-center justify-center">
         <div class="absolute inset-0 bg-black/60" @click="showNewDocModal = false" />
         <form @submit.prevent="createDocument" class="relative bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 max-w-lg w-full mx-4 space-y-4">
-          <h2 class="text-lg font-semibold text-slate-100">New Document</h2>
+          <h2 class="text-lg font-semibold text-slate-100">{{ t('documents.new_doc.heading') }}</h2>
 
           <div class="space-y-4">
             <!-- Title — primary field, always first -->
             <div>
-              <label class="block text-xs text-slate-500 mb-1">Title <span class="text-red-400">*</span></label>
+              <label class="block text-xs text-slate-500 mb-1">{{ t('documents.new_doc.title') }} <span class="text-red-400">*</span></label>
               <input v-model="newDoc.title" @input="autoSlug" type="text" autofocus
                 class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-sm text-white focus:outline-none focus:border-blue-500"
-                placeholder="e.g. Data Classification Policy" />
+                :placeholder="t('documents.new_doc.title_placeholder')" />
             </div>
             <!-- Type -->
             <div>
-              <label class="block text-xs text-slate-500 mb-1">Type</label>
+              <label class="block text-xs text-slate-500 mb-1">{{ t('documents.new_doc.type') }}</label>
               <select v-model="newDoc.type"
                 class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-sm text-white focus:outline-none focus:border-blue-500">
-                <option value="">Document</option>
-                <option value="policy">Policy</option>
-                <option value="procedure">Procedure</option>
-                <option value="control">Control</option>
-                <option value="guideline">Guideline</option>
-                <option value="record">Record</option>
+                <option v-for="o in newDocTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
               </select>
             </div>
             <!-- Location — compact, sensible default, not the focus -->
@@ -1245,14 +1243,14 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
               </svg>
               <span v-if="newDoc.folder && !showFolderPicker" class="text-slate-400">{{ newDoc.folder }}</span>
-              <span v-if="!newDoc.folder && !showFolderPicker" class="text-slate-500 italic">No folder selected</span>
+              <span v-if="!newDoc.folder && !showFolderPicker" class="text-slate-500 italic">{{ t('documents.new_doc.no_folder') }}</span>
               <button v-if="!showFolderPicker" @click="showFolderPicker = true" class="text-blue-400 hover:text-blue-300 ml-auto text-[10px]">
-                {{ newDoc.folder ? 'change' : 'pick folder' }}
+                {{ newDoc.folder ? t('documents.new_doc.change_folder') : t('documents.new_doc.pick_folder') }}
               </button>
               <div v-if="showFolderPicker" class="flex-1">
                 <input v-model="newDoc.folder" type="text" list="folder-list"
                   class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-white focus:outline-none focus:border-blue-500"
-                  placeholder="Type or select folder" @blur="showFolderPicker = false" />
+                  :placeholder="t('documents.new_doc.folder_placeholder')" @blur="showFolderPicker = false" />
                 <datalist id="folder-list">
                   <option v-for="f in allFolderPaths" :key="f" :value="f" />
                 </datalist>
@@ -1260,25 +1258,25 @@
             </div>
             <!-- Advanced (collapsed by default) -->
             <button @click="showNewDocAdvanced = !showNewDocAdvanced" class="text-[10px] text-slate-600 hover:text-slate-400 transition-colors">
-              {{ showNewDocAdvanced ? 'Hide' : 'Show' }} advanced options
+              {{ showNewDocAdvanced ? t('documents.new_doc.hide_advanced') : t('documents.new_doc.show_advanced') }}
             </button>
             <div v-if="showNewDocAdvanced" class="grid grid-cols-2 gap-3 pt-1">
               <div>
-                <label class="block text-[10px] text-slate-600 mb-1">Document ID</label>
+                <label class="block text-[10px] text-slate-600 mb-1">{{ t('documents.new_doc.document_id') }}</label>
                 <input v-model="newDoc.document_id" @input="slugManuallyEdited = true" type="text"
                   class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-white font-mono focus:outline-none focus:border-blue-500"
-                  placeholder="auto from title" />
-                <div v-if="newDoc.document_id && docIdExists" class="text-[10px] text-red-400 mt-1">This ID already exists</div>
+                  :placeholder="t('documents.new_doc.document_id_placeholder')" />
+                <div v-if="newDoc.document_id && docIdExists" class="text-[10px] text-red-400 mt-1">{{ t('documents.new_doc.document_id_exists') }}</div>
               </div>
               <div>
-                <label class="block text-[10px] text-slate-600 mb-1">Filename</label>
+                <label class="block text-[10px] text-slate-600 mb-1">{{ t('documents.new_doc.filename') }}</label>
                 <input v-model="newDoc.filename" type="text"
                   class="w-full bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-white font-mono focus:outline-none focus:border-blue-500"
-                  placeholder="auto from ID" />
+                  :placeholder="t('documents.new_doc.filename_placeholder')" />
               </div>
               <div class="col-span-2">
-                <label class="block text-[10px] text-slate-600 mb-1">Author</label>
-                <MemberPicker :modelValue="newDoc.author" :members="allUsers" placeholder="Select author..." @update:modelValue="v => newDoc.author = v" />
+                <label class="block text-[10px] text-slate-600 mb-1">{{ t('documents.new_doc.author') }}</label>
+                <MemberPicker :modelValue="newDoc.author" :members="allUsers" :placeholder="t('documents.new_doc.author_placeholder')" @update:modelValue="v => newDoc.author = v" />
               </div>
             </div>
           </div>
@@ -1288,9 +1286,9 @@
           <div class="flex gap-2 pt-2">
             <button type="submit" :disabled="newDocSaving || !newDoc.title || !newDoc.document_id || !newDoc.folder || docIdExists"
               class="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50">
-              {{ newDocSaving ? 'Creating...' : 'Create Document' }}
+              {{ newDocSaving ? t('common.state.creating') : t('documents.new_doc.create') }}
             </button>
-            <button type="button" @click="showNewDocModal = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">Cancel</button>
+            <button type="button" @click="showNewDocModal = false" class="px-4 py-2.5 text-sm text-slate-400 hover:text-white">{{ t('common.action.cancel') }}</button>
           </div>
         </form>
       </div>
@@ -1303,15 +1301,15 @@
       <div v-if="showTemplatePicker" class="fixed inset-0 z-50 flex items-center justify-center">
         <div class="absolute inset-0 bg-black/60" @click="showTemplatePicker = false" />
         <div class="relative bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 max-w-lg w-full mx-4">
-          <h2 class="text-lg font-semibold text-slate-100 mb-1">Import template</h2>
-          <p class="text-xs text-slate-500 mb-4">Choose a standard to scaffold your document structure.</p>
+          <h2 class="text-lg font-semibold text-slate-100 mb-1">{{ t('documents.templates.picker_heading') }}</h2>
+          <p class="text-xs text-slate-500 mb-4">{{ t('documents.templates.picker_subtitle') }}</p>
 
           <input v-model="templateSearch" type="text" autofocus
             class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500 mb-3"
-            placeholder="Search templates..." />
+            :placeholder="t('documents.templates.picker_placeholder')" />
 
           <div v-if="filteredTemplates.length === 0" class="text-center py-6 text-xs text-slate-600">
-            No templates found.
+            {{ t('documents.templates.picker_empty') }}
           </div>
           <div v-else class="space-y-1.5 max-h-72 overflow-y-auto">
             <button v-for="tmpl in filteredTemplates" :key="tmpl.id"
@@ -1332,7 +1330,7 @@
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                   <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
-                <span v-else class="text-xs text-blue-400 group-hover:text-blue-300 font-medium">Import</span>
+                <span v-else class="text-xs text-blue-400 group-hover:text-blue-300 font-medium">{{ t('documents.templates.import') }}</span>
               </div>
             </button>
           </div>
@@ -1343,7 +1341,7 @@
           </div>
 
           <div class="flex justify-end mt-4">
-            <button @click="showTemplatePicker = false" class="text-sm text-slate-400 hover:text-white">Cancel</button>
+            <button @click="showTemplatePicker = false" class="text-sm text-slate-400 hover:text-white">{{ t('common.action.cancel') }}</button>
           </div>
         </div>
       </div>
@@ -1354,6 +1352,7 @@
 
 <script setup>
 import { ref, reactive, computed, watch, onMounted, nextTick, onBeforeUnmount, defineAsyncComponent } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { buildContentBlocks } from '../utils/contentBlocks.js'
 import DOMPurify from 'dompurify'
@@ -1392,7 +1391,7 @@ function renderRefLinks(html) {
     } else if (routeBase) {
       href = orgPath(`/${routeBase}`)
     }
-    return `<a href="${href}" data-ref-type="${type}" data-ref-id="${id}" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-[11px] font-medium no-underline cursor-pointer ${colors}" title="${type}: ${id}">`
+    return `<a href="${href}" data-ref-type="${type}" data-ref-id="${id}" class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-[11px] font-medium no-underline cursor-pointer ${colors}" title="${refTypeLabel(type)}: ${id}">`
       + `<span class="opacity-60">${type}</span>`
       + `<span>${title}</span>`
       + `</a>`
@@ -1406,6 +1405,8 @@ import { useDocumentTree } from '../composables/useDocumentTree'
 import { useDocumentEditor } from '../composables/useDocumentEditor'
 import { useDocumentComments } from '../composables/useDocumentComments'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
+import { enumLabel, entityLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 import StatusBadge from '../components/StatusBadge.vue'
 import MemberPicker from '../components/MemberPicker.vue'
 import DiffView from '../components/DiffView.vue'
@@ -1415,6 +1416,7 @@ import CommentsPanel from '../components/CommentsPanel.vue'
 import HistoryPanel from '../components/HistoryPanel.vue'
 const DocumentEditor = defineAsyncComponent(() => import('../components/DocumentEditor.vue'))
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { orgSlug, orgPath } = useCurrentOrg()
@@ -1637,13 +1639,90 @@ const loadingContent = ref(false)
 // --- Center-pane tabs (Content default; surfaces metadata, versions, links, discussion, history) ---
 const docTab = ref('content')
 const docTabs = computed(() => [
-  { key: 'content', label: 'Content' },
-  { key: 'info', label: 'Info' },
-  { key: 'versions', label: 'Versions' },
-  { key: 'links', label: 'Links' },
-  { key: 'discussion', label: 'Discussion' },
-  { key: 'history', label: 'History' },
+  { key: 'content', label: t('documents.tab.content') },
+  { key: 'info', label: t('documents.tab.info') },
+  { key: 'versions', label: t('documents.tab.versions') },
+  { key: 'links', label: t('documents.tab.links') },
+  { key: 'discussion', label: t('documents.tab.discussion') },
+  { key: 'history', label: t('documents.tab.history') },
 ])
+
+// ---------- Label helpers ----------
+// Each of these exists because the expression it replaces put a quoted word, a
+// bare DB value or a hand-built sentence in the template, where the raw-text
+// scanner counts it and a translator cannot reach it.
+
+const statusLabel = (v) => enumLabel('status', v)
+const roleLabel = (v) => enumLabel('role', v)
+const docTypeLabel = (v) => enumLabel('document_type', v || 'document')
+
+// The reference pill's tooltip. `[[RISK:id|Title]]` types are upper-case
+// shorthands for entities the catalogue already names.
+const REF_TYPE_ENTITIES = {
+  RISK: 'risk',
+  LEGAL: 'legal_requirement',
+  DOC: 'document',
+  ASSET: 'asset',
+  SUPPLIER: 'supplier',
+  SYSTEM: 'system',
+  INCIDENT: 'incident',
+  CA: 'corrective_action',
+}
+function refTypeLabel(type) {
+  const entity = REF_TYPE_ENTITIES[type]
+  return entity ? entityLabel(entity) : type
+}
+
+// The metadata select offers all eight types; the create form offers the six a
+// user would author by hand. Both read the one catalogue group, and the empty
+// value means "document", the default the frontmatter omits.
+const DOC_TYPE_VALUES = ['', 'policy', 'procedure', 'control', 'guideline', 'record', 'clause', 'requirement']
+const NEW_DOC_TYPE_VALUES = ['', 'policy', 'procedure', 'control', 'guideline', 'record']
+const toTypeOption = (value) => ({ value, label: docTypeLabel(value || 'document') })
+const docTypeOptions = computed(() => DOC_TYPE_VALUES.map(toTypeOption))
+const newDocTypeOptions = computed(() => NEW_DOC_TYPE_VALUES.map(toTypeOption))
+
+const neverApprovedCount = computed(
+  () => allNeedsReviewDocs.value.filter((d) => d.never_approved).length)
+
+// A filename fallback, not copy — but '.md' in the template is a quoted word
+// the scanner counts, and it is right to ask why one is there.
+const changedDocLabel = (doc) =>
+  doc.document_id || doc.path.split('/').pop().replace('.md', '')
+
+const blockCommentTitle = (index) =>
+  t('documents.content.comment_count', { count: commentCountForBlock(index) }, commentCountForBlock(index))
+
+const resolvedByLabel = (comment) => t('documents.content.resolved_by', {
+  name: comment.resolved_by || t('documents.content.resolved_by_unknown'),
+  date: formatDate(comment.resolved_at),
+})
+
+// Four conditional clauses collapse to four whole sentences rather than one
+// spliced from fragments: a language may not be able to append " on <date>" to
+// a clause that already ends in a version number.
+const lastApprovedLabel = computed(() => {
+  if (approvedVersion.value && approvedAt.value) {
+    return t('documents.banner.last_approved_version_on', { version: approvedVersion.value, date: approvedAt.value })
+  }
+  if (approvedVersion.value) return t('documents.banner.last_approved_version', { version: approvedVersion.value })
+  if (approvedAt.value) return t('documents.banner.last_approved_on', { date: approvedAt.value })
+  return t('documents.banner.last_approved')
+})
+
+// The print header, assembled here rather than as six spans joined by four
+// literal em dashes in the markup. The separator is presentation.
+const printMeta = computed(() => {
+  const doc = activeDoc.value
+  if (!doc) return ''
+  const parts = []
+  if (doc.version) parts.push(t('documents.print.version', { version: doc.version }))
+  if (doc.status) parts.push(statusLabel(doc.status))
+  if (doc.author) parts.push(t('documents.print.author', { name: resolveUserName(doc.author) || doc.author }))
+  parts.push(activeId.value)
+  parts.push(t('documents.print.printed', { date: formatDateValue(Date.now()) }))
+  return parts.join(' — ')
+})
 async function switchDocTab(key) {
   docTab.value = key
   // Lazy-load version history when entering Versions tab
@@ -1751,8 +1830,8 @@ async function startEditGuarded() {
   if (hasEditorUnsafeHtml(rawContent.value)) {
     const { ask } = useConfirm()
     const ok = await ask(
-      "This document contains embedded HTML/SVG the editor can't preserve — editing here will drop it on save. Edit the source via the CLI to keep it. Edit anyway?",
-      'Embedded HTML will be lost',
+      t('documents.confirm.embedded_html_body'),
+      t('documents.confirm.embedded_html_title'),
     )
     if (!ok) return
   }
@@ -1775,7 +1854,7 @@ async function viewApprovedVersion() {
     const diffText = typeof diff === 'string' ? diff : (diff?.diff || '')
     approvedDiffLines.value = diffText.split('\n')
   } catch {
-    approvedDiffLines.value = ['Failed to load diff']
+    approvedDiffLines.value = [t('documents.error.load_diff')]
   } finally {
     loadingApprovedDiff.value = false
   }
@@ -1791,7 +1870,7 @@ function setDocAuthor(email) {
     if (!activeId.value) return
     api.updateDocumentMetadata(activeId.value, { author: email })
       .then(() => { if (activeDoc.value) activeDoc.value.author = email })
-      .catch(e => { console.error('Failed to set author:', e); toastError('Failed to set author: ' + (e.message || 'unknown error')) })
+      .catch(e => { console.error('Failed to set author:', e); toastError(t('documents.error.set_author', { message: renderApiError(e) })) })
   }
 }
 
@@ -1799,7 +1878,7 @@ function setDocType(type) {
   if (!activeId.value) return
   api.updateDocumentMetadata(activeId.value, { type })
     .then(() => { if (activeDoc.value) activeDoc.value.type = type })
-    .catch(e => { console.error('Failed to set type:', e); toastError('Failed to set type: ' + (e.message || 'unknown error')) })
+    .catch(e => { console.error('Failed to set type:', e); toastError(t('documents.error.set_type', { message: renderApiError(e) })) })
 }
 
 async function saveVersion() {
@@ -1810,7 +1889,7 @@ async function saveVersion() {
     if (activeDoc.value) activeDoc.value.version = v
   } catch (e) {
     console.error('Failed to set version:', e)
-    toastError('Failed to set version: ' + (e.message || 'unknown error'))
+    toastError(t('documents.error.set_version', { message: renderApiError(e) }))
   }
 }
 
@@ -1853,7 +1932,7 @@ async function confirmRootNewFolder() {
     expandedNodes.add(slug)
   } catch (e) {
     const { error: showError } = useToast()
-    showError('Failed to create folder: ' + e.message)
+    showError(t('documents.error.create_folder', { message: renderApiError(e) }))
   }
 }
 
@@ -1883,7 +1962,7 @@ async function confirmInlineNewFolder() {
     expandedNodes.add(folderPath)
   } catch (e) {
     const { error: showError } = useToast()
-    showError('Failed to create folder: ' + e.message)
+    showError(t('documents.error.create_folder', { message: renderApiError(e) }))
   }
 }
 
@@ -1960,7 +2039,7 @@ async function createDocument() {
     // Navigate to the new document
     router.push(orgPath(`/documents/${encodeURIComponent(result.document_id)}`))
   } catch (e) {
-    newDocError.value = e.message || 'Failed to create document'
+    newDocError.value = t('documents.error.create_document', { message: renderApiError(e) })
   } finally {
     newDocSaving.value = false
   }
@@ -1973,7 +2052,7 @@ function printDocument() {
 async function deleteCurrentDocument() {
   if (!activeId.value) return
   const { ask } = useConfirm()
-  if (!await ask(`Delete "${activeDoc.value?.title || activeId.value}"? This cannot be undone.`, 'Delete Document')) return
+  if (!await ask(t('documents.confirm.delete_body', { name: activeDoc.value?.title || activeId.value }), t('documents.confirm.delete_title'))) return
   try {
     await api.deleteDocument(activeId.value)
     activeDoc.value = null
@@ -1983,7 +2062,7 @@ async function deleteCurrentDocument() {
     router.push(orgPath('/documents'))
   } catch (e) {
     const { error: showError } = useToast()
-    showError('Failed to delete: ' + e.message)
+    showError(t('documents.error.delete', { message: renderApiError(e) }))
   }
 }
 
@@ -2036,7 +2115,7 @@ async function sendForReview() {
       loadContent(activeType.value, activeId.value)
     }
   } catch (e) {
-    reviewError.value = e.message || 'Failed to send for review'
+    reviewError.value = t('documents.error.send_for_review', { message: renderApiError(e) })
   } finally {
     reviewSending.value = false
   }
@@ -2121,7 +2200,7 @@ async function viewNeedsReviewDiff(doc) {
       needsReviewDiffLines.value = diff.split('\n')
     }
   } catch {
-    needsReviewDiffLines.value = ['Failed to load diff']
+    needsReviewDiffLines.value = [t('documents.error.load_diff')]
   }
 }
 
@@ -2176,7 +2255,7 @@ async function addTemplate(id) {
   try {
     await api.addTemplate(id)
     const tmpl = availableTemplates.value.find(t => t.id === id)
-    templateMessage.value = `${tmpl?.name || id} template added successfully.`
+    templateMessage.value = t('documents.templates.added', { name: tmpl?.name || id })
     templateMessageError.value = false
     // Reload the document tree
     await loadTree()
@@ -2184,7 +2263,7 @@ async function addTemplate(id) {
       expandedNodes.add(f.name)
     }
   } catch (e) {
-    templateMessage.value = `Failed to add template: ${e.message}`
+    templateMessage.value = t('documents.templates.add_failed', { message: renderApiError(e) })
     templateMessageError.value = true
   } finally {
     templateLoading.value = null
@@ -2203,12 +2282,12 @@ async function removeTemplate(id) {
   try {
     await api.removeTemplate(id)
     const tmpl = availableTemplates.value.find(t => t.id === id)
-    templateMessage.value = `${tmpl?.name || id} template removed.`
+    templateMessage.value = t('documents.templates.removed', { name: tmpl?.name || id })
     templateMessageError.value = false
     // Reload the document tree
     await loadTree()
   } catch (e) {
-    templateMessage.value = `Failed to remove template: ${e.message}`
+    templateMessage.value = t('documents.templates.remove_failed', { message: renderApiError(e) })
     templateMessageError.value = true
   } finally {
     templateLoading.value = null
@@ -2302,7 +2381,7 @@ async function loadContent(folder, id) {
       rawContent.value = detail.content || ''
     }
   } catch (e) {
-    rawContent.value = `**Error loading content:** ${e.message}`
+    rawContent.value = t('documents.error.load_content', { message: renderApiError(e) })
   } finally {
     loadingContent.value = false
   }
@@ -2434,7 +2513,7 @@ async function submitPanelReply() {
     await loadComments(activeId.value)
   } catch (e) {
     console.error('Failed to submit reply:', e)
-    toastError('Failed to submit reply: ' + (e.message || 'unknown error'))
+    toastError(t('documents.error.submit_reply', { message: renderApiError(e) }))
   }
 }
 
@@ -2495,7 +2574,7 @@ async function submitComment() {
     await loadComments(activeId.value)
   } catch (e) {
     console.error('Failed to submit comment:', e)
-    toastError('Failed to submit comment: ' + (e.message || 'unknown error'))
+    toastError(t('documents.error.submit_comment', { message: renderApiError(e) }))
   } finally {
     submitting.value = false
   }
@@ -2507,7 +2586,7 @@ async function resolveComment(id) {
     await loadComments(activeId.value)
   } catch (e) {
     console.error('Failed to resolve comment:', e)
-    toastError('Failed to resolve comment: ' + (e.message || 'unknown error'))
+    toastError(t('documents.error.resolve_comment', { message: renderApiError(e) }))
   }
 }
 
@@ -2601,7 +2680,7 @@ onMounted(async () => {
     }
   } catch (e) {
     console.error('Failed to load document list:', e)
-    toastError('Failed to load documents: ' + (e.message || 'unknown error'))
+    toastError(t('documents.error.load_documents', { message: renderApiError(e) }))
   } finally {
     loadingTree.value = false
   }

--- a/web/src/views/Documents.vue
+++ b/web/src/views/Documents.vue
@@ -1829,10 +1829,7 @@ function hasEditorUnsafeHtml(md) {
 async function startEditGuarded() {
   if (hasEditorUnsafeHtml(rawContent.value)) {
     const { ask } = useConfirm()
-    const ok = await ask(
-      t('documents.confirm.embedded_html_body'),
-      t('documents.confirm.embedded_html_title'),
-    )
+    const ok = await ask(t('documents.confirm.embedded_html_body'), { variant: 'warning' })
     if (!ok) return
   }
   startEdit()
@@ -2052,7 +2049,11 @@ function printDocument() {
 async function deleteCurrentDocument() {
   if (!activeId.value) return
   const { ask } = useConfirm()
-  if (!await ask(t('documents.confirm.delete_body', { name: activeDoc.value?.title || activeId.value }), t('documents.confirm.delete_title'))) return
+  const confirmed = await ask(
+    t('documents.confirm.delete_body', { name: activeDoc.value?.title || activeId.value }),
+    { confirm: t('common.action.delete') },
+  )
+  if (!confirmed) return
   try {
     await api.deleteDocument(activeId.value)
     activeDoc.value = null

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -719,7 +719,7 @@ import { useModalEscape } from '../composables/useModalEscape.js'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate as formatDateValue, formatDay as formatDayValue } from '../composables/useFormat.js'
-import { enumLabel, entityLabel } from '../composables/useEnumLabel.js'
+import { enumLabel, enumLabelAbbr, entityLabel } from '../composables/useEnumLabel.js'
 import { renderApiError } from '../composables/useApiError.js'
 
 const { t } = useI18n()
@@ -903,7 +903,9 @@ const priorityLabel = (v) => enumLabel('priority', v)
 // finding vocabulary, which the catalogue keys as `finding_type`. Mapping both
 // to `severity` renders a CA as the raw "Major Nc". Two helpers, deliberately.
 const severityLabel = (v) => enumLabel('severity', v)
-const caSeverityLabel = (v) => enumLabel('finding_type', v)
+// The abbreviated form: this chip is the same width as the incident severity
+// badge beside it, and the full "Major non-conformity" does not fit.
+const caSeverityLabel = (v) => enumLabelAbbr('finding_type', v)
 const sourceLabel = (v) => enumLabel('source', v)
 const suggestionStatusLabel = (v) => enumLabel('status', v)
 

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -697,7 +697,7 @@
             <div v-if="sg.reject_reason" class="text-xs text-red-400/80">{{ t('inbox.suggestions.rejected_reason', { reason: sg.reject_reason }) }}</div>
 
             <!-- Applied result -->
-            <div v-if="sg.applied_entity_id" class="text-xs text-emerald-400/80">{{ t('inbox.suggestions.applied_result', { entity: entityLabel(sg.entity_type), id: sg.applied_entity_id }) }}</div>
+            <div v-if="sg.applied_entity_id" class="text-xs text-emerald-400/80">{{ t('inbox.suggestions.applied_result', { entity: entityLabel(sg.entity_type, { inline: true }), id: sg.applied_entity_id }) }}</div>
           </div>
         </div>
       </template>

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -18,14 +18,14 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Inbox</h1>
-          <p class="text-sm text-slate-500 mt-1">{{ totalActionItems }} action item{{ totalActionItems !== 1 ? 's' : '' }} requiring attention</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('inbox.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('inbox.subtitle', { count: totalActionItems }, totalActionItems) }}</p>
         </div>
         <div class="flex items-center gap-2">
           <RefreshButton :loading="refreshing" @refresh="reload" />
           <button @click="markAllNotificationsRead"
             class="px-3 py-1.5 text-xs text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg border border-slate-800 transition-colors">
-            Mark all read
+            {{ t('inbox.mark_all_read') }}
           </button>
         </div>
       </div>
@@ -58,7 +58,7 @@
       <!-- ===================== COMMENTS TAB ===================== -->
       <template v-if="activeTab === 'comments'">
         <div v-if="openComments.length === 0" class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
-          <div class="text-slate-500 text-sm">No open comments</div>
+          <div class="text-slate-500 text-sm">{{ t('inbox.comments.empty') }}</div>
         </div>
         <div v-else class="space-y-2">
           <div v-for="c in openComments" :key="c.id"
@@ -69,7 +69,7 @@
               </div>
               <span class="text-sm font-medium text-slate-200">{{ c.author }}</span>
               <span class="text-xs text-slate-600">{{ formatDate(c.created_at) }}</span>
-              <span v-if="c.suggestion_body" class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-amber-800/40 text-amber-300">suggestion</span>
+              <span v-if="c.suggestion_body" class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-amber-800/40 text-amber-300">{{ t('inbox.comments.suggestion_badge') }}</span>
               <router-link :to="orgPath(`/documents/${encodeURIComponent(c.document_id)}`)"
                 class="ml-auto text-xs text-blue-400 hover:text-blue-300 bg-slate-800 px-2 py-0.5 rounded font-mono" @click.stop>{{ c.document_id }}</router-link>
             </div>
@@ -78,20 +78,20 @@
                 <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
                 </svg>
-                Inline
+                {{ t('inbox.comments.scope_inline') }}
               </span>
               <span v-else class="text-[10px] text-slate-500 font-medium flex items-center gap-1">
                 <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>
-                Document
+                {{ t('inbox.comments.scope_document') }}
               </span>
             </div>
             <div class="text-sm text-slate-300 leading-relaxed">{{ c.body }}</div>
             <div v-if="c.quote" class="mt-2 text-xs text-slate-600 border-l-2 border-slate-700 pl-2 italic truncate">"{{ c.quote }}"</div>
             <div class="mt-3 flex gap-2">
-              <button @click="goToComment(c)" class="text-xs text-blue-400 hover:text-blue-300 cursor-pointer">View in document →</button>
-              <button v-if="canResolveComment(c)" @click="resolveFromInbox(c.id)" class="text-xs text-slate-500 hover:text-emerald-400 ml-auto">Resolve</button>
+              <button @click="goToComment(c)" class="text-xs text-blue-400 hover:text-blue-300 cursor-pointer">{{ t('inbox.comments.view_in_document') }}</button>
+              <button v-if="canResolveComment(c)" @click="resolveFromInbox(c.id)" class="text-xs text-slate-500 hover:text-emerald-400 ml-auto">{{ t('common.action.resolve') }}</button>
             </div>
           </div>
         </div>
@@ -104,7 +104,7 @@
           <svg class="w-10 h-10 text-slate-700 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          <div class="text-sm text-slate-500">No reviews pending</div>
+          <div class="text-sm text-slate-500">{{ t('inbox.reviews.empty') }}</div>
         </div>
 
         <!-- Review cards -->
@@ -126,11 +126,11 @@
               <StatusBadge :status="review.status" />
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2">
-                  <span class="text-sm font-medium text-slate-200">{{ review.title || review.document_id || 'Untitled review' }}</span>
-                  <span v-if="review.round > 1" class="text-[10px] px-1.5 py-0.5 rounded-full bg-slate-700/50 text-slate-400 font-medium">Round {{ review.round }}</span>
+                  <span class="text-sm font-medium text-slate-200">{{ review.title || review.document_id || t('inbox.reviews.untitled') }}</span>
+                  <span v-if="review.round > 1" class="text-[10px] px-1.5 py-0.5 rounded-full bg-slate-700/50 text-slate-400 font-medium">{{ t('common.label.round', { round: review.round }) }}</span>
                 </div>
                 <div class="text-xs text-slate-500 mt-0.5">
-                  Requested by {{ review.requested_by || 'Unknown' }}
+                  {{ t('inbox.reviews.requested_by', { name: review.requested_by || t('inbox.reviews.unknown_requester') }) }}
                   <span class="mx-1.5 text-slate-700">|</span>
                   {{ formatDate(review.created_at) }}
                   <span v-if="review.version" class="mx-1.5 text-slate-700">|</span>
@@ -160,26 +160,26 @@
               <!-- Metadata -->
               <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 <div>
-                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Status</div>
+                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('inbox.reviews.meta.status') }}</div>
                   <StatusBadge :status="review.status" />
                 </div>
                 <div>
-                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Document</div>
+                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('inbox.reviews.meta.document') }}</div>
                   <div class="text-sm text-slate-300 font-mono">{{ review.document_id || '-' }}</div>
                 </div>
                 <div>
-                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Version</div>
+                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('inbox.reviews.meta.version') }}</div>
                   <div class="text-sm text-slate-300">{{ review.version || '-' }}</div>
                 </div>
                 <div>
-                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">Requested By</div>
+                  <div class="text-[10px] font-medium text-slate-500 uppercase tracking-wider mb-1">{{ t('inbox.reviews.meta.requested_by') }}</div>
                   <div class="text-sm text-slate-300">{{ review.requested_by || '-' }}</div>
                 </div>
               </div>
 
               <!-- Reviewers -->
               <div v-if="review.reviewers && review.reviewers.length">
-                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Assigned Reviewers</div>
+                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">{{ t('inbox.reviews.assigned_reviewers') }}</div>
                 <div class="flex flex-wrap gap-2">
                   <span
                     v-for="reviewer in review.reviewers"
@@ -196,7 +196,7 @@
 
               <!-- Recent comments -->
               <div v-if="expandedReviewComments.length">
-                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Recent Comments</div>
+                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">{{ t('inbox.reviews.recent_comments') }}</div>
                 <div class="space-y-2">
                   <div
                     v-for="comment in expandedReviewComments.slice(0, 3)"
@@ -221,7 +221,7 @@
                   <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
                   </svg>
-                  Open Review #{{ review.id }}
+                  {{ t('inbox.reviews.open_review', { id: review.id }) }}
                 </router-link>
               </div>
             </div>
@@ -237,7 +237,7 @@
             @click="showTaskForm = !showTaskForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
           >
-            Add Task
+            {{ t('inbox.tasks.add') }}
           </button>
         </div>
 
@@ -248,7 +248,7 @@
           <div class="absolute inset-0 bg-black/60" @click="showTaskForm = false" />
           <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
           <div class="flex items-center justify-between mb-2">
-            <h2 class="text-sm font-semibold text-slate-200">Add Task</h2>
+            <h2 class="text-sm font-semibold text-slate-200">{{ t('inbox.tasks.add') }}</h2>
             <button @click="showTaskForm = false" class="text-slate-500 hover:text-slate-300">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -257,41 +257,33 @@
           </div>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div class="sm:col-span-2">
-              <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
-              <input v-model="newTask.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Task title" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.tasks.form.title') }}</label>
+              <input v-model="newTask.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('inbox.tasks.form.title_placeholder')" />
             </div>
             <div class="sm:col-span-2">
-              <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-              <textarea v-model="newTask.description" rows="2" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" placeholder="Optional description" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.tasks.form.description') }}</label>
+              <textarea v-model="newTask.description" rows="2" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" :placeholder="t('inbox.tasks.form.description_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Type</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.tasks.form.type') }}</label>
               <select v-model="newTask.task_type" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
                 <!-- Manual task types only. The *_followup types are created
                      automatically by the system, not chosen here (#32). -->
-                <option value="general">General</option>
-                <option value="review">Review</option>
-                <option value="onboarding">Onboarding</option>
-                <option value="offboarding">Offboarding</option>
-                <option value="training">Training</option>
-                <option value="other">Other</option>
+                <option v-for="o in taskTypeOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
               </select>
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Priority</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.tasks.form.priority') }}</label>
               <select v-model="newTask.priority" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500">
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
-                <option value="critical">Critical</option>
+                <option v-for="o in priorityOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
               </select>
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Assignee</label>
-              <MemberPicker v-model="newTask.assignee" :members="allUsers" placeholder="Select assignee..." />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.tasks.form.assignee') }}</label>
+              <MemberPicker v-model="newTask.assignee" :members="allUsers" :placeholder="t('inbox.tasks.form.assignee_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Due Date</label>
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.tasks.form.due_date') }}</label>
               <input v-model="newTask.due_date" type="date" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-blue-500" />
             </div>
           </div>
@@ -301,10 +293,10 @@
               :disabled="!newTask.title.trim() || taskCreating"
               class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors"
             >
-              {{ taskCreating ? 'Creating...' : 'Add' }}
+              {{ taskCreating ? t('common.state.creating') : t('common.action.add') }}
             </button>
             <button @click="showTaskForm = false" class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-slate-300 text-sm font-medium rounded-lg transition-colors">
-              Cancel
+              {{ t('common.action.cancel') }}
             </button>
           </div>
           </div>
@@ -317,7 +309,7 @@
           <svg class="w-10 h-10 text-slate-700 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
           </svg>
-          <div class="text-sm text-slate-500">No tasks found</div>
+          <div class="text-sm text-slate-500">{{ t('inbox.tasks.empty') }}</div>
         </div>
 
         <!-- Tasks list (overdue first, then by priority) -->
@@ -335,16 +327,16 @@
             </div>
 
             <!-- Type badge -->
-            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 capitalize flex-shrink-0">
-              {{ (task.task_type || '').replace(/_/g, ' ') }}
+            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 flex-shrink-0">
+              {{ taskTypeLabel(task.task_type) }}
             </span>
 
             <!-- Priority badge -->
             <span
-              class="inline-block px-2 py-0.5 rounded text-xs font-semibold capitalize flex-shrink-0"
+              class="inline-block px-2 py-0.5 rounded text-xs font-semibold flex-shrink-0"
               :class="priorityClasses[task.priority] || 'bg-slate-700 text-slate-300'"
             >
-              {{ task.priority || '-' }}
+              {{ priorityLabel(task.priority) }}
             </span>
 
             <!-- Assignee -->
@@ -356,7 +348,7 @@
               :class="isOverdue(task) ? 'text-red-400 font-medium' : 'text-slate-500'"
             >
               {{ formatDay(task.due_date) }}
-              <span v-if="isOverdue(task)" class="block text-[10px] text-red-500">OVERDUE</span>
+              <span v-if="isOverdue(task)" class="block text-[10px] text-red-500">{{ t('common.state.overdue') }}</span>
             </span>
 
             <!-- Status button (click to advance) -->
@@ -364,7 +356,7 @@
               v-if="task.status !== 'done' && canAdvanceTask(task)"
               @click="advanceTaskStatus(task)"
               class="flex-shrink-0"
-              :title="task.status === 'open' ? 'Start task' : 'Mark done'"
+              :title="taskAdvanceTitle(task)"
             >
               <StatusBadge :status="task.status" class="cursor-pointer hover:opacity-80 transition-opacity" />
             </button>
@@ -376,7 +368,7 @@
       <!-- ===================== INCIDENTS TAB ===================== -->
       <template v-if="activeTab === 'incidents'">
         <div v-if="incidents.length === 0" class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
-          <div class="text-sm text-slate-500">No incidents assigned to you</div>
+          <div class="text-sm text-slate-500">{{ t('inbox.incidents.empty') }}</div>
         </div>
         <div v-else class="space-y-2">
           <router-link
@@ -390,7 +382,7 @@
               <div class="text-sm font-medium text-slate-200 truncate">{{ inc.title }}</div>
               <div v-if="inc.description" class="text-xs text-slate-500 mt-0.5 truncate">{{ inc.description }}</div>
             </div>
-            <span class="inline-block px-2 py-0.5 rounded text-xs font-semibold capitalize flex-shrink-0" :class="priorityClasses[inc.severity] || 'bg-slate-700 text-slate-300'">{{ inc.severity }}</span>
+            <span class="inline-block px-2 py-0.5 rounded text-xs font-semibold flex-shrink-0" :class="priorityClasses[inc.severity] || 'bg-slate-700 text-slate-300'">{{ severityLabel(inc.severity) }}</span>
             <span class="text-xs text-slate-500 flex-shrink-0 capitalize">{{ inc.category }}</span>
             <span class="text-xs text-slate-500 flex-shrink-0 w-28 truncate text-right">{{ formatDate(inc.detected_at || inc.created_at) }}</span>
             <StatusBadge :status="inc.status" class="flex-shrink-0" />
@@ -401,7 +393,7 @@
       <!-- ===================== CORRECTIVE ACTIONS TAB ===================== -->
       <template v-if="activeTab === 'corrective_actions'">
         <div v-if="correctiveActions.length === 0" class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
-          <div class="text-sm text-slate-500">No corrective actions assigned to you</div>
+          <div class="text-sm text-slate-500">{{ t('inbox.corrective_actions.empty') }}</div>
         </div>
         <div v-else class="space-y-2">
           <router-link
@@ -416,11 +408,11 @@
               <div class="text-sm font-medium text-slate-200 truncate">{{ ca.title }}</div>
               <div v-if="ca.description" class="text-xs text-slate-500 mt-0.5 truncate">{{ ca.description }}</div>
             </div>
-            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 flex-shrink-0">{{ (ca.severity || '').replace(/_/g, ' ') }}</span>
-            <span class="text-xs text-slate-500 flex-shrink-0 capitalize w-32 truncate text-right">{{ (ca.source || '').replace(/_/g, ' ') }}</span>
+            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 flex-shrink-0">{{ severityLabel(ca.severity) }}</span>
+            <span class="text-xs text-slate-500 flex-shrink-0 w-32 truncate text-right">{{ sourceLabel(ca.source) }}</span>
             <span v-if="ca.due_date" class="text-xs flex-shrink-0 w-24 text-right" :class="isOverdue(ca) ? 'text-red-400 font-medium' : 'text-slate-500'">
               {{ formatDay(ca.due_date) }}
-              <span v-if="isOverdue(ca)" class="block text-[10px] text-red-500">OVERDUE</span>
+              <span v-if="isOverdue(ca)" class="block text-[10px] text-red-500">{{ t('common.state.overdue') }}</span>
             </span>
             <StatusBadge :status="ca.status" class="flex-shrink-0" />
           </router-link>
@@ -435,7 +427,7 @@
             @click="showChangeForm = !showChangeForm"
             class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-lg transition-colors"
           >
-            Add Change Request
+            {{ t('inbox.changes.add') }}
           </button>
         </div>
 
@@ -446,7 +438,7 @@
           <div class="absolute inset-0 bg-black/60" @click="showChangeForm = false" />
           <div class="relative w-full max-w-2xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl p-6 space-y-4 max-h-[84vh] overflow-y-auto">
           <div class="flex items-center justify-between mb-2">
-            <h2 class="text-sm font-semibold text-slate-200">Add Change Request</h2>
+            <h2 class="text-sm font-semibold text-slate-200">{{ t('inbox.changes.add') }}</h2>
             <button @click="showChangeForm = false" class="text-slate-500 hover:text-slate-300">
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -455,24 +447,24 @@
           </div>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div class="sm:col-span-2">
-              <label class="block text-xs font-medium text-slate-500 mb-1">Title</label>
-              <input v-model="newChange.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" placeholder="Change request title" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.changes.form.title') }}</label>
+              <input v-model="newChange.title" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500" :placeholder="t('inbox.changes.form.title_placeholder')" />
             </div>
             <div class="sm:col-span-2">
-              <label class="block text-xs font-medium text-slate-500 mb-1">Description</label>
-              <textarea v-model="newChange.description" rows="3" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" placeholder="Describe the proposed change" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.changes.form.description') }}</label>
+              <textarea v-model="newChange.description" rows="3" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" :placeholder="t('inbox.changes.form.description_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Justification</label>
-              <textarea v-model="newChange.justification" rows="2" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" placeholder="Why is this change needed?" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.changes.form.justification') }}</label>
+              <textarea v-model="newChange.justification" rows="2" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" :placeholder="t('inbox.changes.form.justification_placeholder')" />
             </div>
             <div>
-              <label class="block text-xs font-medium text-slate-500 mb-1">Impact Assessment</label>
-              <textarea v-model="newChange.impact" rows="2" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" placeholder="Expected impact on ISMS" />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.changes.form.impact') }}</label>
+              <textarea v-model="newChange.impact" rows="2" class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none" :placeholder="t('inbox.changes.form.impact_placeholder')" />
             </div>
             <div class="sm:col-span-2">
-              <label class="block text-xs font-medium text-slate-500 mb-1">Assign To</label>
-              <MemberPicker v-model="newChange.assigned_to" :members="allUsers" placeholder="Select assignee..." />
+              <label class="block text-xs font-medium text-slate-500 mb-1">{{ t('inbox.changes.form.assign_to') }}</label>
+              <MemberPicker v-model="newChange.assigned_to" :members="allUsers" :placeholder="t('inbox.changes.form.assignee_placeholder')" />
             </div>
           </div>
           <div class="flex items-center gap-3 pt-2">
@@ -481,10 +473,10 @@
               :disabled="!newChange.title.trim() || changeSubmitting"
               class="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors"
             >
-              {{ changeSubmitting ? 'Creating...' : 'Add' }}
+              {{ changeSubmitting ? t('common.state.creating') : t('common.action.add') }}
             </button>
             <button @click="showChangeForm = false" class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-slate-300 text-sm font-medium rounded-lg transition-colors">
-              Cancel
+              {{ t('common.action.cancel') }}
             </button>
           </div>
           </div>
@@ -497,7 +489,7 @@
           <svg class="w-10 h-10 text-slate-700 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
           </svg>
-          <div class="text-sm text-slate-500">No change requests</div>
+          <div class="text-sm text-slate-500">{{ t('inbox.changes.empty') }}</div>
         </div>
 
         <!-- Change request cards -->
@@ -516,7 +508,7 @@
               <div class="flex-1 min-w-0">
                 <div class="text-sm font-medium text-slate-200">{{ change.title }}</div>
                 <div class="text-xs text-slate-500 mt-0.5">
-                  Requested by {{ change.requested_by || 'Unknown' }}
+                  {{ t('inbox.changes.requested_by', { name: change.requested_by || t('inbox.changes.unknown_requester') }) }}
                   <span class="mx-1.5 text-slate-700">|</span>
                   {{ formatDate(change.created_at) }}
                 </div>
@@ -549,25 +541,25 @@
             >
               <!-- Description -->
               <div v-if="change.description">
-                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Description</div>
+                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">{{ t('inbox.changes.detail.description') }}</div>
                 <p class="text-sm text-slate-400 leading-relaxed whitespace-pre-line">{{ change.description }}</p>
               </div>
 
               <!-- Justification & Impact -->
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
                 <div v-if="change.justification">
-                  <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Justification</div>
+                  <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">{{ t('inbox.changes.detail.justification') }}</div>
                   <p class="text-sm text-slate-400 leading-relaxed whitespace-pre-line">{{ change.justification }}</p>
                 </div>
                 <div v-if="change.impact">
-                  <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Impact Assessment</div>
+                  <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">{{ t('inbox.changes.detail.impact') }}</div>
                   <p class="text-sm text-slate-400 leading-relaxed whitespace-pre-line">{{ change.impact }}</p>
                 </div>
               </div>
 
               <!-- Affected documents -->
               <div v-if="change.document_ids && change.document_ids.length">
-                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Affected Documents</div>
+                <div class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">{{ t('inbox.changes.detail.affected_documents') }}</div>
                 <div class="flex flex-wrap gap-2">
                   <span
                     v-for="docId in change.document_ids"
@@ -587,7 +579,7 @@
                   :disabled="changeActioning"
                   class="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
                 >
-                  Approve
+                  {{ t('inbox.changes.action.approve') }}
                 </button>
                 <button
                   v-if="canManageInbox && change.status === 'proposed'"
@@ -595,7 +587,7 @@
                   :disabled="changeActioning"
                   class="px-4 py-2 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
                 >
-                  Reject
+                  {{ t('inbox.changes.action.reject') }}
                 </button>
                 <button
                   v-if="canManageInbox && change.status === 'approved'"
@@ -603,13 +595,13 @@
                   :disabled="changeActioning"
                   class="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
                 >
-                  Mark Implemented
+                  {{ t('inbox.changes.action.mark_implemented') }}
                 </button>
                 <button
                   @click="expandedChangeId = null"
                   class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-slate-300 text-sm font-medium rounded-lg transition-colors"
                 >
-                  Close
+                  {{ t('inbox.changes.action.close') }}
                 </button>
               </div>
             </div>
@@ -622,10 +614,10 @@
         <!-- Filters -->
         <div class="flex items-center gap-2">
           <div class="flex items-center gap-0.5 bg-slate-900 border border-slate-800 rounded-lg p-0.5">
-            <button v-for="f in ['open', 'applied', 'rejected']" :key="f" @click="suggestionFilter = f; loadSuggestions()"
+            <button v-for="f in suggestionFilters" :key="f.value" @click="suggestionFilter = f.value; loadSuggestions()"
               class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors"
-              :class="suggestionFilter === f ? 'bg-slate-700 text-white' : 'text-slate-500 hover:text-slate-300'">
-              {{ f.replace(/_/g, ' ') }}
+              :class="suggestionFilter === f.value ? 'bg-slate-700 text-white' : 'text-slate-500 hover:text-slate-300'">
+              {{ f.label }}
             </button>
           </div>
         </div>
@@ -637,7 +629,7 @@
 
         <!-- Empty state -->
         <div v-if="suggestions.length === 0" class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
-          <div class="text-sm text-slate-500">No suggestions with this status.</div>
+          <div class="text-sm text-slate-500">{{ t('inbox.suggestions.empty') }}</div>
         </div>
 
         <!-- Suggestion cards -->
@@ -658,25 +650,25 @@
                       : sg.status === 'rejected' ? 'bg-red-500/15 text-red-400'
                       : sg.status === 'withdrawn' ? 'bg-slate-500/15 text-slate-400'
                       : 'bg-blue-500/15 text-blue-400'">
-                    {{ sg.status }}
+                    {{ suggestionStatusLabel(sg.status) }}
                   </span>
-                  <span v-if="sg.suggested_by_type === 'agent'" class="px-1.5 py-0.5 rounded text-[10px] bg-purple-500/15 text-purple-400">AI</span>
+                  <span v-if="sg.suggested_by_type === 'agent'" class="px-1.5 py-0.5 rounded text-[10px] bg-purple-500/15 text-purple-400">{{ t('inbox.suggestions.agent_badge') }}</span>
                 </div>
                 <div class="text-sm text-slate-300 mt-0.5">{{ sg.title }}</div>
                 <div class="text-xs text-slate-500 mt-1">
-                  Suggested by {{ sg.suggested_by?.split('@')[0] }} &middot; {{ formatDate(sg.created_at) }}
+                  {{ t('inbox.suggestions.suggested_by', { name: sg.suggested_by?.split('@')[0], date: formatDate(sg.created_at) }) }}
                 </div>
               </div>
               <!-- Actions -->
               <div v-if="sg.status === 'open'" class="flex items-center gap-1 flex-shrink-0">
                 <template v-if="canReviewSuggestions">
                   <button @click="applySuggestion(sg.id)"
-                    class="text-[10px] px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600 text-white font-medium transition-colors">Apply</button>
+                    class="text-[10px] px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600 text-white font-medium transition-colors">{{ t('inbox.suggestions.apply') }}</button>
                   <button @click="rejectingId = sg.id; rejectReason = ''"
-                    class="text-[10px] px-2 py-1 rounded bg-slate-700 hover:bg-red-800 text-slate-300 hover:text-red-200 font-medium transition-colors">Reject</button>
+                    class="text-[10px] px-2 py-1 rounded bg-slate-700 hover:bg-red-800 text-slate-300 hover:text-red-200 font-medium transition-colors">{{ t('inbox.suggestions.reject') }}</button>
                 </template>
                 <button v-if="sg.suggested_by === currentUserEmail" @click="withdrawSuggestion(sg.id)"
-                  class="text-[10px] px-2 py-1 rounded text-slate-600 hover:text-slate-300 transition-colors">Withdraw</button>
+                  class="text-[10px] px-2 py-1 rounded text-slate-600 hover:text-slate-300 transition-colors">{{ t('inbox.suggestions.withdraw') }}</button>
               </div>
             </div>
 
@@ -693,19 +685,19 @@
 
             <!-- Reject form -->
             <div v-if="rejectingId === sg.id" class="flex items-center gap-2">
-              <input v-model="rejectReason" type="text" placeholder="Reason for rejection..."
+              <input v-model="rejectReason" type="text" :placeholder="t('inbox.suggestions.reject_placeholder')"
                 class="flex-1 bg-slate-800 border border-slate-700 rounded px-2 py-1.5 text-xs text-white focus:outline-none focus:border-red-500"
                 @keyup.enter="rejectSuggestion(sg.id)" />
               <button @click="rejectSuggestion(sg.id)"
-                class="text-xs px-2 py-1.5 bg-red-600 hover:bg-red-500 text-white rounded font-medium">Reject</button>
-              <button @click="rejectingId = null" class="text-xs text-slate-500 hover:text-slate-300">Cancel</button>
+                class="text-xs px-2 py-1.5 bg-red-600 hover:bg-red-500 text-white rounded font-medium">{{ t('inbox.suggestions.reject') }}</button>
+              <button @click="rejectingId = null" class="text-xs text-slate-500 hover:text-slate-300">{{ t('common.action.cancel') }}</button>
             </div>
 
             <!-- Reject reason (for rejected suggestions) -->
-            <div v-if="sg.reject_reason" class="text-xs text-red-400/80">Rejected: {{ sg.reject_reason }}</div>
+            <div v-if="sg.reject_reason" class="text-xs text-red-400/80">{{ t('inbox.suggestions.rejected_reason', { reason: sg.reject_reason }) }}</div>
 
             <!-- Applied result -->
-            <div v-if="sg.applied_entity_id" class="text-xs text-emerald-400/80">Applied → {{ sg.entity_type }} {{ sg.applied_entity_id }}</div>
+            <div v-if="sg.applied_entity_id" class="text-xs text-emerald-400/80">{{ t('inbox.suggestions.applied_result', { entity: entityLabel(sg.entity_type), id: sg.applied_entity_id }) }}</div>
           </div>
         </div>
       </template>
@@ -715,6 +707,7 @@
 
 <script setup>
 import { ref, computed, reactive, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { api, getCurrentUser } from '../api'
 import StatusBadge from '../components/StatusBadge.vue'
@@ -726,7 +719,10 @@ import { useModalEscape } from '../composables/useModalEscape.js'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatDate as formatDateValue, formatDay as formatDayValue } from '../composables/useFormat.js'
+import { enumLabel, entityLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { orgSlug, orgPath } = useCurrentOrg()
@@ -751,7 +747,7 @@ async function reload() {
       loadSuggestions(),
     ])
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -880,14 +876,51 @@ const totalActionItems = computed(() => {
   return reviews.value.length + tasks.value.length + changes.value.length + openComments.value.length + openSuggestions.value.length + incidents.value.length + correctiveActions.value.length
 })
 
+// The whole bar stays in inbox.* rather than common.tab.*, including the two
+// labels that happen to match existing common keys. It mixes entity plurals
+// with "CAs", an abbreviation sized to this bar — and how far a language can
+// abbreviate "corrective actions" is a property of the bar, not of the entity.
 const tabs = computed(() => [
-  { key: 'comments', label: 'Comments', count: openComments.value.length },
-  { key: 'reviews', label: 'Reviews', count: reviews.value.length },
-  { key: 'tasks', label: 'Tasks', count: tasks.value.length },
-  { key: 'incidents', label: 'Incidents', count: incidents.value.length },
-  { key: 'changes', label: 'Changes', count: changes.value.length },
-  { key: 'corrective_actions', label: 'CAs', count: correctiveActions.value.length },
-  { key: 'suggestions', label: 'Suggestions', count: openSuggestions.value.length },
+  { key: 'comments', label: t('inbox.tab.comments'), count: openComments.value.length },
+  { key: 'reviews', label: t('inbox.tab.reviews'), count: reviews.value.length },
+  { key: 'tasks', label: t('inbox.tab.tasks'), count: tasks.value.length },
+  { key: 'incidents', label: t('inbox.tab.incidents'), count: incidents.value.length },
+  { key: 'changes', label: t('inbox.tab.changes'), count: changes.value.length },
+  { key: 'corrective_actions', label: t('inbox.tab.corrective_actions'), count: correctiveActions.value.length },
+  { key: 'suggestions', label: t('inbox.tab.suggestions'), count: openSuggestions.value.length },
+])
+
+// ---------- Catalogue-backed labels ----------
+// Every one of these renders a DB value, so it resolves through common.enum.*
+// rather than through a label map of this view's own. The <option> factories
+// keep the lookup out of the template: a bare group name in a mustache is a
+// quoted word the raw-text scanner counts, and rightly.
+const taskTypeLabel = (v) => enumLabel('task_type', v)
+const priorityLabel = (v) => enumLabel('priority', v)
+const severityLabel = (v) => enumLabel('severity', v)
+const sourceLabel = (v) => enumLabel('source', v)
+const suggestionStatusLabel = (v) => enumLabel('status', v)
+
+// In a helper, not the :title expression: the bare 'open' the ternary compared
+// against was counted as raw text, and most bare quoted words in a template are.
+const taskAdvanceTitle = (task) => task.status === 'open'
+  ? t('inbox.tasks.start')
+  : t('inbox.tasks.mark_done')
+
+// Manual task types only. The *_followup types are created automatically by the
+// system, not chosen here (#32) — so this list is shorter than the catalogue's.
+const TASK_TYPE_VALUES = ['general', 'review', 'onboarding', 'offboarding', 'training', 'other']
+const taskTypeOptions = computed(
+  () => TASK_TYPE_VALUES.map((value) => ({ value, label: taskTypeLabel(value) })))
+
+const PRIORITY_VALUES = ['low', 'medium', 'high', 'critical']
+const priorityOptions = computed(
+  () => PRIORITY_VALUES.map((value) => ({ value, label: priorityLabel(value) })))
+
+const suggestionFilters = computed(() => [
+  { value: 'open', label: t('inbox.suggestions.filter.open') },
+  { value: 'applied', label: t('inbox.suggestions.filter.applied') },
+  { value: 'rejected', label: t('inbox.suggestions.filter.rejected') },
 ])
 
 const forwardableUsers = computed(() => {
@@ -944,7 +977,7 @@ async function resolveFromInbox(id) {
     await api.resolveComment(id, getCurrentUser())
     await loadOpenComments()
   } catch (e) {
-    showError('Failed to resolve comment: ' + (e.message || 'unknown error'))
+    showError(t('inbox.error.resolve_comment', { message: renderApiError(e) }))
   }
 }
 
@@ -976,7 +1009,7 @@ async function markAllNotificationsRead() {
     // Reload inbox data
     await loadInbox()
   } catch (e) {
-    showError('Failed to mark all notifications read: ' + (e.message || 'unknown error'))
+    showError(t('inbox.error.mark_all_read', { message: renderApiError(e) }))
   }
 }
 
@@ -996,8 +1029,8 @@ async function approveReview(review) {
     expandedReviewId.value = null
     await loadReviews()
   } catch (e) {
-    error.value = e.message
-    showError('Failed to approve review: ' + (e.message || 'unknown error'))
+    error.value = renderApiError(e)
+    showError(t('inbox.error.approve_review', { message: renderApiError(e) }))
   } finally {
     reviewActioning.value = false
   }
@@ -1010,8 +1043,8 @@ async function requestChangesOnReview(review) {
     expandedReviewId.value = null
     await loadReviews()
   } catch (e) {
-    error.value = e.message
-    showError('Failed to request changes: ' + (e.message || 'unknown error'))
+    error.value = renderApiError(e)
+    showError(t('inbox.error.request_changes', { message: renderApiError(e) }))
   } finally {
     reviewActioning.value = false
   }
@@ -1033,8 +1066,8 @@ async function submitForward(reviewId) {
     setTimeout(() => { forwardSuccess.value = null }, 3000)
     await loadData()
   } catch (e) {
-    error.value = e.message
-    showError('Failed to forward review: ' + (e.message || 'unknown error'))
+    error.value = renderApiError(e)
+    showError(t('inbox.error.forward_review', { message: renderApiError(e) }))
   }
 }
 
@@ -1075,7 +1108,7 @@ async function loadReviews() {
       }
     }
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -1086,7 +1119,7 @@ async function advanceTaskStatus(task) {
     await api.updateTaskStatus(task.id, next)
     task.status = next
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -1103,7 +1136,7 @@ async function createTask() {
     showTaskForm.value = false
     await loadTasks()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     taskCreating.value = false
   }
@@ -1111,10 +1144,10 @@ async function createTask() {
 
 async function loadTasks() {
   try {
-    const t = await api.getTasks()
-    tasks.value = Array.isArray(t) ? t : []
+    const res = await api.getTasks()
+    tasks.value = Array.isArray(res) ? res : []
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -1130,7 +1163,7 @@ async function updateChangeStatus(change, status) {
     expandedChangeId.value = null
     await loadChanges()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     changeActioning.value = false
   }
@@ -1152,7 +1185,7 @@ async function submitChange() {
     showChangeForm.value = false
     await loadChanges()
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     changeSubmitting.value = false
   }
@@ -1163,7 +1196,7 @@ async function loadChanges() {
     const ch = await api.getChanges()
     changes.value = Array.isArray(ch) ? ch : []
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   }
 }
 
@@ -1199,7 +1232,7 @@ const suggestionError = ref('')
 async function claimSuggestion(id) {
   suggestionError.value = ''
   try { await api.claimSuggestion(id); await loadSuggestions() }
-  catch (e) { suggestionError.value = e.message || 'Failed to claim suggestion' }
+  catch (e) { suggestionError.value = t('inbox.error.claim_suggestion', { message: renderApiError(e) }) }
 }
 
 async function applySuggestion(id, force) {
@@ -1207,16 +1240,21 @@ async function applySuggestion(id, force) {
   try {
     const result = await api.applySuggestion(id, { force: !!force })
     if (result?.stale) {
-      if (await ask('Entity has changed since this suggestion was created. Apply anyway?', { confirm: 'Apply anyway', variant: 'warning' })) {
+      if (await ask(t('inbox.confirm.apply_stale_body'), { confirm: t('inbox.confirm.apply_stale_title'), variant: 'warning' })) {
         await applySuggestion(id, true)
       }
       return
     }
     await loadSuggestions()
-  } catch (e) { suggestionError.value = e.message || 'Failed to apply suggestion' }
+  } catch (e) { suggestionError.value = t('inbox.error.apply_suggestion', { message: renderApiError(e) }) }
 }
 
 async function rejectSuggestion(id) {
+  // Deliberately not translated. This is persisted as the suggestion's
+  // reject_reason and read back by everyone in the org, including the CLI and
+  // the MCP tools — storing the rejecting user's language would leave a row
+  // nobody else can read. Same reasoning as the notification keying work: text
+  // that outlives the request is stored in one language, not the sender's.
   const reason = rejectReason.value.trim() || 'Rejected'
   suggestionError.value = ''
   try {
@@ -1224,18 +1262,19 @@ async function rejectSuggestion(id) {
     rejectingId.value = null
     rejectReason.value = ''
     await loadSuggestions()
-  } catch (e) { suggestionError.value = e.message || 'Failed to reject suggestion' }
+  } catch (e) { suggestionError.value = t('inbox.error.reject_suggestion', { message: renderApiError(e) }) }
 }
 
 async function withdrawSuggestion(id) {
   suggestionError.value = ''
   try { await api.withdrawSuggestion(id); await loadSuggestions() }
-  catch (e) { suggestionError.value = e.message || 'Failed to withdraw suggestion' }
+  catch (e) { suggestionError.value = t('inbox.error.withdraw_suggestion', { message: renderApiError(e) }) }
 }
 
+// Was a local map whose only divergence from the catalogue was "New" for
+// `create`; the catalogue says "Create", and one word for one value beats two.
 function suggestionTypeLabel(sg) {
-  const labels = { create: 'New', update: 'Update', reassess: 'Reassess', link: 'Link', review: 'Review' }
-  return labels[sg.suggestion_type] || sg.suggestion_type
+  return enumLabel('suggestion_type', sg.suggestion_type)
 }
 
 function parsedPayload(raw) {
@@ -1247,9 +1286,11 @@ function parsedPayload(raw) {
   return null
 }
 
+// Twelve entity names the catalogue already carries. Four normalise to its
+// sentence case — "Legal Requirement" becomes "Legal requirement", and so on
+// for change request, corrective action and audit finding.
 function suggestionEntityLabel(sg) {
-  const labels = { risk: 'Risk', incident: 'Incident', supplier: 'Supplier', legal_requirement: 'Legal Requirement', change_request: 'Change Request', corrective_action: 'Corrective Action', objective: 'Objective', task: 'Task', system: 'System', asset: 'Asset', audit_finding: 'Audit Finding', document: 'Document' }
-  return labels[sg.entity_type] || sg.entity_type
+  return entityLabel(sg.entity_type)
 }
 
 function entityIcon(type) {
@@ -1262,13 +1303,29 @@ function entityIconBg(type) {
   return bgs[type] || 'bg-slate-500/10'
 }
 
-const fieldLabels = {
-  title: 'Title', name: 'Name', description: 'Description', category: 'Category',
-  risk_type: 'Risk type', origin: 'Origin', severity: 'Severity', priority: 'Priority',
-  status: 'Status', type: 'Type', criticality: 'Criticality', jurisdiction: 'Jurisdiction',
-  classification: 'Classification', finding_type: 'Finding type',
-  risk_level: 'Risk level', source: 'Source', incident_type: 'Incident type',
-  current_likelihood: 'Likelihood', current_impact: 'Impact',
+// A module-scope label map is invisible to both scanners, which is exactly why
+// it survived this long. Keys are spelled out rather than built from the field
+// name so the keyset walk can see them.
+const PAYLOAD_FIELD_KEYS = {
+  title: 'inbox.suggestions.payload_field.title',
+  name: 'inbox.suggestions.payload_field.name',
+  description: 'inbox.suggestions.payload_field.description',
+  category: 'inbox.suggestions.payload_field.category',
+  risk_type: 'inbox.suggestions.payload_field.risk_type',
+  origin: 'inbox.suggestions.payload_field.origin',
+  severity: 'inbox.suggestions.payload_field.severity',
+  priority: 'inbox.suggestions.payload_field.priority',
+  status: 'inbox.suggestions.payload_field.status',
+  type: 'inbox.suggestions.payload_field.type',
+  criticality: 'inbox.suggestions.payload_field.criticality',
+  jurisdiction: 'inbox.suggestions.payload_field.jurisdiction',
+  classification: 'inbox.suggestions.payload_field.classification',
+  finding_type: 'inbox.suggestions.payload_field.finding_type',
+  risk_level: 'inbox.suggestions.payload_field.risk_level',
+  source: 'inbox.suggestions.payload_field.source',
+  incident_type: 'inbox.suggestions.payload_field.incident_type',
+  current_likelihood: 'inbox.suggestions.payload_field.current_likelihood',
+  current_impact: 'inbox.suggestions.payload_field.current_impact',
 }
 
 function payloadFields(sg) {
@@ -1279,7 +1336,7 @@ function payloadFields(sg) {
     if (!obj || typeof obj !== 'object') return []
     return Object.entries(obj)
       .filter(([, v]) => v !== null && v !== '' && v !== undefined)
-      .map(([k, v]) => ({ key: k, label: fieldLabels[k] || k.replace(/_/g, ' '), value: v }))
+      .map(([k, v]) => ({ key: k, label: PAYLOAD_FIELD_KEYS[k] ? t(PAYLOAD_FIELD_KEYS[k]) : k.replace(/_/g, ' '), value: v }))
   } catch { return [] }
 }
 
@@ -1308,7 +1365,7 @@ onMounted(async () => {
       loadSuggestions(),
     ])
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Inbox.vue
+++ b/web/src/views/Inbox.vue
@@ -408,7 +408,7 @@
               <div class="text-sm font-medium text-slate-200 truncate">{{ ca.title }}</div>
               <div v-if="ca.description" class="text-xs text-slate-500 mt-0.5 truncate">{{ ca.description }}</div>
             </div>
-            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 flex-shrink-0">{{ severityLabel(ca.severity) }}</span>
+            <span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 flex-shrink-0">{{ caSeverityLabel(ca.severity) }}</span>
             <span class="text-xs text-slate-500 flex-shrink-0 w-32 truncate text-right">{{ sourceLabel(ca.source) }}</span>
             <span v-if="ca.due_date" class="text-xs flex-shrink-0 w-24 text-right" :class="isOverdue(ca) ? 'text-red-400 font-medium' : 'text-slate-500'">
               {{ formatDay(ca.due_date) }}
@@ -897,7 +897,13 @@ const tabs = computed(() => [
 // quoted word the raw-text scanner counts, and rightly.
 const taskTypeLabel = (v) => enumLabel('task_type', v)
 const priorityLabel = (v) => enumLabel('priority', v)
+// Incidents and corrective actions both call their column "severity" and they
+// are NOT the same value set: an incident is critical/high/medium/low, a
+// corrective action is major_nc/minor_nc/observation/opportunity — the audit
+// finding vocabulary, which the catalogue keys as `finding_type`. Mapping both
+// to `severity` renders a CA as the raw "Major Nc". Two helpers, deliberately.
 const severityLabel = (v) => enumLabel('severity', v)
+const caSeverityLabel = (v) => enumLabel('finding_type', v)
 const sourceLabel = (v) => enumLabel('source', v)
 const suggestionStatusLabel = (v) => enumLabel('status', v)
 

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -20,11 +20,11 @@
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
         </svg>
-        Back to reviews
+        {{ t('reviews.back') }}
       </button>
 
       <div v-if="!review" class="flex items-center justify-center h-64">
-        <div class="text-slate-500 text-sm">Review not found</div>
+        <div class="text-slate-500 text-sm">{{ t('reviews.not_found') }}</div>
       </div>
 
       <template v-else>
@@ -43,13 +43,13 @@
                   {{ statusLabel(review.status) }}
                 </span>
                 <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-slate-700/50 text-slate-300">
-                  Round {{ review.round || 1 }}
+                  {{ t('common.label.round', { round: review.round || 1 }) }}
                 </span>
                 <span v-if="aiReviewActive" class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-purple-500/15 text-purple-400">
-                  AI review in progress
+                  {{ t('reviews.ai.active') }}
                 </span>
                 <span v-if="aiReviewEscalated" class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-red-500/15 text-red-400">
-                  Escalated — AI review stalled
+                  {{ t('reviews.ai.escalated') }}
                 </span>
                 <span class="text-sm text-slate-400">
                   {{ review.version }}
@@ -62,7 +62,7 @@
                   </div>
                   <span class="text-sm text-slate-400">{{ review.requested_by }}</span>
                 </div>
-                <span class="text-xs text-slate-600">opened {{ timeAgo(review.created_at) }}</span>
+                <span class="text-xs text-slate-600">{{ t('reviews.opened_ago', { time: timeAgo(review.created_at) }) }}</span>
               </div>
             </div>
           </div>
@@ -77,9 +77,9 @@
         <div v-if="review.status === 'open' && !reviewGuideHidden && !userIsAuthor && userCanReview" class="mb-6 bg-blue-950/20 border border-blue-800/20 rounded-xl px-5 py-4">
           <div class="flex items-start justify-between">
             <div class="space-y-2 text-sm text-blue-300/80">
-              <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">1</span> Review the document and changes</div>
-              <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">2</span> Add comments or suggest edits</div>
-              <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">3</span> Approve or request changes</div>
+              <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">1</span> {{ t('reviews.guide.step_review') }}</div>
+              <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">2</span> {{ t('reviews.guide.step_comment') }}</div>
+              <div class="flex items-center gap-2"><span class="w-5 h-5 rounded-full bg-blue-600/30 flex items-center justify-center text-xs font-bold text-blue-300">3</span> {{ t('reviews.guide.step_decide') }}</div>
             </div>
             <button @click="reviewGuideHidden = true" class="text-blue-600 hover:text-blue-400 p-1">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -95,13 +95,13 @@
           <div class="flex-1 min-w-0">
             <!-- Detail tabs -->
             <div class="flex gap-1 bg-slate-900 border border-slate-800 rounded-lg p-1 mb-6">
-              <button v-for="t in detailTabs" :key="t.key" @click="detailTab = t.key"
+              <button v-for="tab in detailTabs" :key="tab.key" @click="detailTab = tab.key"
                 class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors"
-                :class="detailTab === t.key ? 'bg-slate-800 text-white' : 'text-slate-500 hover:text-slate-300'">
-                {{ t.label }}
-                <span v-if="t.count > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-semibold rounded-full"
-                  :class="detailTab === t.key ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'">
-                  {{ t.count }}
+                :class="detailTab === tab.key ? 'bg-slate-800 text-white' : 'text-slate-500 hover:text-slate-300'">
+                {{ tab.label }}
+                <span v-if="tab.count > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-semibold rounded-full"
+                  :class="detailTab === tab.key ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'">
+                  {{ tab.count }}
                 </span>
               </button>
             </div>
@@ -123,7 +123,7 @@
                   </div>
                   <div class="flex items-center gap-3">
                     <div class="h-px flex-1 bg-slate-700"></div>
-                    <span class="text-xs font-semibold text-slate-500 whitespace-nowrap">Round {{ entry.round }}</span>
+                    <span class="text-xs font-semibold text-slate-500 whitespace-nowrap">{{ t('common.label.round', { round: entry.round }) }}</span>
                     <div class="h-px flex-1 bg-slate-700"></div>
                   </div>
                 </div>
@@ -140,13 +140,13 @@
                         {{ initial(entry.actor) }}
                       </div>
                       <span class="text-sm font-medium text-slate-200">{{ entry.actor }}</span>
-                      <span class="text-xs text-slate-600">{{ entry.data?.suggestion_body ? 'suggested an edit' : 'commented' }} {{ timeAgo(entry.created_at) }}</span>
+                      <span class="text-xs text-slate-600">{{ entry.data?.suggestion_body ? t('reviews.timeline.suggested_edit') : t('reviews.timeline.commented') }} {{ timeAgo(entry.created_at) }}</span>
                       <span v-if="entry.data?.suggestion_status"
                         class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
                         :class="{ 'bg-amber-800/40 text-amber-300': entry.data.suggestion_status === 'pending', 'bg-emerald-800/40 text-emerald-300': entry.data.suggestion_status === 'accepted', 'bg-red-800/40 text-red-300': entry.data.suggestion_status === 'rejected' }">
-                        {{ entry.data.suggestion_status }}
+                        {{ suggestionStatusLabel(entry.data.suggestion_status) }}
                       </span>
-                      <span v-if="entry.round > 1" class="text-[10px] text-slate-600 px-1.5 py-0.5 rounded bg-slate-800/50 font-medium">R{{ entry.round }}</span>
+                      <span v-if="entry.round > 1" class="text-[10px] text-slate-600 px-1.5 py-0.5 rounded bg-slate-800/50 font-medium">{{ t('reviews.timeline.round_short', { round: entry.round }) }}</span>
                     </div>
                     <div v-if="entry.quote" class="mx-4 mt-3 px-3 py-2 border-l-2 border-slate-700 bg-slate-800/30 rounded-r text-xs text-slate-500 italic">
                       "{{ entry.quote }}"
@@ -168,11 +168,11 @@
                       {{ initial(entry.actor) }}
                     </div>
                     <span class="text-sm font-medium text-slate-200">{{ entry.actor }}</span>
-                    <span v-if="entry.decision === 'approved'" class="text-sm text-emerald-400 font-medium">approved this review</span>
-                    <span v-else-if="entry.decision === 'proposed_revision'" class="text-sm text-blue-400 font-medium">proposed a revision</span>
-                    <span v-else-if="entry.decision === 'changes_requested'" class="text-sm text-amber-400 font-medium">requested changes</span>
+                    <span v-if="entry.decision === 'approved'" class="text-sm text-emerald-400 font-medium">{{ t('reviews.timeline.approved') }}</span>
+                    <span v-else-if="entry.decision === 'proposed_revision'" class="text-sm text-blue-400 font-medium">{{ t('reviews.timeline.proposed_revision') }}</span>
+                    <span v-else-if="entry.decision === 'changes_requested'" class="text-sm text-amber-400 font-medium">{{ t('reviews.timeline.requested_changes') }}</span>
                     <span class="text-xs text-slate-600 ml-1">{{ timeAgo(entry.created_at) }}</span>
-                    <span v-if="entry.round > 1" class="text-[10px] text-slate-600 px-1.5 py-0.5 rounded bg-slate-800/50 font-medium">R{{ entry.round }}</span>
+                    <span v-if="entry.round > 1" class="text-[10px] text-slate-600 px-1.5 py-0.5 rounded bg-slate-800/50 font-medium">{{ t('reviews.timeline.round_short', { round: entry.round }) }}</span>
                     <div v-if="entry.detail" class="ml-2 text-xs text-slate-500 italic">"{{ entry.detail }}"</div>
                   </div>
 
@@ -190,9 +190,9 @@
                     <svg class="w-4 h-4 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zM4 19.235v-.11a6.375 6.375 0 0112.75 0v.109A12.318 12.318 0 0110.374 21c-2.331 0-4.512-.645-6.374-1.766z" />
                     </svg>
-                    <span class="text-slate-400">
-                      <span class="text-slate-300 font-medium">{{ entry.reviewer }}</span> was assigned as reviewer
-                    </span>
+                    <i18n-t keypath="reviews.timeline.assigned" tag="span" class="text-slate-400" scope="global">
+                      <template #reviewer><span class="text-slate-300 font-medium">{{ entry.reviewer }}</span></template>
+                    </i18n-t>
                     <span class="text-xs text-slate-600">{{ timeAgo(entry.created_at) }}</span>
                   </div>
 
@@ -208,7 +208,7 @@
                       </div>
                       <span class="text-sm font-medium text-slate-200">{{ entry.actor }}</span>
                       <span class="text-sm font-medium" :class="entry.decision === 'merged' ? 'text-purple-400' : entry.decision === 'approved' ? 'text-emerald-400' : entry.decision === 'proposed_revision' ? 'text-blue-400' : 'text-amber-400'">
-                        {{ entry.decision === 'merged' ? 'merged this review' : entry.decision === 'approved' ? 'approved (decision record)' : entry.decision === 'proposed_revision' ? 'proposed revision (decision record)' : 'requested changes (decision record)' }}
+                        {{ decisionLabel(entry.decision) }}
                       </span>
                       <span class="text-xs text-slate-600 ml-1">{{ timeAgo(entry.created_at) }}</span>
                     </div>
@@ -217,16 +217,16 @@
                       <svg class="w-3 h-3 text-slate-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0119.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 004.5 10.5a7.464 7.464 0 01-1.15 3.993m1.989 3.559A11.209 11.209 0 008.25 10.5a3.75 3.75 0 117.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 01-3.6 9.75m6.633-4.596a18.666 18.666 0 01-2.485 5.33" />
                       </svg>
-                      <span class="text-[10px] font-mono text-slate-600" title="SHA-256 content hash for tamper evidence">{{ entry.content_hash.substring(0, 16) }}...</span>
+                      <span class="text-[10px] font-mono text-slate-600" :title="t('reviews.timeline.content_hash')">{{ entry.content_hash.substring(0, 16) }}...</span>
                     </div>
                     <!-- Per-event diff: exactly what this revision changed (#6) -->
                     <div v-if="entry.decision === 'proposed_revision' && entry.data?.commit_ref" class="ml-6 mt-2">
                       <button @click="toggleEventDiff(entry)" class="text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors">
-                        {{ openEventDiff === entry.data.commit_ref ? 'Hide changes' : 'View changes' }}
+                        {{ openEventDiff === entry.data.commit_ref ? t('reviews.timeline.hide_changes') : t('reviews.timeline.view_changes') }}
                       </button>
                       <div v-if="openEventDiff === entry.data.commit_ref" class="mt-2 bg-slate-900 border border-slate-800 rounded-lg overflow-hidden">
-                        <div v-if="eventDiff[entry.data.commit_ref]?.loading" class="px-4 py-3 text-xs text-slate-500">Loading changes…</div>
-                        <div v-else-if="eventDiff[entry.data.commit_ref]?.error" class="px-4 py-3 text-xs text-red-400">Couldn't load this revision's diff.</div>
+                        <div v-if="eventDiff[entry.data.commit_ref]?.loading" class="px-4 py-3 text-xs text-slate-500">{{ t('reviews.timeline.diff_loading') }}</div>
+                        <div v-else-if="eventDiff[entry.data.commit_ref]?.error" class="px-4 py-3 text-xs text-red-400">{{ t('reviews.timeline.diff_error') }}</div>
                         <TrackChanges v-else
                           :old-body="eventDiff[entry.data.commit_ref]?.old || ''"
                           :new-body="eventDiff[entry.data.commit_ref]?.new || ''"
@@ -245,42 +245,44 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" />
                 </svg>
                 <div class="flex-1">
-                  <div class="text-sm text-blue-300 font-medium">Document updated since review was sent</div>
+                  <div class="text-sm text-blue-300 font-medium">{{ t('reviews.updated.heading') }}</div>
                   <div v-if="lastModifiedBy" class="text-xs text-blue-400/70 mt-0.5">
-                    Last modified by {{ lastModifiedBy }}<span v-if="lastCommitMsg"> — {{ lastCommitMsg }}</span>
+                    {{ lastCommitMsg
+                      ? t('reviews.updated.last_modified_by_with_message', { name: lastModifiedBy, message: lastCommitMsg })
+                      : t('reviews.updated.last_modified_by', { name: lastModifiedBy }) }}
                   </div>
-                  <div class="text-xs text-slate-500 mt-0.5">The diff below shows all changes since the last approved version.</div>
+                  <div class="text-xs text-slate-500 mt-0.5">{{ t('reviews.updated.note') }}</div>
                 </div>
               </div>
 
               <!-- Changes summary (always visible at top of conversation) -->
               <div v-if="oldBody || newBody" class="mb-6">
-                <div class="text-xs text-slate-500 font-medium mb-2">Changes in this review</div>
+                <div class="text-xs text-slate-500 font-medium mb-2">{{ t('reviews.diff.summary_heading') }}</div>
                 <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
                   <TrackChanges :old-body="oldBody" :new-body="newBody" :author="diffMeta?.last_modified_by" :date="diffMeta?.last_modified" :document-id="review?.document_id || ''" :blame-ref="diffMeta?.has_branch ? `review/${review?.id}` : ''" />
                 </div>
               </div>
               <div v-else-if="!diffLoading" class="mb-6 px-4 py-3 bg-slate-900 border border-slate-800 rounded-lg text-xs text-slate-500">
-                <span v-if="!diffMeta?.commit_hash">Full review — this document has never been approved. Review the full document in the Document tab.</span>
-                <span v-else>No diff available — the document may not have been modified since the review base.</span>
+                <span v-if="!diffMeta?.commit_hash">{{ t('reviews.diff.never_approved_inline') }}</span>
+                <span v-else>{{ t('reviews.diff.none_inline') }}</span>
               </div>
 
               <!-- Empty state -->
               <div v-if="timeline.length === 0 && !diffData" class="text-center py-12 text-slate-500 text-sm">
-                No activity yet.
+                {{ t('reviews.timeline.empty') }}
               </div>
 
               <!-- Comment input -->
               <div v-if="canCommentOnReview" class="mt-6 bg-slate-900 border border-slate-800 rounded-lg overflow-hidden">
                 <div class="px-4 py-2.5 border-b border-slate-800">
-                  <span class="text-xs text-slate-500 font-medium">Add a comment</span>
+                  <span class="text-xs text-slate-500 font-medium">{{ t('reviews.comment.heading') }}</span>
                 </div>
-                <textarea v-model="newComment" rows="3" placeholder="Leave a comment..."
+                <textarea v-model="newComment" rows="3" :placeholder="t('reviews.comment.placeholder')"
                   class="w-full bg-transparent px-4 py-3 text-sm text-slate-200 placeholder-slate-600 focus:outline-none resize-none"></textarea>
                 <div class="flex justify-end px-4 py-2.5 border-t border-slate-800">
                   <button @click="submitComment" :disabled="!newComment.trim() || submitting"
                     class="px-4 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors">
-                    Comment
+                    {{ t('common.action.comment') }}
                   </button>
                 </div>
               </div>
@@ -289,7 +291,7 @@
             <!-- Changes Tab -->
             <div v-if="detailTab === 'changes'">
               <div v-if="diffLoading" class="flex items-center justify-center h-48">
-                <div class="text-slate-400 text-sm">Loading changes...</div>
+                <div class="text-slate-400 text-sm">{{ t('reviews.diff.loading') }}</div>
               </div>
               <div v-else-if="oldBody || newBody || activeOldBody || activeNewBody" class="space-y-3">
                 <!-- Scope + view mode toggles -->
@@ -298,11 +300,11 @@
                   <div v-if="review.round > 1" class="flex items-center gap-0.5 bg-slate-900 border border-slate-800 rounded-lg p-0.5">
                     <button @click="switchDiffScope('round')" class="px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors"
                       :class="diffScope === 'round' ? 'bg-blue-600 text-white' : 'text-slate-500 hover:text-slate-300'">
-                      Changes in this round
+                      {{ t('reviews.diff.scope_round') }}
                     </button>
                     <button @click="switchDiffScope('all')" class="px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors"
                       :class="diffScope === 'all' ? 'bg-blue-600 text-white' : 'text-slate-500 hover:text-slate-300'">
-                      All changes in review
+                      {{ t('reviews.diff.scope_all') }}
                     </button>
                   </div>
                   <div v-else></div>
@@ -310,11 +312,11 @@
                   <div class="flex items-center gap-0.5 bg-slate-900 border border-slate-800 rounded-lg p-0.5">
                     <button @click="changesViewMode = 'split'" class="px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors"
                       :class="changesViewMode === 'split' ? 'bg-slate-700 text-white' : 'text-slate-500 hover:text-slate-300'">
-                      Split
+                      {{ t('reviews.diff.mode_split') }}
                     </button>
                     <button @click="changesViewMode = 'unified'" class="px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors"
                       :class="changesViewMode === 'unified' ? 'bg-slate-700 text-white' : 'text-slate-500 hover:text-slate-300'">
-                      Unified
+                      {{ t('reviews.diff.mode_unified') }}
                     </button>
                   </div>
                 </div>
@@ -337,10 +339,10 @@
               </div>
               <div v-else class="bg-slate-900 border border-slate-800 rounded-lg p-12 text-center">
                 <div v-if="!diffMeta?.commit_hash" class="space-y-2">
-                  <div class="text-slate-400 text-sm font-medium">Full review — this document has never been approved</div>
-                  <div class="text-slate-500 text-xs">There is no prior approved version to diff against. Review the full document in the Document tab.</div>
+                  <div class="text-slate-400 text-sm font-medium">{{ t('reviews.diff.never_approved_heading') }}</div>
+                  <div class="text-slate-500 text-xs">{{ t('reviews.diff.never_approved_body') }}</div>
                 </div>
-                <div v-else class="text-slate-500 text-sm">No changes found in this round.</div>
+                <div v-else class="text-slate-500 text-sm">{{ t('reviews.diff.none_in_round') }}</div>
               </div>
             </div>
 
@@ -352,24 +354,24 @@
                   <button @click="userIsAuthor ? saveAndResubmit() : saveReviewEdit()" :disabled="savingReviewEdit || (!userIsAuthor && !revisionNote.trim())"
                     class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors text-white disabled:opacity-50"
                     :class="userIsAuthor ? 'bg-blue-600 hover:bg-blue-500' : 'bg-amber-600 hover:bg-amber-500'">
-                    {{ savingReviewEdit ? 'Sending...' : userIsAuthor ? 'Save &amp; Resubmit' : 'Send proposed revision' }}
+                    {{ savingReviewEdit ? t('common.state.sending') : userIsAuthor ? t('reviews.edit.save_and_resubmit') : t('reviews.edit.send_revision') }}
                   </button>
-                  <span v-if="revisionDraftSaved" class="text-[10px] text-slate-600">Draft saved</span>
+                  <span v-if="revisionDraftSaved" class="text-[10px] text-slate-600">{{ t('reviews.edit.draft_saved') }}</span>
                   <button @click="cancelReviewEdit"
                     class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors text-slate-400 hover:text-slate-200 hover:bg-slate-800 border border-slate-700">
-                    Cancel
+                    {{ t('common.action.cancel') }}
                   </button>
                 </div>
 <textarea v-model="revisionNote" rows="2"
-                  placeholder="What did you change and why?"
+                  :placeholder="t('reviews.edit.note_placeholder')"
                   class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-xs text-slate-200 placeholder-slate-600 focus:outline-none focus:ring-1 focus:ring-amber-500 resize-none" />
               </div>
               <!-- Editor (same rich editor as Documents) -->
               <div v-if="reviewEditMode" class="space-y-2">
                 <div v-if="revisionDraftRecovered"
                   class="flex items-center gap-2 px-3 py-2 bg-blue-950/30 border border-blue-800/30 rounded-lg text-xs text-blue-400">
-                  <span>Draft recovered from previous session.</span>
-                  <button @click="reviewEditContent = documentContent; discardRevisionDraft(); revisionDraftRecovered = false" class="text-slate-500 hover:text-slate-300 ml-auto">Discard draft</button>
+                  <span>{{ t('reviews.edit.draft_recovered') }}</span>
+                  <button @click="reviewEditContent = documentContent; discardRevisionDraft(); revisionDraftRecovered = false" class="text-slate-500 hover:text-slate-300 ml-auto">{{ t('common.action.discard_draft') }}</button>
                 </div>
                 <div class="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
                   <DocumentEditor v-model="reviewEditContent" :editable="true" :documentId="review.document_id" @save="saveReviewEdit" />
@@ -397,24 +399,26 @@
             <!-- Review status summary — always shown for active reviews -->
             <div v-if="review.status !== 'merged' && review.status !== 'closed'"
               class="bg-blue-950/30 border border-blue-800/30 rounded-lg p-4">
-              <div class="text-sm font-semibold text-blue-300 mb-1">Round {{ review.round || 1 }}</div>
+              <div class="text-sm font-semibold text-blue-300 mb-1">{{ t('common.label.round', { round: review.round || 1 }) }}</div>
               <div class="text-xs text-blue-400/70 mb-3">
-                {{ (review.round || 1) > 1 ? 'Resubmitted after requested changes' : 'Initial review' }}
+                {{ (review.round || 1) > 1 ? t('reviews.summary.resubmitted') : t('reviews.summary.initial') }}
               </div>
               <div class="border-t border-blue-800/20 pt-2 space-y-1.5">
                 <div class="text-xs text-slate-400">
-                  <span class="text-slate-500">Approved:</span>
-                  {{ assignments.filter(a => a.status === 'approved').length }} of {{ assignments.length }}
+                  <span class="text-slate-500">{{ t('common.label.approved_prefix') }}</span>
+                  {{ t('reviews.summary.approved_count', { approved: approvedAssignmentCount, total: assignments.length }) }}
                 </div>
-                <div v-if="assignments.filter(a => a.status === 'pending').length > 0" class="text-xs text-slate-400">
-                  <span class="text-slate-500">Waiting on:</span>
-                  {{ assignments.filter(a => a.status === 'pending').map(a => a.reviewer.split('@')[0]).join(', ') }}
+                <div v-if="pendingReviewerNames" class="text-xs text-slate-400">
+                  <span class="text-slate-500">{{ t('reviews.summary.waiting_on') }}</span>
+                  {{ pendingReviewerNames }}
                 </div>
                 <div v-else-if="review.status === 'approved'" class="text-xs text-emerald-400 font-medium">
-                  All reviewers have approved. Ready to merge.
+                  {{ t('reviews.summary.ready_to_merge') }}
                 </div>
                 <div v-else-if="review.status === 'changes_requested'" class="text-xs text-amber-400 font-medium">
-                  Changes requested. {{ userIsAuthor ? 'Waiting for you to respond.' : 'Waiting for ' + (review.requested_by?.split('@')[0] || 'author') + ' to respond.' }}
+                  {{ userIsAuthor
+                    ? t('reviews.summary.changes_requested_you')
+                    : t('reviews.summary.changes_requested_author', { author: authorShortName }) }}
                 </div>
               </div>
             </div>
@@ -422,21 +426,21 @@
             <!-- Suggestion summary -->
             <div v-if="suggestionSummary.total > 0" class="bg-amber-950/20 border border-amber-800/20 rounded-lg p-4">
               <div class="text-xs font-semibold text-amber-300 mb-2">
-                {{ suggestionSummary.total }} suggestion{{ suggestionSummary.total === 1 ? '' : 's' }}
+                {{ t('reviews.suggestion.count', { count: suggestionSummary.total }, suggestionSummary.total) }}
               </div>
               <div class="space-y-1 text-xs">
-                <div v-if="suggestionSummary.pending" class="text-amber-400/80">{{ suggestionSummary.pending }} pending</div>
-                <div v-if="suggestionSummary.accepted" class="text-emerald-400/80">{{ suggestionSummary.accepted }} accepted</div>
-                <div v-if="suggestionSummary.rejected" class="text-red-400/80">{{ suggestionSummary.rejected }} rejected</div>
+                <div v-if="suggestionSummary.pending" class="text-amber-400/80">{{ t('reviews.suggestion.pending', { count: suggestionSummary.pending }) }}</div>
+                <div v-if="suggestionSummary.accepted" class="text-emerald-400/80">{{ t('reviews.suggestion.accepted', { count: suggestionSummary.accepted }) }}</div>
+                <div v-if="suggestionSummary.rejected" class="text-red-400/80">{{ t('reviews.suggestion.rejected', { count: suggestionSummary.rejected }) }}</div>
               </div>
             </div>
 
             <!-- Reviewers -->
             <div class="bg-slate-900 border border-slate-800 rounded-lg p-4">
               <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">
-                Reviewers<span class="text-slate-600 normal-case font-normal"> (Round {{ review.round || 1 }})</span>
+                {{ t('common.label.reviewers') }}<span class="text-slate-600 normal-case font-normal"> {{ t('common.label.round_paren', { round: review.round || 1 }) }}</span>
               </h3>
-              <div v-if="assignments.length === 0" class="text-xs text-slate-600">No reviewers assigned</div>
+              <div v-if="assignments.length === 0" class="text-xs text-slate-600">{{ t('reviews.assignment.empty') }}</div>
               <div v-else class="space-y-2.5">
                 <div v-for="a in assignments" :key="a.id" class="flex items-center gap-2.5">
                   <div class="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-bold text-white flex-shrink-0"
@@ -452,7 +456,7 @@
                     <span v-else-if="a.status === 'proposed_revision'" class="w-1.5 h-1.5 rounded-full bg-blue-400"></span>
                     <span v-else-if="a.status === 'changes_requested'" class="w-1.5 h-1.5 rounded-full bg-amber-400"></span>
                     <span v-else class="w-1.5 h-1.5 rounded-full bg-slate-500"></span>
-                    {{ a.status === 'changes_requested' ? 'changes' : a.status === 'proposed_revision' ? 'revision' : a.status }}
+                    {{ assignmentStatusLabel(a.status) }}
                   </span>
                 </div>
               </div>
@@ -460,7 +464,7 @@
 
             <!-- Policy compliance -->
             <div v-if="policyStatus && policyStatus.policies?.length > 0" class="bg-slate-900 border border-slate-800 rounded-lg p-4">
-              <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">Approval Requirements</h3>
+              <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">{{ t('reviews.policy.heading') }}</h3>
               <div class="space-y-2.5">
                 <div v-for="p in policyStatus.policies" :key="p.policy_id" class="text-xs">
                   <div class="flex items-center gap-1.5 mb-1">
@@ -468,31 +472,31 @@
                     <span class="text-slate-300 font-medium">{{ p.name }}</span>
                   </div>
                   <div class="pl-3.5 space-y-0.5 text-slate-500">
-                    <div>{{ p.current_approvals }}/{{ p.min_approvals }} approvals</div>
-                    <div v-if="p.missing_roles?.length" class="text-amber-400/70">Missing: {{ p.missing_roles.join(', ') }} role</div>
-                    <div v-if="p.missing_users?.length" class="text-amber-400/70">Awaiting: {{ p.missing_users.join(', ') }}</div>
+                    <div>{{ t('reviews.policy.approvals', { current: p.current_approvals, min: p.min_approvals }) }}</div>
+                    <div v-if="p.missing_roles?.length" class="text-amber-400/70">{{ t('reviews.policy.missing_roles', { roles: p.missing_roles.join(', ') }) }}</div>
+                    <div v-if="p.missing_users?.length" class="text-amber-400/70">{{ t('reviews.policy.missing_users', { users: p.missing_users.join(', ') }) }}</div>
                   </div>
                 </div>
               </div>
               <div v-if="!policyStatus.all_satisfied" class="mt-3 pt-2 border-t border-slate-800 text-[10px] text-amber-400">
-                Merge blocked until all requirements are met
+                {{ t('reviews.policy.blocked') }}
               </div>
               <div v-else-if="policyStatus.can_auto_merge" class="mt-3 pt-2 border-t border-slate-800 text-[10px] text-emerald-400">
-                Will auto-merge when all approvals are in
+                {{ t('reviews.policy.will_auto_merge') }}
               </div>
               <div v-for="p in policyStatus.policies" :key="'info-'+p.policy_id">
                 <div v-if="p.require_human && !p.satisfied" class="text-[10px] text-amber-400/70 mt-1 pl-3.5">
-                  At least one human approval required
+                  {{ t('reviews.policy.require_human') }}
                 </div>
                 <div v-if="p.auto_merge" class="text-[10px] text-emerald-400/70 mt-1 pl-3.5">
-                  Auto-merge enabled for this policy
+                  {{ t('reviews.policy.auto_merge') }}
                 </div>
               </div>
             </div>
 
             <!-- Actions -->
             <div v-if="review.status !== 'merged' && review.status !== 'closed'" class="bg-slate-900 border border-slate-800 rounded-lg p-4 space-y-2">
-              <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">Actions</h3>
+              <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">{{ t('reviews.actions.heading') }}</h3>
 
               <!-- Approval feedback -->
               <div v-if="approvalFeedback" class="px-3 py-2 bg-emerald-950/30 border border-emerald-800/30 rounded-lg text-xs text-emerald-400 mb-2">
@@ -508,13 +512,13 @@
                   <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
                   </svg>
-                  {{ policyStatus && !policyStatus.all_satisfied ? 'Requirements not met' : review.version ? `Publish ${review.version}` : 'Publish' }}
+                  {{ publishButtonLabel }}
                 </button>
                 <div v-if="canWrite" class="text-[10px] text-slate-600 text-center mt-1">
-                  This will make {{ review.version || 'this version' }} the accepted document.
+                  {{ publishNote }}
                 </div>
                 <div v-else class="px-3 py-2 bg-emerald-950/30 border border-emerald-800/30 rounded-lg text-xs text-emerald-400">
-                  All reviewers approved. Waiting for a manager to publish.
+                  {{ t('reviews.actions.awaiting_manager') }}
                 </div>
               </template>
 
@@ -523,40 +527,42 @@
                 <!-- Proposed revision — reviewer edited the document -->
                 <div v-if="review.status === 'changes_requested' && hasProposedRevision" class="space-y-2">
                   <div class="px-3 py-2 bg-blue-950/30 border border-blue-800/30 rounded-lg text-xs text-blue-400">
-                    <span class="font-medium">{{ proposedRevisionBy }}</span> proposed a revision to this document.
+                    <i18n-t keypath="reviews.actions.revision_proposed_by" tag="span" scope="global">
+                      <template #name><span class="font-medium">{{ proposedRevisionBy }}</span></template>
+                    </i18n-t>
                   </div>
                   <button @click="acceptAndPublish" :disabled="submitting"
                     class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                     </svg>
-                    {{ submitting ? 'Publishing...' : 'Accept &amp; Publish' }}
+                    {{ submitting ? t('reviews.actions.publishing') : t('reviews.actions.accept_and_publish') }}
                   </button>
                   <button @click="acceptProposedRevision" :disabled="submitting"
                     class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-slate-700 hover:bg-slate-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors">
-                    Request Another Review
+                    {{ t('reviews.actions.request_another_review') }}
                   </button>
                   <button @click="detailTab = 'document'; startReviewEdit()"
                     class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-slate-800 hover:bg-slate-700 text-slate-300 text-sm font-medium rounded-lg transition-colors border border-slate-700">
-                    Propose New Revision
+                    {{ t('reviews.actions.propose_new_revision') }}
                   </button>
                 </div>
                 <!-- Regular changes requested -->
                 <div v-else-if="review.status === 'changes_requested'" class="space-y-2">
                   <div class="px-3 py-2 bg-amber-950/30 border border-amber-800/30 rounded-lg text-xs text-amber-400">
-                    Changes were requested. Edit the document and resubmit.
+                    {{ t('reviews.actions.changes_were_requested') }}
                   </div>
                   <button @click="detailTab = 'document'; startReviewEdit()"
                     class="w-full flex items-center justify-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-500 text-white text-sm font-medium rounded-lg transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
                     </svg>
-                    Edit &amp; Resubmit
+                    {{ t('reviews.actions.edit_and_resubmit') }}
                   </button>
                 </div>
                 <!-- Waiting for feedback -->
                 <div v-else class="px-3 py-2 bg-slate-800/50 border border-slate-700 rounded-lg text-xs text-slate-400">
-                  <span class="text-slate-300 font-medium">You sent this review.</span> Waiting for reviewer feedback.
+                  <span class="text-slate-300 font-medium">{{ t('reviews.actions.you_sent_this') }}</span> {{ t('reviews.actions.waiting_for_feedback') }}
                 </div>
               </template>
 
@@ -564,17 +570,17 @@
               <template v-else-if="userCanReview">
                 <!-- Already acted in this round -->
                 <div v-if="userAlreadyActed" class="px-3 py-2 bg-slate-800/50 border border-slate-700 rounded-lg text-xs text-slate-400">
-                  <span v-if="userAssignmentStatus === 'approved'" class="text-emerald-400 font-medium">You approved this round.</span>
-                  <span v-else-if="userAssignmentStatus === 'proposed_revision'" class="text-blue-400 font-medium">You proposed a revision.</span>
-                  <span v-else-if="userAssignmentStatus === 'changes_requested'" class="text-amber-400 font-medium">You requested changes.</span>
-                  <template v-if="review.status === 'changes_requested'"> Waiting for {{ review.requested_by?.split('@')[0] || 'author' }} to respond.</template>
-                  <template v-else>Waiting for other reviewers.</template>
+                  <span v-if="userAssignmentStatus === 'approved'" class="text-emerald-400 font-medium">{{ t('reviews.actions.you_approved') }}</span>
+                  <span v-else-if="userAssignmentStatus === 'proposed_revision'" class="text-blue-400 font-medium">{{ t('reviews.actions.you_proposed_revision') }}</span>
+                  <span v-else-if="userAssignmentStatus === 'changes_requested'" class="text-amber-400 font-medium">{{ t('reviews.actions.you_requested_changes') }}</span>
+                  <template v-if="review.status === 'changes_requested'"> {{ t('reviews.actions.waiting_for_author', { author: authorShortName }) }}</template>
+                  <template v-else>{{ t('reviews.actions.waiting_for_reviewers') }}</template>
                 </div>
 
                 <!-- Actions (only if user hasn't acted yet) -->
                 <template v-else>
                   <div v-if="isUpdatedSinceSent" class="px-3 py-2 bg-amber-950/30 border border-amber-800/30 rounded-lg text-xs text-amber-400 mb-2">
-                    Document was updated after this review was sent. Review the latest changes before approving.
+                    {{ t('reviews.actions.stale_warning') }}
                   </div>
 
                   <!-- Default: show all 3 buttons. When one is active, hide the others. -->
@@ -584,7 +590,7 @@
                       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                       </svg>
-                      Approve
+                      {{ t('common.action.approve') }}
                     </button>
 
                     <button @click="activeAction = 'changes'" :disabled="submitting"
@@ -592,7 +598,7 @@
                       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" />
                       </svg>
-                      Request Changes
+                      {{ t('reviews.actions.request_changes') }}
                     </button>
 
                     <button @click="startProposeRevision" :disabled="submitting"
@@ -600,35 +606,35 @@
                       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
                       </svg>
-                      Propose Revision
+                      {{ t('reviews.actions.propose_revision') }}
                     </button>
                   </template>
 
                   <!-- Approve confirmation -->
                   <div v-if="activeAction === 'approve'" class="bg-emerald-950/30 border border-emerald-800/30 rounded-lg p-3 space-y-2">
-                    <div class="text-xs text-emerald-400 font-medium">Approve this document</div>
-                    <textarea v-model="approveComment" rows="2" placeholder="Optional comment..."
+                    <div class="text-xs text-emerald-400 font-medium">{{ t('reviews.actions.approve_heading') }}</div>
+                    <textarea v-model="approveComment" rows="2" :placeholder="t('reviews.actions.approve_placeholder')"
                       class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:ring-1 focus:ring-emerald-500 resize-none"></textarea>
                     <div class="flex gap-2">
                       <button @click="isUpdatedSinceSent ? confirmApproveStale() : submitApproval('approved')" :disabled="submitting"
                         class="flex-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-colors">
-                        {{ submitting ? 'Approving...' : 'Confirm Approve' }}
+                        {{ submitting ? t('reviews.actions.approving') : t('reviews.actions.confirm_approve') }}
                       </button>
-                      <button @click="activeAction = null; approveComment = ''" class="px-3 py-1.5 text-xs text-slate-500 hover:text-slate-300">Cancel</button>
+                      <button @click="activeAction = null; approveComment = ''" class="px-3 py-1.5 text-xs text-slate-500 hover:text-slate-300">{{ t('common.action.cancel') }}</button>
                     </div>
                   </div>
 
                   <!-- Request changes confirmation -->
                   <div v-if="activeAction === 'changes'" class="bg-amber-950/30 border border-amber-800/30 rounded-lg p-3 space-y-2">
-                    <div class="text-xs text-amber-400 font-medium">Request changes</div>
-                    <textarea v-model="changesComment" rows="2" placeholder="Describe what needs to change... (required)"
+                    <div class="text-xs text-amber-400 font-medium">{{ t('reviews.actions.changes_heading') }}</div>
+                    <textarea v-model="changesComment" rows="2" :placeholder="t('reviews.actions.changes_placeholder')"
                       class="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:ring-1 focus:ring-amber-500 resize-none"></textarea>
                     <div class="flex gap-2">
                       <button @click="submitApproval('changes_requested')" :disabled="!changesComment.trim() || submitting"
                         class="flex-1 px-3 py-1.5 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-colors">
-                        {{ submitting ? 'Submitting...' : 'Submit Request' }}
+                        {{ submitting ? t('reviews.actions.submitting') : t('reviews.actions.submit_request') }}
                       </button>
-                      <button @click="activeAction = null; changesComment = ''" class="px-3 py-1.5 text-xs text-slate-500 hover:text-slate-300">Cancel</button>
+                      <button @click="activeAction = null; changesComment = ''" class="px-3 py-1.5 text-xs text-slate-500 hover:text-slate-300">{{ t('common.action.cancel') }}</button>
                     </div>
                   </div>
                 </template>
@@ -638,13 +644,13 @@
               <div v-if="canWrite || userIsAuthor" class="border-t border-slate-800 pt-2 mt-2">
                 <button @click="closeReview" :disabled="submitting"
                   class="w-full flex items-center justify-center gap-2 px-4 py-1.5 text-slate-500 hover:text-red-400 text-xs font-medium transition-colors">
-                  {{ userIsAuthor ? 'Withdraw Review' : 'Close Without Merging' }}
+                  {{ userIsAuthor ? t('reviews.actions.withdraw') : t('reviews.actions.close_without_merging') }}
                 </button>
               </div>
 
               <!-- No actions for this user -->
               <div v-if="!canWrite && !userIsAuthor && !userCanReview" class="px-3 py-2 bg-slate-800/50 border border-slate-700 rounded-lg text-xs text-slate-500">
-                You are not a reviewer on this request.
+                {{ t('reviews.actions.not_a_reviewer') }}
               </div>
             </div>
 
@@ -654,35 +660,35 @@
                 <svg class="w-5 h-5 mx-auto mb-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
                 </svg>
-                Merged
+                {{ t('reviews.closed_state.merged') }}
               </div>
               <div v-else class="text-slate-500 font-semibold text-sm">
-                Closed
+                {{ t('reviews.closed_state.closed') }}
               </div>
               <div class="text-xs text-slate-600 mt-1">{{ timeAgo(review.updated_at) }}</div>
             </div>
 
             <!-- Document info -->
             <div class="bg-slate-900 border border-slate-800 rounded-lg p-4">
-              <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">Document</h3>
+              <h3 class="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">{{ t('reviews.document.heading') }}</h3>
               <div class="space-y-2 text-sm">
                 <div class="flex justify-between">
-                  <span class="text-slate-600">ID</span>
+                  <span class="text-slate-600">{{ t('reviews.document.id') }}</span>
                   <router-link :to="orgPath(`/documents/${encodeURIComponent(review.document_id)}`)"
                     class="text-blue-400 hover:text-blue-300 font-mono text-xs transition-colors">
                     {{ review.document_id }}
                   </router-link>
                 </div>
                 <div class="flex justify-between">
-                  <span class="text-slate-600">Version</span>
+                  <span class="text-slate-600">{{ t('common.label.version') }}</span>
                   <span class="text-slate-300">{{ review.version }}</span>
                 </div>
                 <div class="flex justify-between">
-                  <span class="text-slate-600">Comments</span>
+                  <span class="text-slate-600">{{ t('reviews.document.comments') }}</span>
                   <span class="text-slate-300">{{ review.comment_count || 0 }}</span>
                 </div>
                 <div v-if="review.open_comments > 0" class="flex justify-between">
-                  <span class="text-slate-600">Open</span>
+                  <span class="text-slate-600">{{ t('reviews.document.open_comments') }}</span>
                   <span class="text-amber-400">{{ review.open_comments }}</span>
                 </div>
               </div>
@@ -697,8 +703,8 @@
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
-          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">Reviews</h1>
-          <p class="text-sm text-slate-500 mt-1">Document review requests</p>
+          <h1 class="text-2xl font-bold text-slate-100 tracking-tight">{{ t('reviews.title') }}</h1>
+          <p class="text-sm text-slate-500 mt-1">{{ t('reviews.subtitle') }}</p>
         </div>
         <RefreshButton :loading="refreshing" @refresh="reload" />
       </div>
@@ -707,23 +713,23 @@
       <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ reviewStats.open || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Open</div>
+          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.open') }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ reviewStats.approved || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Approved</div>
+          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.approved') }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ reviewStats.changes_requested || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Changes Requested</div>
+          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.changes_requested') }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-slate-400 tabular-nums">{{ reviewStats.closed || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Closed</div>
+          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.closed') }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-purple-400 tabular-nums">{{ reviewStats.merged || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">Merged</div>
+          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.merged') }}</div>
         </div>
       </div>
 
@@ -732,7 +738,7 @@
         <button @click="statusFilter = 'open'"
           class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors"
           :class="statusFilter === 'open' ? 'bg-slate-800 text-white' : 'text-slate-500 hover:text-slate-300'">
-          Open
+          {{ t('reviews.filter.open') }}
           <span v-if="openCount > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-semibold rounded-full"
             :class="statusFilter === 'open' ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'">
             {{ openCount }}
@@ -741,7 +747,7 @@
         <button @click="statusFilter = 'closed'"
           class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors"
           :class="statusFilter === 'closed' ? 'bg-slate-800 text-white' : 'text-slate-500 hover:text-slate-300'">
-          Closed
+          {{ t('reviews.filter.closed') }}
           <span v-if="closedCount > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-semibold rounded-full"
             :class="statusFilter === 'closed' ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'">
             {{ closedCount }}
@@ -754,7 +760,7 @@
         <svg class="w-10 h-10 text-slate-700 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
         </svg>
-        <div class="text-slate-500 text-sm">No {{ statusFilter }} reviews</div>
+        <div class="text-slate-500 text-sm">{{ emptyListLabel }}</div>
       </div>
 
       <div v-else class="bg-slate-900 border border-slate-800 rounded-lg divide-y divide-slate-800 overflow-hidden">
@@ -785,13 +791,13 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-baseline gap-2">
                 <span class="text-sm font-semibold text-slate-200 group-hover:text-white transition-colors truncate">
-                  Review #{{ r.id }} -- {{ r.title }}
+                  {{ t('reviews.list.item_title', { id: r.id, title: r.title }) }}
                 </span>
               </div>
               <div class="flex items-center gap-2 mt-1 text-xs text-slate-500 flex-wrap">
                 <span>{{ r.version }}</span>
                 <span class="text-slate-700">*</span>
-                <span>Opened by {{ r.requested_by }}</span>
+                <span>{{ t('reviews.list.opened_by', { name: r.requested_by }) }}</span>
                 <span class="text-slate-700">*</span>
                 <span>{{ timeAgo(r.created_at) }}</span>
                 <span v-if="r.comment_count > 0" class="flex items-center gap-1 ml-2 text-slate-500">
@@ -810,7 +816,7 @@
                   </div>
                   <span class="text-[11px]"
                     :class="a.status === 'approved' ? 'text-emerald-400' : a.status === 'changes_requested' ? 'text-amber-400' : 'text-slate-500'">
-                    {{ a.reviewer.split('@')[0] }} ({{ a.status === 'changes_requested' ? 'changes' : a.status }})
+                    {{ t('reviews.list.reviewer_status', { name: a.reviewer.split('@')[0], status: assignmentStatusLabel(a.status) }) }}
                   </span>
                 </div>
               </div>
@@ -837,6 +843,7 @@
 
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useConfirm } from '../composables/useConfirm'
 import { useRoute, useRouter } from 'vue-router'
 import api from '../api'
@@ -854,8 +861,11 @@ import RefreshButton from '../components/RefreshButton.vue'
 import { useToast } from '../composables/useToast.js'
 import { useCurrentOrg } from '../composables/useCurrentOrg.js'
 import { formatRelative } from '../composables/useFormat.js'
+import { enumLabel } from '../composables/useEnumLabel.js'
+import { renderApiError } from '../composables/useApiError.js'
 const DocumentEditor = defineAsyncComponent(() => import('../components/DocumentEditor.vue'))
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { orgSlug, orgPath } = useCurrentOrg()
@@ -906,8 +916,44 @@ const hasProposedRevision = computed(() => {
 
 const proposedRevisionBy = computed(() => {
   const a = assignments.value.find(a => a.status === 'proposed_revision')
-  return a?.reviewer?.split('@')[0] || 'A reviewer'
+  return a?.reviewer?.split('@')[0] || t('reviews.reviewer_fallback')
 })
+
+// The author's local-part, or the translated word "author" when the review
+// carries no requester. Two sentences splice it and both used to build the
+// fallback inline.
+const authorShortName = computed(
+  () => review.value?.requested_by?.split('@')[0] || t('reviews.author_fallback'))
+
+const approvedAssignmentCount = computed(
+  () => assignments.value.filter(a => a.status === 'approved').length)
+
+// In a computed, not the template: a bare 'pending' in a v-if expression is a
+// quoted word the raw-text scanner counts, and it is right to — most of them
+// are copy.
+const pendingReviewerNames = computed(() => assignments.value
+  .filter(a => a.status === 'pending')
+  .map(a => a.reviewer.split('@')[0])
+  .join(', '))
+
+// Three states in one button, so the ternary lives here rather than in the
+// template where the raw-text scanner would count each arm.
+const publishButtonLabel = computed(() => {
+  if (policyStatus.value && !policyStatus.value.all_satisfied) return t('reviews.actions.requirements_not_met')
+  return review.value?.version
+    ? t('reviews.actions.publish_version', { version: review.value.version })
+    : t('reviews.actions.publish')
+})
+
+// Two whole sentences, not one with a spliced fragment: a language may not be
+// able to drop "this version" into the same slot a version number fills.
+const publishNote = computed(() => review.value?.version
+  ? t('reviews.actions.publish_note', { version: review.value.version })
+  : t('reviews.actions.publish_note_this_version'))
+
+const emptyListLabel = computed(() => statusFilter.value === 'closed'
+  ? t('reviews.list.empty_closed')
+  : t('reviews.list.empty_open'))
 
 const userCanReview = computed(() => {
   if (!userEmail.value || !review.value) return false
@@ -927,7 +973,7 @@ async function reload() {
   try {
     await Promise.all([loadReviews(), loadReviewStats()])
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     refreshing.value = false
   }
@@ -957,7 +1003,7 @@ async function saveAndResubmit() {
     // 2. Resubmit (triggers new round)
     await api.sendForReview(review.value.document_id, {
       reviewers: assignments.value.map(a => a.reviewer),
-      message: revisionNote.value.trim() || 'Author edits',
+      message: revisionNote.value.trim() || t('reviews.revision_note_fallback'),
     })
     reviewEditMode.value = false
     reviewEditContent.value = ''
@@ -966,7 +1012,7 @@ async function saveAndResubmit() {
     await loadReviewDetail(review.value.id)
   } catch (e) {
     console.error('Save & resubmit failed:', e)
-    showError('Save & resubmit failed: ' + (e.message || 'unknown error'))
+    showError(t('reviews.error.save_and_resubmit', { message: renderApiError(e) }))
   } finally {
     savingReviewEdit.value = false
   }
@@ -976,10 +1022,10 @@ async function acceptAndPublish() {
   submitting.value = true
   try {
     await api.acceptAndMerge(review.value.id)
-    approvalFeedback.value = 'Revision accepted and published.'
+    approvalFeedback.value = t('reviews.toast.revision_published')
     await loadReviewDetail(review.value.id)
   } catch (e) {
-    approvalFeedback.value = 'Failed to publish: ' + (e.message || 'unknown error')
+    approvalFeedback.value = t('reviews.error.publish', { message: renderApiError(e) })
   } finally {
     submitting.value = false
   }
@@ -991,11 +1037,11 @@ async function acceptProposedRevision() {
   try {
     await api.sendForReview(review.value.document_id, {
       reviewers: assignments.value.map(a => a.reviewer),
-      message: 'Accepted proposed revision',
+      message: t('reviews.toast.revision_accepted'),
     })
     await loadReviewDetail(review.value.id)
   } catch (e) {
-    approvalFeedback.value = 'Failed to accept revision: ' + (e.message || 'unknown error')
+    approvalFeedback.value = t('reviews.error.accept_revision', { message: renderApiError(e) })
   } finally {
     submitting.value = false
   }
@@ -1114,9 +1160,9 @@ watch([statusFilter], () => { page.value = 1; loadReviews() })
 watch([page, pageSize], () => { loadReviews() })
 
 const detailTabs = computed(() => [
-  { key: 'changes', label: `Changes (Round ${review.value?.round || 1})`, count: changedParagraphCount.value },
-  { key: 'document', label: 'Document', count: 0 },
-  { key: 'conversation', label: 'Conversation', count: timeline.value.filter(e => e.type === 'comment').length },
+  { key: 'changes', label: t('reviews.tab.changes', { round: review.value?.round || 1 }), count: changedParagraphCount.value },
+  { key: 'document', label: t('reviews.tab.document'), count: 0 },
+  { key: 'conversation', label: t('reviews.tab.conversation'), count: timeline.value.filter(e => e.type === 'comment').length },
 ])
 
 // Active diff bodies: switch between current-round and all-changes views
@@ -1189,15 +1235,46 @@ function statusDotClass(status) {
   }
 }
 
+// The five review statuses are all in common.enum.status, which is also what
+// StatusBadge renders — so this is a lookup, not a switch. It changes the case
+// of one label: "Changes Requested" becomes the catalogue's "Changes requested",
+// the same normalisation the register views took.
 function statusLabel(status) {
-  switch (status) {
-    case 'open': return 'Open'
-    case 'approved': return 'Approved'
-    case 'changes_requested': return 'Changes Requested'
-    case 'merged': return 'Merged'
-    case 'closed': return 'Closed'
-    default: return status
-  }
+  return enumLabel('status', status)
+}
+
+// Abbreviated assignment status for the reviewer chips, which are too narrow for
+// the full label — "changes", not "Changes requested". Authored per language
+// rather than derived, and kept in reviews.* because the abbreviation is a
+// property of this control's width, not of the value.
+// Keys are spelled out rather than built from the value: a concatenated key is
+// invisible to the keyset walk, and both value sets are closed anyway.
+const ASSIGNMENT_STATUS_KEYS = {
+  approved: 'reviews.assignment.status.approved',
+  pending: 'reviews.assignment.status.pending',
+  changes_requested: 'reviews.assignment.status.changes_requested',
+  proposed_revision: 'reviews.assignment.status.proposed_revision',
+}
+function assignmentStatusLabel(status) {
+  const key = ASSIGNMENT_STATUS_KEYS[status]
+  return key ? t(key) : status
+}
+
+function suggestionStatusLabel(status) {
+  return enumLabel('status', status)
+}
+
+// The decision record's own wording, which differs from the timeline entry above
+// it — "approved (decision record)" against "approved this review". Anything
+// that is not merged/approved/proposed_revision is a change request, which is
+// how the ternary this replaces behaved.
+const DECISION_KEYS = {
+  merged: 'reviews.timeline.decision.merged',
+  approved: 'reviews.timeline.decision.approved',
+  proposed_revision: 'reviews.timeline.decision.proposed_revision',
+}
+function decisionLabel(decision) {
+  return t(DECISION_KEYS[decision] || 'reviews.timeline.decision.changes_requested')
 }
 
 function assignmentStatusClass(status) {
@@ -1255,7 +1332,7 @@ function openReview(id) {
 const { ask } = useConfirm()
 
 async function confirmApproveStale() {
-  if (await ask('The document was modified after this review was sent. Approve based on the current version?', { confirm: 'Approve anyway', variant: 'warning' })) {
+  if (await ask(t('reviews.confirm.approve_stale_body'), { confirm: t('reviews.confirm.approve_stale_title'), variant: 'warning' })) {
     submitApproval('approved')
   }
 }
@@ -1297,7 +1374,7 @@ function startReviewEdit() {
 async function cancelReviewEdit() {
   const key = revisionDraftKey()
   if (key && reviewEditContent.value !== documentContent.value) {
-    if (!await ask('Discard unsaved changes?', { confirm: 'Discard', variant: 'danger' })) return
+    if (!await ask(t('reviews.confirm.discard_changes'), { confirm: t('common.action.discard'), variant: 'danger' })) return
   }
   stopRevisionAutosave()
   reviewEditMode.value = false
@@ -1348,7 +1425,7 @@ async function saveReviewEdit() {
     await loadReviewDetail(review.value.id)
     loadDiff()
   } catch (e) {
-    showError('Failed to submit revision: ' + (e.message || 'unknown error'))
+    showError(t('reviews.error.submit_revision', { message: renderApiError(e) }))
   } finally {
     savingReviewEdit.value = false
   }
@@ -1376,7 +1453,7 @@ async function loadReviews() {
       }
     }))
   } catch (e) {
-    showError('Failed to load reviews: ' + e.message)
+    showError(t('reviews.error.load_list', { message: renderApiError(e) }))
   }
 }
 
@@ -1406,7 +1483,7 @@ async function loadReviewDetail(id) {
     loadDiff()
     loadPolicyStatus()
   } catch (e) {
-    error.value = 'Failed to load review: ' + e.message
+    error.value = t('reviews.error.load_one', { message: renderApiError(e) })
   }
 }
 
@@ -1470,7 +1547,7 @@ async function submitComment() {
     newComment.value = ''
     await loadReviewDetail(reviewId.value)
   } catch (e) {
-    showError('Failed to add comment: ' + (e.message || 'unknown error'))
+    showError(t('reviews.error.add_comment', { message: renderApiError(e) }))
   } finally {
     submitting.value = false
   }
@@ -1488,18 +1565,25 @@ async function submitApproval(decision) {
     changesComment.value = ''
     approveComment.value = ''
     // Show feedback with round context
-    const roundLabel = result?.round > 1 ? ` for Round ${result.round}` : ''
-    if (result?.pending_reviewers?.length > 0) {
-      approvalFeedback.value = `Your ${decision === 'approved' ? 'approval' : 'request for changes'} has been recorded${roundLabel}. Waiting on ${result.pending_reviewers.length} more reviewer${result.pending_reviewers.length > 1 ? 's' : ''}.`
+    // The round clause is a suffix on all three sentences, so it stays one
+    // param rather than three spliced fragments; the plural on "reviewer" is
+    // vue-i18n's, not an appended "s".
+    const round = result?.round > 1 ? t('reviews.toast.for_round', { round: result.round }) : ''
+    const pending = result?.pending_reviewers?.length || 0
+    if (pending > 0) {
+      const key = decision === 'approved'
+        ? 'reviews.toast.decision_recorded'
+        : 'reviews.toast.decision_recorded_changes'
+      approvalFeedback.value = t(key, { round, count: pending }, pending)
     } else if (decision === 'approved') {
-      approvalFeedback.value = `All reviewers have approved${roundLabel}. Ready to merge.`
+      approvalFeedback.value = t('reviews.toast.all_approved', { round })
     } else {
-      approvalFeedback.value = `Changes requested${roundLabel}. The author will be notified.`
+      approvalFeedback.value = t('reviews.toast.changes_requested', { round })
     }
     setTimeout(() => { approvalFeedback.value = '' }, 8000)
     await loadReviewDetail(reviewId.value)
   } catch (e) {
-    showError('Failed to submit decision: ' + (e.message || 'unknown error'))
+    showError(t('reviews.error.submit_decision', { message: renderApiError(e) }))
   } finally {
     submitting.value = false
   }
@@ -1513,7 +1597,7 @@ async function mergeReview() {
     await loadReviewDetail(reviewId.value)
     loadReviewStats()
   } catch (e) {
-    showError('Failed to merge review: ' + (e.message || 'unknown error'))
+    showError(t('reviews.error.merge', { message: renderApiError(e) }))
   } finally {
     submitting.value = false
   }
@@ -1527,7 +1611,7 @@ async function closeReview() {
     await loadReviewDetail(reviewId.value)
     loadReviewStats()
   } catch (e) {
-    showError('Failed to close review: ' + (e.message || 'unknown error'))
+    showError(t('reviews.error.close', { message: renderApiError(e) }))
   } finally {
     submitting.value = false
   }
@@ -1565,7 +1649,7 @@ onMounted(async () => {
       await loadReviewDetail(reviewId.value)
     }
   } catch (e) {
-    error.value = e.message
+    error.value = renderApiError(e)
   } finally {
     loading.value = false
   }

--- a/web/src/views/Reviews.vue
+++ b/web/src/views/Reviews.vue
@@ -713,23 +713,23 @@
       <div class="grid grid-cols-2 lg:grid-cols-5 gap-4">
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-blue-400 tabular-nums">{{ reviewStats.open || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.open') }}</div>
+          <div class="text-xs text-slate-500 mt-1">{{ statOpen }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-emerald-400 tabular-nums">{{ reviewStats.approved || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.approved') }}</div>
+          <div class="text-xs text-slate-500 mt-1">{{ statApproved }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-amber-400 tabular-nums">{{ reviewStats.changes_requested || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.changes_requested') }}</div>
+          <div class="text-xs text-slate-500 mt-1">{{ statChangesRequested }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-slate-400 tabular-nums">{{ reviewStats.closed || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.closed') }}</div>
+          <div class="text-xs text-slate-500 mt-1">{{ statClosed }}</div>
         </div>
         <div class="bg-slate-900 border border-slate-800 rounded-xl p-4">
           <div class="text-2xl font-bold text-purple-400 tabular-nums">{{ reviewStats.merged || 0 }}</div>
-          <div class="text-xs text-slate-500 mt-1">{{ t('reviews.stat.merged') }}</div>
+          <div class="text-xs text-slate-500 mt-1">{{ statMerged }}</div>
         </div>
       </div>
 
@@ -738,7 +738,7 @@
         <button @click="statusFilter = 'open'"
           class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors"
           :class="statusFilter === 'open' ? 'bg-slate-800 text-white' : 'text-slate-500 hover:text-slate-300'">
-          {{ t('reviews.filter.open') }}
+          {{ statOpen }}
           <span v-if="openCount > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-semibold rounded-full"
             :class="statusFilter === 'open' ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'">
             {{ openCount }}
@@ -747,7 +747,7 @@
         <button @click="statusFilter = 'closed'"
           class="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors"
           :class="statusFilter === 'closed' ? 'bg-slate-800 text-white' : 'text-slate-500 hover:text-slate-300'">
-          {{ t('reviews.filter.closed') }}
+          {{ statClosed }}
           <span v-if="closedCount > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-semibold rounded-full"
             :class="statusFilter === 'closed' ? 'bg-slate-700 text-slate-200' : 'bg-slate-800 text-slate-400'">
             {{ closedCount }}
@@ -950,6 +950,16 @@ const publishButtonLabel = computed(() => {
 const publishNote = computed(() => review.value?.version
   ? t('reviews.actions.publish_note', { version: review.value.version })
   : t('reviews.actions.publish_note_this_version'))
+
+// The five stat tiles and the two filter tabs name review statuses, so they
+// read the same catalogue the badge beside them does. Keeping their own copies
+// is what let one screen show "Changes Requested" on the tile and "Changes
+// requested" on the badge two inches away.
+const statOpen = computed(() => statusLabel('open'))
+const statApproved = computed(() => statusLabel('approved'))
+const statChangesRequested = computed(() => statusLabel('changes_requested'))
+const statClosed = computed(() => statusLabel('closed'))
+const statMerged = computed(() => statusLabel('merged'))
 
 const emptyListLabel = computed(() => statusFilter.value === 'closed'
   ? t('reviews.list.empty_closed')

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -1,4 +1,1 @@
-{
-  "composables/useDocumentEditor.js": 1,
-  "views/Documents.vue": 15
-}
+{}

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -1,5 +1,4 @@
 {
   "composables/useDocumentEditor.js": 1,
-  "views/Documents.vue": 15,
-  "views/Inbox.vue": 21
+  "views/Documents.vue": 15
 }

--- a/web/test/errorRender.baseline.json
+++ b/web/test/errorRender.baseline.json
@@ -1,6 +1,5 @@
 {
   "composables/useDocumentEditor.js": 1,
   "views/Documents.vue": 15,
-  "views/Inbox.vue": 21,
-  "views/Reviews.vue": 12
+  "views/Inbox.vue": 21
 }

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,5 +1,4 @@
 {
   "views/Documents.vue": 186,
-  "views/Inbox.vue": 90,
-  "views/Reviews.vue": 146
+  "views/Inbox.vue": 90
 }

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,3 +1,1 @@
-{
-  "views/Documents.vue": 186
-}
+{}

--- a/web/test/rawText.baseline.json
+++ b/web/test/rawText.baseline.json
@@ -1,4 +1,3 @@
 {
-  "views/Documents.vue": 186,
-  "views/Inbox.vue": 90
+  "views/Documents.vue": 186
 }


### PR DESCRIPTION
Makes the last three screens of the app translatable: **Documents, Reviews and Inbox**, plus the document editor behind them. With #271, which has now merged, every screen in the product is translatable and none is left.

**Rebased onto master and ready to review.** #271 and #273 have both landed, and this branch has been rebased on top of them. The two automated text scanners now report **zero findings across zero files** for the whole app — that was the point of the series.

## What changes for a user

Nothing visible, with four exceptions, all deliberate:

- A few labels change capitalisation so the same value reads the same way everywhere. A review that says "Changes requested" on its badge now also says "Changes requested" on the counter above it, instead of "Changes Requested". Same for a handful of task and suggestion labels.
- Two labels were plain wrong and are now right. A corrective action's severity displayed as "Major Nc"; a suggestion to create something displayed as "New Risk" on this screen and "Create Risk" everywhere else — both are fixed.
- **The corrective-action severity chip on the inbox now shows the short form** — "Major NC" rather than "Major non-conformity", "OFI" rather than "Opportunity for improvement". That chip is the same width as the incident severity badge beside it, which holds one word, so the full label did not fit. #271 introduced the short forms for exactly this situation and this screen now uses them.
- Error messages on these screens are now assembled the same way as on every other screen, so they can be translated. The wording a user sees is unchanged.

## Why it matters

Until now roughly a fifth of the app was still hard-coded English. A translator could not reach it, and the release gate that decides whether a second language may be offered was set against exactly this measurement. That gate is satisfied once this merges — turning on Indonesian (or later Brazilian Portuguese) becomes a one-line decision rather than a project.

The gate's own budget allows a small residue of text the scanner cannot tell apart from copy. Now that the whole app is extracted, the measured residue is nothing at all, so that budget is headroom for a future screen rather than an estimate of an unmeasured remainder. The budget itself is unchanged here; adjusting it is a separate decision.

## Risk

**Low, and the low-risk part is the bulk of it.** Most of the change is mechanical: a hard-coded phrase becomes a lookup that returns the same phrase. Automated checks confirm no screen renders untranslatable text any more and that every lookup resolves to a real phrase.

**The genuine risk is a phrase quietly losing a word during that swap**, because a lookup that returns slightly wrong text still passes every automated check. That happened once here — a tab lost the word "Round" and read "Changes (1)". It is fixed, and the fix includes a new check that compares every phrase the old code produced against the new text, which found nothing else across all three screens.

**Everything was also checked by hand in a browser** against realistic data: a live review with a proposed revision, comments, tasks, an incident, a corrective action, a change request and a suggestion. That pass is what caught the two wrong labels above; no automated check could have. It is also how the two previous PRs in this series found dead panels, which is why it is not optional.

**On the rebase itself:** the two branches overlapped in five files, all of them shared bookkeeping — the shared phrase file, its index, the two scanner tracking files, and one comment in the release-gate test. The shared phrase file was purely additive on both sides and the twenty-one entries both sides added were identical in value, so there was no wording decision to make; each resolution was verified by checking that the merged entry set is exactly the union of the two sides, with a duplicate-key check on top. The tracking files were regenerated from the scanners rather than merged by hand, at every step, and the scanners agreed at each one.

## Scope

- Three screens plus one shared editor file.
- 422 phrases and 49 error messages moved into the translation files.
- 463 new entries: 422 specific to these screens, 41 shared with the rest of the app.
- No database changes, no API changes, no new dependencies.

## Deliberately not included

- One field on the inbox incident row still shows its raw stored value. There is no agreed list of allowed values for it yet, and guessing at one would be worse than leaving it.
- The shared button that handled its label the old way shipped separately as #273, as planned, and has merged.

## Checks, re-run after the rebase

- Front-end test suite: 152/152.
- The shared-vocabulary test run on its own, because #271 extended it and it had never seen the entries this branch adds: 12/12.
- Back-end: `go vet` clean, release-gate test and the API package tests passing.
- Production build: clean. Run separately because the test runner does not compile screen templates.
- Both automated text scanners: **zero findings across zero files**, for the whole app.

**Please merge with a merge commit or a rebase, not a squash.** The per-screen history is the point of this series — nine commits, each one screen or one fix, so a defect found later reverts one screen rather than all three.

