### PR TITLE
fix(i18n): SuggestNewButton splices a standalone entity name mid-sentence (#212)

### DIFF
--- a/web/src/components/SuggestNewButton.vue
+++ b/web/src/components/SuggestNewButton.vue
@@ -84,20 +84,22 @@ const form = ref({ suggestion_type: 'create', title: '', description: '', ration
 
 const isDetail = computed(() => !!props.entityId)
 
-// The entity name is interpolated whole. It used to be lower-cased for the
-// "new" variant, which is locale-blind — German capitalises every noun — so
-// the casing now belongs to whatever the caller passes.
-// Mid-sentence ("Suggest new risk") wants the inline entity name, which
-// `common.entity_inline.*` authors per locale — the old code lower-cased
-// `typeLabel`, which is locale-blind. Falls back to the prop for an entity
-// type with no catalogue entry.
+// Every frame this component fills puts the entity name mid-sentence —
+// "Suggest new risk", "Suggest change to risk", "Edit risk", "Describe the new
+// risk..." — so all four take the inline form from `common.entity_inline.*`,
+// which authors that casing per locale. The old code lower-cased `typeLabel`
+// instead, which is locale-blind: German capitalises every noun.
+//
+// `typeLabel` is the caller's standalone label and is never spliced into a
+// frame any more; it survives only as the fallback for an entity type the
+// catalogue does not name.
 const inlineEntity = computed(
   () => entityLabel(props.entityType, { inline: true }) || props.typeLabel,
 )
 
 const formTitle = computed(() =>
   isDetail.value
-    ? t('components.suggest_new.form_title_change', { entity: props.typeLabel })
+    ? t('components.suggest_new.form_title_change', { entity: inlineEntity.value })
     : t('components.suggest_new.form_title_new', { entity: inlineEntity.value }),
 )
 
@@ -121,7 +123,7 @@ const typeOptions = computed(() => {
   if (!isDetail.value) return []
   const defs = detailTypes[props.entityType]
   if (!defs) {
-    return [{ value: 'update', label: t('components.suggest_new.type.edit_entity', { entity: props.typeLabel }) }]
+    return [{ value: 'update', label: t('components.suggest_new.type.edit_entity', { entity: inlineEntity.value }) }]
   }
   return defs.map((o) => ({ value: o.value, label: t(`components.suggest_new.type.${o.labelKey}`) }))
 })


### PR DESCRIPTION
Fixes a small wording inconsistency in the "Suggest" button that appears on fifteen screens.

## What a user sees

The dropdown on that button lists options like "Edit risk", "Edit supplier", "Edit corrective action" — except for entity types without a hand-written entry, which rendered "Edit Corrective Action" with capitals, sitting directly beneath siblings that did not. The form heading had the same split: "Suggest new corrective action" but "Suggest change to Corrective action".

Both now read the same way as the options around them.

## Why it is worth a change rather than living with it

The capitalisation is the visible symptom; the reason to fix it is that the two frames were reaching for the wrong source. The app keeps two forms of every entity name — a standalone one for headings and badges, and a mid-sentence one — because which is correct is a property of the language, not of the app. Lower-casing the standalone form in code would break German, where every noun is capitalised.

Two of this component's four sentences already used the mid-sentence form. The other two used the standalone one. This makes all four consistent, so a translator has one place to make that decision instead of finding that half the sentences ignore it.

## Risk

Very low. Two expressions now read a value defined three lines above them, from a list that already covers every entity type the app knows; anything unknown falls back to exactly what was shown before. No behaviour changes, no data changes, no new text to translate.

## Scope and sequencing

One file, two lines plus a comment. Deliberately kept out of the larger translation PRs in this series — the component has fifteen callers, and that reach does not belong buried in a large diff.

Branched from master and independent of the two open translation PRs. Neither touches this component, and this changes no tracked counts, so it can merge before or after either without a rebase.

It is complementary to #271 rather than overlapping: that PR fixes what six screens *pass in*, this fixes what the component *does with it*. This one also repairs three screens that still pass hard-coded English today, so it stands on its own if #271 is delayed.

## Checks

- Front-end test suite: 150/150.
- Production build: clean.
- Both automated text scanners: counts byte-identical to master.
- Rendered wording confirmed for all five affected entity types.
