### PR TITLE
Hide the Language setting entirely when there is only one language (#281)

### DIFF
--- a/web/src/components/LocalePicker.vue
+++ b/web/src/components/LocalePicker.vue
@@ -1,33 +1,54 @@
 <template>
   <!-- Hidden entirely when the deployment ships a single locale: a picker with
-       one option is noise, and it would suggest a choice that does not exist. -->
-  <select v-if="options.length > 1" :value="selected" @change="onChange"
-    :disabled="saving"
-    :aria-label="$t('common.locale.label')"
-    :class="compact
-      ? 'bg-transparent border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 hover:text-slate-200 focus:outline-none transition-colors disabled:opacity-50'
-      : 'w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50'">
-    <!-- Only offered when signed in: with no account to store it against,
-         "follow the org default" is not a state the user can be in. -->
-    <option v-if="persist" value="">{{ $t('common.locale.org_default') }}</option>
-    <option v-for="l in options" :key="l.tag" :value="l.tag">{{ l.name }}</option>
-  </select>
+       one option is noise, and it would suggest a choice that does not exist.
+       The wrapper is inside that condition, and so is the label, because only
+       this component knows whether it will render. A caller drawing its own
+       label had no way to find out, and left it stranded above nothing
+       (#281). Anything a call site wants beside the picker belongs in the slot
+       for the same reason.
+
+       Attribute fallthrough still works: when hidden the root is this comment
+       plus a `v-if` placeholder, which Vue treats as a single comment root and
+       exempts from the extraneous-attrs warning, so a caller's classes land on
+       the wrapper when there is a wrapper and are dropped when there is not. -->
+  <div v-if="options.length > 1">
+    <label v-if="label" :for="selectId" class="block text-xs text-slate-500 mb-1">{{ label }}</label>
+    <select :id="selectId" :value="selected" @change="onChange"
+      :disabled="saving"
+      :aria-label="label ? undefined : $t('common.locale.label')"
+      :class="compact
+        ? 'bg-transparent border border-slate-800 rounded-lg px-2 py-1 text-xs text-slate-400 hover:text-slate-200 focus:outline-none transition-colors disabled:opacity-50'
+        : 'w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500 disabled:opacity-50'">
+      <!-- Only offered when signed in: with no account to store it against,
+           "follow the org default" is not a state the user can be in. -->
+      <option v-if="persist" value="">{{ $t('common.locale.org_default') }}</option>
+      <option v-for="l in options" :key="l.tag" :value="l.tag">{{ l.name }}</option>
+    </select>
+    <slot />
+  </div>
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
-import { useLocale } from '../composables/useLocale'
+import { computed, ref, useId } from 'vue'
+import { useLocale } from '../composables/useLocale.js'
 import { renderApiError } from '../composables/useApiError.js'
 
 const props = defineProps({
   // false on login / landing, where there is no session to save against.
   persist: { type: Boolean, default: true },
   compact: { type: Boolean, default: false },
+  // The visible label. Absent on the compact pickers, which stand alone and
+  // fall back to the aria-label. Passed in rather than decided here so a call
+  // site can name the setting in its own terms.
+  label: { type: String, default: '' },
 })
 const emit = defineEmits(['error'])
 
 const { options, preference, active, chooseLocale } = useLocale()
 const saving = ref(false)
+// Per instance, not a constant: the same picker can be mounted more than once
+// in a session, and a duplicated id would point every label at the first one.
+const selectId = useId()
 
 // Signed in, the picker reflects the stored preference — including the empty
 // value that means "org default". Signed out there is no preference, so it

--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -199,9 +199,7 @@
 
       <!-- Pre-login language choice, so a user can read the app before they have
            an account. Local only — nothing to persist against yet. -->
-      <div class="mt-8 flex justify-center">
-        <LocalePicker :persist="false" compact />
-      </div>
+      <LocalePicker :persist="false" compact class="mt-8 flex justify-center" />
     </div>
     <div class="fixed bottom-4 left-0 right-0 text-center text-xs text-slate-600">
       <a v-if="privacyUrl" :href="privacyUrl" target="_blank" class="hover:text-slate-400 transition-colors">{{ $t('common.footer.privacy') }}</a>

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -22,11 +22,14 @@
           </div>
           <div v-if="nameMsg" class="text-xs mt-1" :class="nameError ? 'text-red-400' : 'text-emerald-400'">{{ nameMsg }}</div>
         </div>
-        <div>
-          <label class="block text-xs text-slate-500 mb-1">{{ $t('common.locale.label') }}</label>
-          <LocalePicker @error="localeMsg = $event" />
+        <!-- No wrapper of our own: the picker hides itself on a single-locale
+             deployment, and a wrapper here would survive it as an empty row in
+             the surrounding space-y-4. The label and the error go through the
+             component for the same reason — an error can only happen when the
+             picker is on screen. -->
+        <LocalePicker :label="$t('common.locale.label')" @error="localeMsg = $event">
           <div v-if="localeMsg" class="text-xs mt-1 text-red-400">{{ localeMsg }}</div>
-        </div>
+        </LocalePicker>
         <div>
           <label class="block text-xs text-slate-500 mb-1">{{ t('settings.profile.role') }}</label>
           <span class="inline-block px-2 py-0.5 text-xs font-medium rounded-full"

--- a/web/test/localePicker.test.js
+++ b/web/test/localePicker.test.js
@@ -1,0 +1,98 @@
+// The picker's visibility contract: on a single-locale deployment it must put
+// nothing on the page — not the select, and not the label or the error row that
+// used to be drawn by its callers.
+//
+// This is issue #281. Settings.vue rendered `<label>Language</label>` outside the
+// component and unconditionally, because `v-if="options.length > 1"` lived on
+// the component's own root and no caller could see it. The label was left above
+// nothing, and the wrapper it sat in kept its slot in a `space-y-4` column. The
+// fix moved both inside that one condition; these tests are what stops a caller
+// from drawing its own chrome again.
+//
+// The condition is reachable even though the product now ships two locales:
+// `renderableOptions()` intersects the server's advertised set with the loaders
+// in this bundle, so a server ahead of the client narrows it to one.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+// FIRST, before any import that reaches vue: the helper installs the DOM that
+// vue/runtime-dom captures at evaluation time. See its header.
+import { compileSfc, renderSfc, stripComments } from './support/renderSfc.js'
+import { applyConfigLocales } from '../src/composables/useLocale.js'
+import { setSupportedLocales } from '../src/i18n.js'
+
+const SFC = new URL('../src/components/LocalePicker.vue', import.meta.url).pathname
+
+const EN = { tag: 'en', name: 'English' }
+const ID = { tag: 'id-ID', name: 'Bahasa Indonesia' }
+
+// `options` is a module-level ref shared by every picker, seeded from /config —
+// so the fixture is a config payload, as in useLocale.test.js.
+async function withLocales(locales) {
+  await applyConfigLocales({ locales, default_locale: 'en' })
+}
+
+test.after(() => setSupportedLocales([]))
+
+const LocalePicker = await compileSfc(SFC)
+
+test('one locale renders nothing at all, label and slot included', async () => {
+  await withLocales([EN])
+  const html = await renderSfc(
+    LocalePicker,
+    { persist: false, label: 'Language' },
+    { default: () => 'save failed' },
+  )
+  // Comments stripped: Vue's SSR anchors and the component's own template
+  // comment both survive into the output, so emptiness has to be asked without
+  // them. The assertion that matters is that no element and no text made it
+  // through — the bug was text ("Language") with nothing to label.
+  assert.equal(stripComments(html), '')
+  assert.ok(!html.includes('Language'), `label leaked into a hidden picker: ${html}`)
+  assert.ok(!html.includes('save failed'), `slot leaked into a hidden picker: ${html}`)
+})
+
+test('two locales render the label, the select and the slot together', async () => {
+  await withLocales([EN, ID])
+  const html = await renderSfc(
+    LocalePicker,
+    { persist: false, label: 'Language' },
+    { default: () => '<span>save failed</span>' },
+  )
+  assert.match(html, /<select/)
+  assert.match(html, /Language/)
+  assert.match(html, /save failed/)
+  assert.match(html, /Bahasa Indonesia/)
+})
+
+test('the label points at the select it labels', async () => {
+  await withLocales([EN, ID])
+  const html = await renderSfc(LocalePicker, { persist: false, label: 'Language' })
+  const forAttr = html.match(/<label[^>]*\bfor="([^"]+)"/)
+  assert.ok(forAttr, `no labelled label in: ${html}`)
+  assert.match(html, new RegExp(`<select[^>]*\\bid="${forAttr[1]}"`))
+  // With a visible label the aria-label would be a second, redundant name.
+  assert.ok(!/<select[^>]*aria-label/.test(html), `select kept its aria-label: ${html}`)
+})
+
+test('without a label the select keeps an accessible name', async () => {
+  await withLocales([EN, ID])
+  const html = await renderSfc(LocalePicker, { persist: false, compact: true })
+  assert.ok(!html.includes('<label'), `unlabelled picker drew a label: ${html}`)
+  assert.match(html, /<select[^>]*aria-label="[^"]+"/)
+})
+
+// Landing.vue passes `class="shrink-0"` and Login.vue passes its layout classes
+// straight to the component, so fallthrough has to survive the wrapper moving
+// inside the `v-if`. It does, and this is the check: when hidden the root is a
+// comment, which Vue treats as a single root and does not warn about; when
+// visible the classes land on the wrapper.
+test('a caller class lands on the wrapper when visible and vanishes when not', async () => {
+  await withLocales([EN, ID])
+  const shown = await renderSfc(LocalePicker, { persist: false, compact: true, class: 'shrink-0' })
+  // Not anchored: the component's own template comment precedes the wrapper.
+  assert.match(shown, /<div class="shrink-0"><\/?/)
+
+  await withLocales([EN])
+  const hidden = await renderSfc(LocalePicker, { persist: false, compact: true, class: 'shrink-0' })
+  assert.equal(stripComments(hidden), '')
+})

--- a/web/test/support/renderSfc.js
+++ b/web/test/support/renderSfc.js
@@ -1,0 +1,97 @@
+// Compile-and-render for single-file components, so a test can assert on what a
+// component actually puts on the page.
+//
+// Nothing else in test/ mounts an SFC: the suite runs under bare `node --test`,
+// and the tests that care about `.vue` files scan them as source text
+// (errorRender.test.js). That convention cannot catch a rendering regression —
+// the same objection a review raised against the hand transplant in
+// jurisdictionPicker.test.js — so this compiles the real file instead.
+//
+// Two deliberate constraints, both from review of #281:
+//
+//  1. No new dependency. `vue` itself depends on @vue/compiler-sfc and exposes
+//     it as the public subpath `vue/compiler-sfc`, so the compiler arrives with
+//     the framework at exactly the framework's version — nothing to declare and
+//     nothing to keep in step. Importing the bare package would have meant
+//     relying on a hoisted transitive of @vitejs/plugin-vue.
+//  2. No SSR. The app has no server-rendered path, so a component verified
+//     through `renderToString` would be verified through a code path that never
+//     runs in production — different compiler output, different runtime. This
+//     mounts into jsdom with `createApp().mount()`, which is what main.js does.
+//
+// `node --test` discovers everything under test/, so this file is also executed
+// as a test file with no tests in it — which passes, and is why nothing here may
+// throw at module scope.
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { parse, compileScript } from 'vue/compiler-sfc'
+import { JSDOM } from 'jsdom'
+
+// vue/runtime-dom captures `document` ONCE, at module evaluation, into the node
+// operations it hands the renderer. A DOM installed later leaves it holding null
+// and every mount dies on `createTextNode` of null — so this runs as an import
+// side effect, and vue is imported dynamically further down.
+//
+// The consequence for callers: **import this helper before anything that pulls
+// in vue**, `src/i18n.js` included. ESM evaluates static imports in the order
+// they are written, so the helper's import line has to come first in the test
+// file. Nothing enforces that, which is why the failure mode is spelled out
+// here: a null-document TypeError from inside the renderer means an import got
+// reordered.
+const dom = new JSDOM('<!doctype html><html><body></body></html>')
+for (const key of ['window', 'document', 'Node', 'Element', 'HTMLElement', 'SVGElement', 'Text', 'Comment', 'DocumentFragment', 'CustomEvent']) {
+  globalThis[key] = key === 'window' ? dom.window : dom.window[key]
+}
+
+// A `data:` module resolves nothing on its own: relative specifiers have no base
+// to resolve against, and bare ones ("vue") are rejected outright because the
+// URL scheme is not hierarchical. So every specifier is rewritten to an absolute
+// URL first — relative ones against the SFC's own path, bare ones through Node's
+// resolver, which finds web/node_modules from here.
+//
+// The alternative is writing the compiled file next to its source so Node
+// resolves it normally, but `node --test` runs each file in its own process and
+// a process that dies mid-run would leave that file behind under src/.
+function absolutizeImports(code, sfcPath) {
+  const base = pathToFileURL(sfcPath)
+  return code.replaceAll(/(\bfrom\s*|\bimport\s*\(\s*)(['"])([^'"]+)\2/g, (_m, head, q, spec) => {
+    const href = spec.startsWith('.') ? new URL(spec, base).href : import.meta.resolve(spec)
+    return `${head}${q}${href}${q}`
+  })
+}
+
+// Returns the component's default export, compiled the way Vite compiles it for
+// the browser.
+export async function compileSfc(sfcPath) {
+  const source = readFileSync(sfcPath, 'utf8')
+  const { descriptor, errors } = parse(source, { filename: sfcPath })
+  if (errors.length) throw new Error(`parsing ${sfcPath}: ${errors[0].message}`)
+  const { content } = compileScript(descriptor, { id: sfcPath, inlineTemplate: true })
+  const mod = `data:text/javascript,${encodeURIComponent(absolutizeImports(content, sfcPath))}`
+  return (await import(mod)).default
+}
+
+// Mounts the component and returns the host element's HTML. Async only because
+// vue is imported dynamically, after the DOM above is in place.
+export async function renderSfc(component, props = {}, slots = {}) {
+  const { createApp, h } = await import('vue')
+  const { i18n } = await import('../../src/i18n.js')
+  // Mounted through a wrapper: `createApp` takes props but not slots, and a slot
+  // is part of what this component's contract covers.
+  const app = createApp({ render: () => h(component, props, slots) })
+  app.use(i18n)
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  app.mount(host)
+  const html = host.innerHTML
+  app.unmount()
+  host.remove()
+  return html
+}
+
+// A `v-if` that renders nothing leaves a comment placeholder behind, and a
+// component's own template comments survive too, so "rendered nothing" has to be
+// asked without them.
+export function stripComments(html) {
+  return html.replaceAll(/<!--[\s\S]*?-->/g, '').trim()
+}


### PR DESCRIPTION
Fixes #281.

## What users see

On **Settings → Profile**, a **Language** heading appeared with nothing under it and an extra gap before **Role**. The language picker deliberately hides itself when a deployment offers only one language, but the heading was written into the Settings page separately, so it stayed behind on its own. Now the whole setting disappears together — the section reads Email → Name → Role, as though it were never there — and when a second language is available the heading and the picker appear as a pair.

The sign-in page had a milder version of the same thing: an invisible block of empty space where the picker would have been. That is gone too.

## Why it happened, in one line

Two places had to agree about whether the setting was visible, and only one of them could actually know. The picker decided for itself; the page around it guessed and drew the heading regardless. The decision now lives in one place, so there is nothing left to disagree.

## Scope and risk

Small and contained: the language picker component, plus the two pages that surround it. No API, database, or server changes, and **no new dependencies**. Nothing about *which* languages are offered changes — only whether the setting is drawn at all.

Note on when this is visible today: the product currently ships two languages, so the picker renders and the reported empty heading is not on screen right now. The underlying flaw is still live — it returns for any single-language deployment, and during a rolling deploy where the server offers a language the browser's copy of the app cannot yet display. So this is a fix worth having, not an urgent one.

## Verification

- 188 automated web tests pass. Five are new and cover this behaviour directly; deliberately putting the bug back makes two of them fail, so they will catch a repeat.
- Checked by hand in a browser against a local server, on the two-language configuration that ships today: the Settings rows are evenly spaced with the heading correctly attached to the control, the footer picker on the marketing page sits level with the text beside it, the sign-in picker is centred where it should be, and a deliberately failed save still shows its error message in the right place with the picker snapping back to the previous language.

## One thing reviewers may notice

The test suite could not previously render a Vue component at all — tests that looked at component files read them as plain text, which cannot catch a visual regression like this one. This adds a small shared helper that renders a component for real, through the same start-up path the live app uses, so the fix is verified by what the component actually produces rather than by what its source looks like.

It needs nothing new installed: the compiler it uses ships inside the Vue package as a published entry point, and the browser-simulation library was already in use. One incidental correction came with it — a file extension missing from an import, which the app's build tool tolerated and plain Node did not.