### PR TITLE
refactor(i18n): fold the six per-register unsaved-changes copies into common (#212)

### DIFF
--- a/web/src/locales/en/assets.json
+++ b/web/src/locales/en/assets.json
@@ -67,10 +67,5 @@
     "warning": "Deleting this asset is permanent and cannot be undone. History, comments, and linked references will be lost.",
     "delete": "Delete asset",
     "confirm": "Delete this asset? This cannot be undone."
-  },
-  "dirty": {
-    "switch_tab": "You have unsaved changes. Discard and switch tab?",
-    "close": "You have unsaved changes. Discard and close?",
-    "discard": "Discard"
   }
 }

--- a/web/src/locales/en/incidents.json
+++ b/web/src/locales/en/incidents.json
@@ -84,10 +84,5 @@
     "warning": "Deleting this incident is permanent and cannot be undone.",
     "delete": "Delete incident",
     "confirm": "Delete incident \"{title}\"? This cannot be undone."
-  },
-  "dirty": {
-    "switch_tab": "You have unsaved changes. Discard and switch tab?",
-    "close": "You have unsaved changes. Discard and close?",
-    "discard": "Discard"
   }
 }

--- a/web/src/locales/en/legal.json
+++ b/web/src/locales/en/legal.json
@@ -70,10 +70,5 @@
     "warning": "Deleting this legal requirement is permanent and cannot be undone. History, comments, and linked references will be lost.",
     "delete": "Delete requirement",
     "confirm": "Delete this legal requirement? This cannot be undone."
-  },
-  "dirty": {
-    "switch_tab": "You have unsaved changes. Discard and switch tab?",
-    "close": "You have unsaved changes. Discard and close?",
-    "discard": "Discard"
   }
 }

--- a/web/src/locales/en/risks.json
+++ b/web/src/locales/en/risks.json
@@ -89,10 +89,5 @@
     "warning": "Deleting this risk is permanent and cannot be undone. History, comments, and linked references will be lost.",
     "delete": "Delete risk",
     "confirm": "Delete this risk? This cannot be undone."
-  },
-  "dirty": {
-    "switch_tab": "You have unsaved changes. Discard and switch tab?",
-    "close": "You have unsaved changes. Discard and close?",
-    "discard": "Discard"
   }
 }

--- a/web/src/locales/en/suppliers.json
+++ b/web/src/locales/en/suppliers.json
@@ -79,10 +79,5 @@
     "warning": "Deleting this supplier is permanent and cannot be undone. History, comments, reviews and linked references will be lost.",
     "delete": "Delete supplier",
     "confirm": "Delete this supplier? This cannot be undone."
-  },
-  "dirty": {
-    "switch_tab": "You have unsaved changes. Discard and switch tab?",
-    "close": "You have unsaved changes. Discard and close?",
-    "discard": "Discard"
   }
 }

--- a/web/src/locales/en/systems.json
+++ b/web/src/locales/en/systems.json
@@ -97,10 +97,5 @@
     "warning": "Deleting this system is permanent and cannot be undone. History, comments, access reviews and linked references will be lost.",
     "delete": "Delete system",
     "confirm": "Delete this system? This cannot be undone."
-  },
-  "dirty": {
-    "switch_tab": "You have unsaved changes. Discard and switch tab?",
-    "close": "You have unsaved changes. Discard and close?",
-    "discard": "Discard"
   }
 }

--- a/web/src/views/Assets.vue
+++ b/web/src/views/Assets.vue
@@ -670,9 +670,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('assets.dirty.switch_tab'),
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: t('assets.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -683,9 +683,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('assets.dirty.close'),
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: t('assets.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }

--- a/web/src/views/Incidents.vue
+++ b/web/src/views/Incidents.vue
@@ -834,9 +834,9 @@ async function selectIncident(inc) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('incidents.dirty.switch_tab'),
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: t('incidents.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -847,9 +847,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('incidents.dirty.close'),
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: t('incidents.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }

--- a/web/src/views/Legal.vue
+++ b/web/src/views/Legal.vue
@@ -758,9 +758,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('legal.dirty.switch_tab'),
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: t('legal.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -771,9 +771,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('legal.dirty.close'),
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: t('legal.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }

--- a/web/src/views/Risks.vue
+++ b/web/src/views/Risks.vue
@@ -738,9 +738,9 @@ async function saveSection() {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('risks.dirty.switch_tab'),
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: t('risks.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -751,9 +751,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('risks.dirty.close'),
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: t('risks.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }

--- a/web/src/views/Suppliers.vue
+++ b/web/src/views/Suppliers.vue
@@ -774,9 +774,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('suppliers.dirty.switch_tab'),
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: t('suppliers.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -787,9 +787,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('suppliers.dirty.close'),
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: t('suppliers.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }

--- a/web/src/views/Systems.vue
+++ b/web/src/views/Systems.vue
@@ -864,9 +864,9 @@ async function openItemFromRoute(id) {
 async function switchDetailTab(key) {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('systems.dirty.switch_tab'),
+      message: t('common.dirty.switch_tab'),
       variant: 'danger',
-      confirmLabel: t('systems.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }
@@ -877,9 +877,9 @@ async function switchDetailTab(key) {
 async function closeDetail() {
   if (editingSection.value && isDirty()) {
     const ok = await confirmDialog({
-      message: t('systems.dirty.close'),
+      message: t('common.dirty.close'),
       variant: 'danger',
-      confirmLabel: t('systems.dirty.discard'),
+      confirmLabel: t('common.dirty.discard'),
     })
     if (!ok) return
   }


### PR DESCRIPTION
Removes six duplicate copies of the same three sentences from the translation files, so a translator sees each one once instead of seven times.

## What this is

Every register screen (risks, assets, suppliers, systems, incidents, legal requirements) warns you before you navigate away from an unsaved edit. When those screens were made translatable, each one got its own private copy of the warning. The workflow screens, done afterwards, put the same three sentences in the shared file instead — which is where they belong.

The result is seven identical copies of "You have unsaved changes. Discard and close?" in the translation files. This deletes six of them and points the six screens at the shared one.

## What changes for a user

**Nothing.** Every copy being deleted was character-for-character identical to the shared version, so all 24 places affected show exactly the same sentence as before.

## Why it matters now

A translator is about to start work against a frozen set of these entries. Seven copies of one sentence means seven chances to translate it seven slightly different ways, and the user then sees the wording change as they move between screens. It also means seven times the work for no benefit. Fixing it after translation starts would mean throwing away work already done, which is why it goes in before rather than after.

## Risk

**Very low.** The change is a mechanical rename of which entry each screen reads from, with no wording change on either side. Three things confirm it:

- The deleted entries were verified identical to the shared one before deletion, not assumed to be.
- All 571 translation lookups across the six screens were resolved against the real translation file — none is broken or missing.
- Nothing else in the codebase referenced the deleted entries.

One copy is deliberately kept: the audit screen's version says "unsaved **report** changes", which is genuinely different wording rather than a duplicate.

## Scope

- 18 entries deleted from six translation files.
- 24 lookups repointed across six screens.
- No new entries, no wording changes, no database or API changes.

## Checks

- Front-end suite: 152/152, including the two automated text scanners and the translation-file consistency check.
- Production build: clean.
- Both text scanners report the same numbers as before — this kind of change is invisible to them, and neither tracking file moves.

## Relationship to the other open work

Independent of #272 (the document screens). The two touch no file in common, so they can merge in either order with no rebase.
