### PR TITLE
docs(i18n): fix an add-a-locale step that defeated the new coverage gate (#212)

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -206,7 +206,7 @@ and the web unit-test job, plus two release gates on the Go side:
 | Release gate (`internal/isms/i18n/release_gate_test.go`) | Fails on |
 |---|---|
 | `TestSecondLocaleRequiresExtraction` | a second locale enabled while the raw-text baseline is over its threshold — the app is not extracted |
-| `TestEnabledLocalesAreTranslated` | an enabled locale translating under 90% of the frozen keyset — the bundle is not finished |
+| `TestEnabledLocalesAreTranslated` | an enabled locale whose bundle covers under 90% of the frozen keyset — the bundle is not finished |
 
 Both gates are inert while `en` is the only enabled locale, which is the point:
 extraction and translation can land incrementally at no user-visible cost, and

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -93,9 +93,31 @@ is a lost-update race against a concurrent rename.
    national adoption of ISO/IEC 27001 or 9001, and record your table there —
    this is a step, not a suggestion: two of the three Indonesian terms it
    catches were wrong on the first pass.
-3. **Copy the message bundle** — `cp -r web/src/locales/en web/src/locales/<tag>`
-   and translate the values. Keep the filenames and the keys; change only the
-   right-hand side.
+3. **Translate one area file at a time, adding each file when it is done.**
+   Start from an empty `web/src/locales/<tag>/` and copy `en/<area>.json` as you
+   pick that area up. Keep the filenames and the keys; change only the
+   right-hand side. `common.json` first — every other area draws on it.
+
+   **Do not copy the whole `en/` directory up front and edit it in place.** It
+   is the obvious move and it defeats both of the things that are supposed to
+   watch your progress, because both count keys that are *present*, not keys
+   that are *translated*:
+
+   - the keyset test's missing-key warning is what reports how far along a
+     bundle is — `[keyset] <tag> is missing N of M keys (rendered in en): …`,
+     with the first ten named. A copied bundle is missing none, so it reports
+     nothing, from the first commit to the last.
+   - `TestEnabledLocalesAreTranslated` (step 6) measures the same way, so a
+     copied bundle reads as **100% translated** while every value is still
+     English — which is precisely the release it exists to block. This was
+     verified rather than reasoned about: an enabled locale whose bundle was a
+     byte-for-byte copy of `en` passed the gate at 100%.
+
+   A partial directory is a normal, supported state: missing keys render in
+   English through `fallbackLocale`, and `id-ID` ships 2 of the 25 area files
+   with the build green. Adding files as you finish them is what makes the
+   remaining count mean something.
+
 4. **Register the loader** — add one line to the `loaders` map in
    `web/src/i18n.js`:
    ```js

--- a/internal/isms/i18n/release_gate_test.go
+++ b/internal/isms/i18n/release_gate_test.go
@@ -101,8 +101,14 @@ const keysetSnapshot = "../../../web/test/keyset.snapshot.json"
 // area, and the area key is the filename — see web/src/locales/en/index.js.
 const localesDir = "../../../web/src/locales"
 
-// translationGateThreshold is the share of the frozen keyset an enabled locale
-// must actually translate, in percent.
+// translationGateThreshold is the share of the frozen keyset an enabled locale's
+// bundle must *cover* — that is, contain a key for — in percent.
+//
+// Coverage, not translatedness: what this number bounds is how much of the app
+// a bundle has entries for, and the paragraph below on `cp -r en` is why the
+// distinction has to be stated rather than left as a synonym. The procedure in
+// docs/i18n.md is what makes coverage stand in for translation, by having a key
+// arrive only when someone has translated it.
 //
 // This gate exists because the extraction gate above was necessary and not
 // sufficient, and the gap was invisible for exactly as long as extraction was
@@ -116,11 +122,11 @@ const localesDir = "../../../web/src/locales"
 // because it measures the *app*, not the *bundle*. This one measures the
 // bundle.
 //
-// It measures which keys are *present* in the bundle, not which are actually
-// translated, and that limit is worth stating because the obvious way to start a
-// locale walks straight into it: `cp -r en <tag>` yields a bundle that is
-// missing nothing, so this gate reads 100% while every value is English — the
-// exact release it exists to block, waved through. Verified, not assumed.
+// The limit that follows from measuring presence is worth spelling out, because
+// the obvious way to start a locale walks straight into it: `cp -r en <tag>`
+// yields a bundle that is missing nothing, so this gate reads 100% while every
+// value is English — the exact release it exists to block, waved through.
+// Verified, not assumed.
 //
 // Detecting that here would need a value comparison, and values legitimately
 // agree with `en` sometimes: 17 of id-ID's 244 keys do, all loanwords
@@ -198,7 +204,7 @@ func bundleKeys(t *testing.T, tag string) []string {
 // TestEnabledLocalesAreTranslated is the second half of the release gate.
 //
 // TestSecondLocaleRequiresExtraction asks whether the *app* is extracted.
-// This asks whether the *bundle* is translated. Both were once satisfied by the
+// This asks whether the *bundle* covers it. Both were once satisfied by the
 // same fact — nothing was extracted, so nothing could be translated — and they
 // came apart the moment extraction finished. A reader meets the worse of the
 // two, so both are gated.
@@ -242,8 +248,11 @@ func TestEnabledLocalesAreTranslated(t *testing.T) {
 		percent := covered * 100 / len(frozen)
 		if percent < translationGateThreshold {
 			t.Errorf(
-				"locale %q (%s) is enabled but translates %d of %d keys (%d%%), under the %d%% "+
+				"locale %q (%s) is enabled but covers %d of %d keys (%d%%), under the %d%% "+
 					"threshold.\n\n"+
+					"Coverage counts keys the bundle has, so this is the generous reading; a key "+
+					"that is present but still English counts here and the procedure in "+
+					"docs/i18n.md is what keeps that from happening at scale.\n"+
 					"Missing keys render in English, so enabling it now offers a language the app "+
 					"largely cannot speak — which is worse for the contributor who translated the "+
 					"bundle than for anyone else.\n"+

--- a/internal/isms/i18n/release_gate_test.go
+++ b/internal/isms/i18n/release_gate_test.go
@@ -116,6 +116,20 @@ const localesDir = "../../../web/src/locales"
 // because it measures the *app*, not the *bundle*. This one measures the
 // bundle.
 //
+// It measures which keys are *present* in the bundle, not which are actually
+// translated, and that limit is worth stating because the obvious way to start a
+// locale walks straight into it: `cp -r en <tag>` yields a bundle that is
+// missing nothing, so this gate reads 100% while every value is English — the
+// exact release it exists to block, waved through. Verified, not assumed.
+//
+// Detecting that here would need a value comparison, and values legitimately
+// agree with `en` sometimes: 17 of id-ID's 244 keys do, all loanwords
+// ("Audit", "Program", "Passkey"). So the control is the procedure instead —
+// docs/i18n.md step 3 says to add area files as they are finished and why — and
+// a reviewer seeing 25 new files of English in one commit. If a copied bundle
+// ever reaches a release, the fix is a check that fails on a *large* share of
+// identical values, not on any.
+//
 // 90 rather than 100 because `localeKeyset.test.js` deliberately lets a
 // translation lag: a missing key renders in English through fallbackLocale, and
 // a bundle a few keys behind must not block an unrelated PR. So a small,

--- a/web/src/locales/README.md
+++ b/web/src/locales/README.md
@@ -22,8 +22,12 @@ PR per view and a single `en.json` would make them all collide on one file.
 
 Adding an **area**: one JSON file plus one import line in `index.js`.
 Adding a **locale**: register the tag server-side in
-`internal/isms/i18n/locale.go`, copy `en/`, translate the values, register the
-loader — see [`docs/i18n.md`](../../../docs/i18n.md).
+`internal/isms/i18n/locale.go`, settle the ISO vocabulary (see "ISO terminology"
+below), then add area files one at a time as you finish them — starting from an
+empty directory, **not** from a copy of `en/`, which reports itself as fully
+translated while it is still English. Then register the loader. Full procedure —
+seven steps, ending at the release gates and a layout pass — and the reasoning:
+[`docs/i18n.md`](../../../docs/i18n.md).
 
 ## The keyset is frozen
 


### PR DESCRIPTION
**Our instructions for adding a language told contributors to do the one thing that switches off the safety check we just added.**

The last i18n change added a release gate: a language cannot be switched on until its translation file covers 90% of the app's text. The gate works by counting how many of the app's text entries the translation file *contains*.

Our documented first step was "copy the English folder, then translate it in place". A copied folder already contains every entry — so the gate reads it as **100% translated while every word in it is still English**. That is exactly the release the gate was added to prevent, and following our own instructions was enough to get there.

It also removes the only progress signal a translator has. The build prints a line like *"pt-BR is missing 2204 of 2448 entries"*, and that number going down is how anyone can see how far a translation has got. Copy the folder and it is missing nothing, so the line never appears — from the first day to the last.

**This is verified, not theoretical.** A Portuguese translation file that was a byte-for-byte copy of the English one, switched on, passed the gate at 100% and produced no warning.

## The fix

The procedure now says to start from an empty folder and add one area file at a time as each is finished, beginning with the shared vocabulary. A partly-finished folder is a perfectly normal state — anything not yet translated shows in English — so adding files as they are done is what makes the remaining count mean something. Indonesian already works this way in the repository: 2 of the 25 files, and the build is green.

Three places changed: the step-by-step procedure, the one-line summary in the translators' README that repeated it, and a comment on the gate itself recording that it counts entries present rather than entries translated.

**Risk: none at runtime.** Documentation plus one code comment. No behaviour, schema or API change, and no test logic changed.

## Why the gate itself was left alone

Catching a copied file automatically would mean comparing translated values against English ones — but some legitimately match. In the Indonesian translation, 17 of its 244 entries are identical to English, all loanwords ("Audit", "Program", "Passkey"). So a useful check would have to fail on a *large share* of identical values rather than on any, which is a change to a release gate and not a documentation fix. The gate's comment now records that limit and what such a check would need to look like, so the next person does not have to rediscover it.

Worth noting for the same reason: Indonesian's 10% coverage figure is not inflated by that overlap — 17 of 244 is 7%.

## Context

This is the **second** contributor document in this series to end up one step behind the mechanism it describes; the previous review found the translators' README teaching a duplication pattern that the following change deleted. The generalisable lesson, and the reason this was worth its own change rather than a footnote: **a document that describes enforcement has to be re-read whenever the enforcement changes.**

Found while checking whether an outside contributor could actually start translating. They can — this was the last thing in the way, along with registering the language itself, which needs the contributor's answer on Brazilian vs European Portuguese first.

## Verification

`gofmt -l`, `CGO_ENABLED=0 go build ./...`, `CGO_ENABLED=0 go test ./internal/... -count=1`, and `npm test` in `web/` (153 tests) all pass.