### PR TITLE
Make record references like ASSET-3 resolve to the right record everywhere (#201)

### DIFF
--- a/internal/isms/api/api_asset_reviews.go
+++ b/internal/isms/api/api_asset_reviews.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"isms.sh/internal/isms/db"
@@ -26,9 +26,12 @@ func (s *Server) handleCreateAssetReview(c echo.Context) error {
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
+	// Accept the numeric id OR the display identifier, resolved by lookup (#201).
+	id, err := s.resolveAssetID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("asset")
+	} else if err != nil {
+		return errNotFound("asset")
 	}
 
 	// Verify asset exists in this org (cross-org safety).
@@ -69,9 +72,12 @@ func (s *Server) handleCreateAssetReview(c echo.Context) error {
 
 func (s *Server) handleListAssetReviews(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
+	// Accept the numeric id OR the display identifier, resolved by lookup (#201).
+	id, err := s.resolveAssetID(c.Request().Context(), orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("asset")
+	} else if err != nil {
+		return errNotFound("asset")
 	}
 
 	reviews, err := s.db.ListAssetReviews(c.Request().Context(), orgID, id)

--- a/internal/isms/api/api_audit.go
+++ b/internal/isms/api/api_audit.go
@@ -641,7 +641,11 @@ func (s *Server) handlePaginatedAuditFindings(c echo.Context) error {
 
 func (s *Server) handleGetAuditFinding(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	// Findings are the one register whose display id IS its primary key —
+	// db.SoftDeleteAuditFinding mints "FIND-<id>" from the row id, and
+	// audit_findings has no identifier column to look up. Stripping is correct
+	// here, and only here (#201).
+	id, err := strconv.ParseInt(stripPrefix(c.Param("id"), "FIND-"), 10, 64)
 	if err != nil {
 		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
@@ -726,7 +730,7 @@ func (s *Server) handleUpdateAuditFinding(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := strconv.ParseInt(stripPrefix(c.Param("id"), "FIND-"), 10, 64)
 	if err != nil {
 		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
@@ -791,7 +795,7 @@ func (s *Server) handleUpdateAuditFindingStatus(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := strconv.ParseInt(stripPrefix(c.Param("id"), "FIND-"), 10, 64)
 	if err != nil {
 		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}
@@ -833,7 +837,7 @@ func (s *Server) handleDeleteAuditFinding(c echo.Context) error {
 		return err
 	}
 	orgID := getOrgID(c)
-	id, err := parseID(c.Param("id"))
+	id, err := strconv.ParseInt(stripPrefix(c.Param("id"), "FIND-"), 10, 64)
 	if err != nil {
 		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("audit_finding"))
 	}

--- a/internal/isms/api/api_changelog.go
+++ b/internal/isms/api/api_changelog.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -27,9 +28,20 @@ func (s *Server) handleListChangelog(c echo.Context) error {
 func (s *Server) handleEntityChangelog(c echo.Context) error {
 	orgID := getOrgID(c)
 	entityType := c.Param("type")
-	entityID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	// Accept the numeric id OR the entity's display identifier (#201); which
+	// forms are valid depends on the :type, so dispatch on it.
+	entityID, hasIdentifier, err := s.resolveEntityID(c.Request().Context(), orgID, entityType, c.Param("id"))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid entity id")
+		if !hasIdentifier {
+			// No display identifier for this type, so the param could only ever
+			// have been numeric — and entityType may have no entity_inline key
+			// to name in the message.
+			return apiError(http.StatusBadRequest, CodeInvalidID)
+		}
+		if errors.Is(err, errInvalidID) {
+			return errInvalidEntityID(entityType)
+		}
+		return errNotFound(entityType)
 	}
 
 	entries, err := s.db.ListEntityChangelog(c.Request().Context(), orgID, entityType, entityID)

--- a/internal/isms/api/api_collab.go
+++ b/internal/isms/api/api_collab.go
@@ -2718,10 +2718,15 @@ func (s *Server) handleUpdateChange(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("change_request"))
+	// Accept the numeric id OR the CR-12 identifier, resolved by lookup like
+	// handleGetChange next door (#201). resolveChangeID returns int64 → cast.
+	id64, err := s.resolveChangeID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("change_request")
+	} else if err != nil {
+		return errNotFound("change_request")
 	}
+	id := int(id64)
 
 	old, err := s.db.GetChangeRequest(ctx, orgID, id)
 	if err != nil {
@@ -2846,10 +2851,15 @@ func (s *Server) handleUpdateChangeStatus(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("change_request"))
+	// Accept the numeric id OR the CR-12 identifier, resolved by lookup like
+	// handleGetChange next door (#201). resolveChangeID returns int64 → cast.
+	id64, err := s.resolveChangeID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("change_request")
+	} else if err != nil {
+		return errNotFound("change_request")
 	}
+	id := int(id64)
 
 	old, _ := s.db.GetChangeRequest(ctx, orgID, id)
 	oldStatus := ""
@@ -2955,10 +2965,15 @@ func (s *Server) handleDeleteChange(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidEntityID, Entity("change_request"))
+	// Accept the numeric id OR the CR-12 identifier, resolved by lookup like
+	// handleGetChange next door (#201). resolveChangeID returns int64 → cast.
+	id64, err := s.resolveChangeID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("change_request")
+	} else if err != nil {
+		return errNotFound("change_request")
 	}
+	id := int(id64)
 
 	cr, err := s.db.GetChangeRequest(ctx, orgID, id)
 	if err != nil || cr == nil {

--- a/internal/isms/api/api_objectives.go
+++ b/internal/isms/api/api_objectives.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -394,9 +395,13 @@ func (s *Server) handleUpdateObjective(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidID)
+	// Accept the numeric id OR the program-scoped display id (ISMS2026-3),
+	// resolved by lookup like handleGetObjective (#201).
+	id, err := s.resolveObjectiveID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("objective")
+	} else if err != nil {
+		return errNotFound("objective")
 	}
 
 	old, err := s.db.GetObjective(ctx, orgID, id)
@@ -488,9 +493,13 @@ func (s *Server) handleDeleteObjective(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidID)
+	// Accept the numeric id OR the program-scoped display id (ISMS2026-3),
+	// resolved by lookup like handleGetObjective (#201).
+	id, err := s.resolveObjectiveID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("objective")
+	} else if err != nil {
+		return errNotFound("objective")
 	}
 
 	if err := s.db.DeleteObjective(ctx, orgID, id); err != nil {
@@ -519,9 +528,13 @@ func (s *Server) handleArchiveObjective(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidID)
+	// Accept the numeric id OR the program-scoped display id (ISMS2026-3),
+	// resolved by lookup like handleGetObjective (#201).
+	id, err := s.resolveObjectiveID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("objective")
+	} else if err != nil {
+		return errNotFound("objective")
 	}
 
 	before, _ := s.db.GetObjective(ctx, orgID, id)
@@ -560,9 +573,13 @@ func (s *Server) handleUnarchiveObjective(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		return apiError(http.StatusBadRequest, CodeInvalidID)
+	// Accept the numeric id OR the program-scoped display id (ISMS2026-3),
+	// resolved by lookup like handleGetObjective (#201).
+	id, err := s.resolveObjectiveID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
+		return errInvalidEntityID("objective")
+	} else if err != nil {
+		return errNotFound("objective")
 	}
 
 	before, _ := s.db.GetObjective(ctx, orgID, id)
@@ -605,9 +622,13 @@ func (s *Server) handleUnarchiveObjective(c echo.Context) error {
 
 func (s *Server) handleListCheckins(c echo.Context) error {
 	orgID := getOrgID(c)
-	objectiveID, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
+	// Accept the numeric id OR the program-scoped display id (ISMS2026-3),
+	// resolved by lookup like handleGetObjective (#201).
+	objectiveID, err := s.resolveObjectiveID(c.Request().Context(), orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("objective")
+	} else if err != nil {
+		return errNotFound("objective")
 	}
 
 	limit := 50
@@ -636,9 +657,13 @@ func (s *Server) handleCreateCheckin(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	objectiveID, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
+	// Accept the numeric id OR the program-scoped display id (ISMS2026-3),
+	// resolved by lookup like handleGetObjective (#201).
+	objectiveID, err := s.resolveObjectiveID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("objective")
+	} else if err != nil {
+		return errNotFound("objective")
 	}
 
 	var req checkinCreateRequest

--- a/internal/isms/api/api_readings.go
+++ b/internal/isms/api/api_readings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -18,9 +19,11 @@ import (
 func (s *Server) handleListRiskReadings(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	riskID, err := parseID(c.Param("id"))
-	if err != nil {
+	riskID, err := s.resolveRiskID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("risk")
+	} else if err != nil {
+		return errNotFound("risk")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "risk", riskID)
 	if err != nil {
@@ -38,9 +41,11 @@ func (s *Server) handleCreateRiskReading(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	riskID, err := parseID(c.Param("id"))
-	if err != nil {
+	riskID, err := s.resolveRiskID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("risk")
+	} else if err != nil {
+		return errNotFound("risk")
 	}
 
 	var req struct {
@@ -162,9 +167,11 @@ func writeRiskFromReading(ctx context.Context, tx pgx.Tx, s *Server, orgID int, 
 func (s *Server) handleListAssetReadings(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	assetID, err := parseID(c.Param("id"))
-	if err != nil {
+	assetID, err := s.resolveAssetID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("asset")
+	} else if err != nil {
+		return errNotFound("asset")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "asset", assetID)
 	if err != nil {
@@ -182,9 +189,11 @@ func (s *Server) handleCreateAssetReading(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	assetID, err := parseID(c.Param("id"))
-	if err != nil {
+	assetID, err := s.resolveAssetID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("asset")
+	} else if err != nil {
+		return errNotFound("asset")
 	}
 
 	var req struct {
@@ -285,9 +294,11 @@ func writeAssetFromReading(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 func (s *Server) handleListLegalReadings(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	legalID, err := parseID(c.Param("id"))
-	if err != nil {
+	legalID, err := s.resolveLegalID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("legal_requirement")
+	} else if err != nil {
+		return errNotFound("legal_requirement")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "legal_requirement", legalID)
 	if err != nil {
@@ -305,9 +316,11 @@ func (s *Server) handleCreateLegalReading(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	legalID, err := parseID(c.Param("id"))
-	if err != nil {
+	legalID, err := s.resolveLegalID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("legal_requirement")
+	} else if err != nil {
+		return errNotFound("legal_requirement")
 	}
 
 	var req struct {
@@ -389,9 +402,11 @@ func writeLegalFromReading(ctx context.Context, tx pgx.Tx, s *Server, orgID int,
 func (s *Server) handleListSupplierReadings(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	supplierID, err := parseID(c.Param("id"))
-	if err != nil {
+	supplierID, err := s.resolveSupplierID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("supplier")
+	} else if err != nil {
+		return errNotFound("supplier")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "supplier", supplierID)
 	if err != nil {
@@ -409,9 +424,11 @@ func (s *Server) handleCreateSupplierReading(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	supplierID, err := parseID(c.Param("id"))
-	if err != nil {
+	supplierID, err := s.resolveSupplierID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("supplier")
+	} else if err != nil {
+		return errNotFound("supplier")
 	}
 
 	var req struct {
@@ -489,9 +506,11 @@ func writeSupplierFromReading(ctx context.Context, tx pgx.Tx, s *Server, orgID i
 func (s *Server) handleListSystemReadings(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	systemID, err := parseID(c.Param("id"))
-	if err != nil {
+	systemID, err := s.resolveSystemID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("system")
+	} else if err != nil {
+		return errNotFound("system")
 	}
 	readings, err := s.db.ListEntityReadings(ctx, orgID, "system", systemID)
 	if err != nil {
@@ -509,9 +528,11 @@ func (s *Server) handleCreateSystemReading(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	systemID, err := parseID(c.Param("id"))
-	if err != nil {
+	systemID, err := s.resolveSystemID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("system")
+	} else if err != nil {
+		return errNotFound("system")
 	}
 
 	var req struct {

--- a/internal/isms/api/api_references.go
+++ b/internal/isms/api/api_references.go
@@ -279,6 +279,8 @@ func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, viewer db.Ta
 		return entityID
 
 	case "audit":
+		// AUDIT-/FIND- are built from the row id (audits and audit_findings have
+		// no identifier column), so stripping is correct here — see api_audit.go.
 		id, err := strconv.Atoi(stripPrefix(entityID, "AUDIT-"))
 		if err != nil {
 			return entityID
@@ -301,22 +303,26 @@ func (s *Server) resolveEntityTitle(ctx context.Context, orgID int, viewer db.Ta
 		return f.Title
 
 	case "change_request":
-		id, err := strconv.Atoi(stripPrefix(entityID, "CR-"))
+		// CR- identifiers come from the per-org sequence, so the suffix is not
+		// the primary key — stripping it named a different change request's
+		// title on the reference chip (#201, and the warning in db/changes.go).
+		id, err := s.resolveChangeID(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
-		cr, err := s.db.GetChangeRequest(ctx, orgID, id)
+		cr, err := s.db.GetChangeRequest(ctx, orgID, int(id))
 		if err != nil {
 			return entityID
 		}
 		return cr.Title
 
 	case "task":
-		id, err := strconv.Atoi(stripPrefix(entityID, "TASK-"))
+		// As with CR- above: TASK- is a per-org sequence, not the primary key.
+		id, err := s.resolveTaskID(ctx, orgID, entityID)
 		if err != nil {
 			return entityID
 		}
-		t, err := s.db.GetTask(ctx, orgID, int64(id))
+		t, err := s.db.GetTask(ctx, orgID, id)
 		if err != nil {
 			return entityID
 		}

--- a/internal/isms/api/api_supplier_reviews.go
+++ b/internal/isms/api/api_supplier_reviews.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"isms.sh/internal/isms/db"
@@ -27,9 +27,12 @@ func (s *Server) handleCreateSupplierReview(c echo.Context) error {
 	ctx := c.Request().Context()
 	actor := getUserEmail(c)
 
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
+	// Accept the numeric id OR the display identifier, resolved by lookup (#201).
+	id, err := s.resolveSupplierID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("supplier")
+	} else if err != nil {
+		return errNotFound("supplier")
 	}
 
 	// Verify supplier exists in this org (cross-org safety).
@@ -71,9 +74,12 @@ func (s *Server) handleCreateSupplierReview(c echo.Context) error {
 
 func (s *Server) handleListSupplierReviews(c echo.Context) error {
 	orgID := getOrgID(c)
-	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
+	// Accept the numeric id OR the display identifier, resolved by lookup (#201).
+	id, err := s.resolveSupplierID(c.Request().Context(), orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("supplier")
+	} else if err != nil {
+		return errNotFound("supplier")
 	}
 
 	reviews, err := s.db.ListSupplierReviews(c.Request().Context(), orgID, id)

--- a/internal/isms/api/id_resolution_pg_test.go
+++ b/internal/isms/api/id_resolution_pg_test.go
@@ -1,0 +1,333 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"isms.sh/internal/isms/db"
+)
+
+// #201: the defect this file exists for cannot be reproduced inside a single
+// organization. Primary keys come from a per-TABLE `GENERATED ALWAYS AS
+// IDENTITY` column; display identifiers come from a per-(org, entity type)
+// counter in identifier_sequences. In one org the two march in lockstep — and
+// deletes do not rewind the sequence — so the old arithmetic strip ("ASSET-3" →
+// primary key 3) landed on the right row by luck and any single-org test passes
+// against the bug.
+//
+// With two orgs they diverge on the very first row: org A's asset is PK n and
+// "ASSET-1"; org B's asset is PK n+1 and also "ASSET-1", from B's own counter.
+// Acting as org B, "ASSET-1" must reach PK n+1. The old parseID sent it to PK n
+// — a row org B cannot even see — so this is the assertion that tells the fix
+// from the bug.
+//
+// Requires a migrated Postgres; skipped otherwise so `go test ./...` stays green
+// without a database:
+//
+//	ISMS_TEST_DATABASE_URL="postgres://…/isms_db_test?sslmode=disable" go test ./internal/isms/api/...
+func testServer(t *testing.T) *Server {
+	t.Helper()
+	url := os.Getenv("ISMS_TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("ISMS_TEST_DATABASE_URL not set — skipping identifier resolution database test")
+	}
+	d, err := db.New(context.Background(), url)
+	if err != nil {
+		t.Fatalf("connecting to test database: %v", err)
+	}
+	t.Cleanup(d.Close)
+	return &Server{db: d, searchIndex: NewSearchIndex()}
+}
+
+// newTestOrg creates a throwaway organization and returns its id. Everything it
+// creates is removed on cleanup so the suite can run repeatedly.
+func newTestOrg(t *testing.T, s *Server, name string) int {
+	t.Helper()
+	ctx := context.Background()
+	slug := fmt.Sprintf("%s-%d", name, os.Getpid())
+
+	org := &db.Organization{Name: slug, Slug: slug, RepoPath: "/tmp/none"}
+	if err := s.db.CreateOrganization(ctx, org); err != nil {
+		t.Fatalf("creating org %s: %v", name, err)
+	}
+	// Soft delete; the slug/domain unique indexes filter on deleted_at, so the
+	// suite can run repeatedly against the same database.
+	t.Cleanup(func() {
+		_ = s.db.DeleteOrganization(context.Background(), org.ID)
+	})
+	return org.ID
+}
+
+func newTestAsset(t *testing.T, s *Server, orgID int, name string) *db.Asset {
+	t.Helper()
+	a := &db.Asset{Name: name, AssetType: db.AssetTypes[0], Status: db.AssetStatuses[0]}
+	if err := s.db.CreateAsset(context.Background(), orgID, a); err != nil {
+		t.Fatalf("creating asset in org %d: %v", orgID, err)
+	}
+	return a
+}
+
+// ctxFor builds an echo context carrying the org, role and user the handlers read.
+func ctxFor(orgID int, method, param, body string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(method, "/api/v1/assets/"+param, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(param)
+	c.Set("org_id", orgID)
+	c.Set("user_role", "admin")
+	c.Set("user_email", "admin@id-resolution.test")
+	return c, rec
+}
+
+// TestUpdateByIdentifierHitsTheRightRowAcrossOrgs is the regression that matters:
+// under the old arithmetic strip this wrote to another organization's asset (or
+// 404'd), silently and with a 200.
+func TestUpdateByIdentifierHitsTheRightRowAcrossOrgs(t *testing.T) {
+	s := testServer(t)
+	ctx := context.Background()
+
+	orgA := newTestOrg(t, s, "id-res-a")
+	orgB := newTestOrg(t, s, "id-res-b")
+
+	assetA := newTestAsset(t, s, orgA, "org A first asset")
+	assetB := newTestAsset(t, s, orgB, "org B first asset")
+
+	if assetA.Identifier != assetB.Identifier {
+		t.Fatalf("precondition: both orgs' first asset should be %q; got %q and %q",
+			"ASSET-1", assetA.Identifier, assetB.Identifier)
+	}
+	if assetA.ID == assetB.ID {
+		t.Fatalf("precondition: primary keys must differ across orgs; both are %d", assetA.ID)
+	}
+
+	// Act as org B, addressing the asset by the identifier it shares with org A's.
+	c, rec := ctxFor(orgB, http.MethodPut, assetB.Identifier, `{"notes":"written via identifier"}`)
+	if err := s.handleUpdateAsset(c); err != nil {
+		t.Fatalf("handleUpdateAsset(%s) as org B: %v", assetB.Identifier, err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %s", rec.Code, rec.Body.String())
+	}
+
+	var got db.Asset
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if got.ID != assetB.ID {
+		t.Errorf("write landed on asset id %d, want %d — the identifier resolved to the wrong row", got.ID, assetB.ID)
+	}
+
+	after, err := s.db.GetAsset(ctx, orgB, assetB.ID)
+	if err != nil {
+		t.Fatalf("reading org B asset back: %v", err)
+	}
+	if after.Notes != "written via identifier" {
+		t.Errorf("org B asset notes = %q, want the written value", after.Notes)
+	}
+
+	// Org A's asset — the one the arithmetic strip could have reached — must be untouched.
+	untouched, err := s.db.GetAsset(ctx, orgA, assetA.ID)
+	if err != nil {
+		t.Fatalf("reading org A asset back: %v", err)
+	}
+	if untouched.Notes != "" {
+		t.Errorf("org A asset was modified by a write addressed to org B (notes = %q)", untouched.Notes)
+	}
+}
+
+// TestUpdateRejectsMismatchedAndMalformedIdentifiers: the strip accepted any
+// prefix in its list and never checked the identifier belonged to an asset, so
+// PUT /assets/RISK-<n> wrote to the asset whose PRIMARY KEY was n.
+//
+// The suffix used below is deliberately another asset's primary key in the SAME
+// org — that is what makes this discriminating. With a suffix that happens to
+// match no row, the old code 404s by luck and the test passes against the bug.
+func TestUpdateRejectsMismatchedAndMalformedIdentifiers(t *testing.T) {
+	s := testServer(t)
+	ctx := context.Background()
+	orgID := newTestOrg(t, s, "id-res-reject")
+
+	victim := newTestAsset(t, s, orgID, "the row a mismatched prefix would reach")
+	target := newTestAsset(t, s, orgID, "the row being addressed")
+	pk := fmt.Sprint(victim.ID)
+
+	for _, tc := range []struct {
+		param      string
+		wantStatus int
+		why        string
+	}{
+		{"RISK-" + pk, http.StatusNotFound, "a risk identifier must not reach an asset"},
+		{"SUPPLIER-" + pk, http.StatusNotFound, "nor a supplier identifier"},
+		{"FIND-" + pk, http.StatusNotFound, "nor an audit-finding identifier"},
+		{"AST-" + pk, http.StatusNotFound, "nor the prefix retired in #173"},
+		{"garbage", http.StatusBadRequest, "not identifier-shaped at all"},
+	} {
+		t.Run(tc.param, func(t *testing.T) {
+			c, rec := ctxFor(orgID, http.MethodPut, tc.param, `{"notes":"should never land"}`)
+			err := s.handleUpdateAsset(c)
+			if err == nil {
+				t.Fatalf("PUT /assets/%s returned %d — %s", tc.param, rec.Code, tc.why)
+			}
+			he, ok := err.(*echo.HTTPError)
+			if !ok {
+				t.Fatalf("error is %T, want *echo.HTTPError: %v", err, err)
+			}
+			if he.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (%s)", he.Code, tc.wantStatus, tc.why)
+			}
+		})
+	}
+
+	// Neither asset may have been touched: not the one addressed, and above all
+	// not the one whose primary key the stripped suffix pointed at.
+	for _, a := range []*db.Asset{victim, target} {
+		after, err := s.db.GetAsset(ctx, orgID, a.ID)
+		if err != nil {
+			t.Fatalf("reading asset %d back: %v", a.ID, err)
+		}
+		if after.Notes != "" {
+			t.Errorf("asset %d (%s) was written by a request that should have been rejected (notes = %q)",
+				a.ID, a.Identifier, after.Notes)
+		}
+	}
+}
+
+// TestNumericAndIdentifierFormsAgree is the sweep: for every register whose
+// routes this change touched, both addressing forms must reach the same row on
+// both the read and the write handler. That the two forms agreed on GET but not
+// on PUT is precisely how #201 stayed invisible — the UI reads by identifier and
+// writes by numeric id, so nothing in the browser ever exercised the broken half.
+func TestNumericAndIdentifierFormsAgree(t *testing.T) {
+	s := testServer(t)
+	orgID := newTestOrg(t, s, "id-res-agree")
+	ctx := context.Background()
+
+	type entity struct {
+		name    string
+		id      int64
+		ident   string
+		get     func(echo.Context) error
+		update  func(echo.Context) error
+		reread  func(int64) (string, error)
+		updBody string
+	}
+
+	asset := newTestAsset(t, s, orgID, "sweep asset")
+
+	risk := &db.Risk{Title: "sweep risk", RiskType: db.RiskTypes[0], Origin: db.RiskOrigins[0], Status: db.RiskStatuses[0]}
+	if err := s.db.CreateRisk(ctx, orgID, risk); err != nil {
+		t.Fatalf("creating risk: %v", err)
+	}
+	system := &db.System{Name: "sweep system", Classification: db.SystemClassifications[0],
+		Criticality: db.CriticalityLevels[0], Status: db.SystemStatuses[0]}
+	if err := s.db.CreateSystem(ctx, orgID, system); err != nil {
+		t.Fatalf("creating system: %v", err)
+	}
+	supplier := &db.Supplier{Name: "sweep supplier", SupplierType: db.SupplierTypes[0],
+		Criticality: db.CriticalityLevels[0], Status: db.SupplierStatuses[0]}
+	if err := s.db.CreateSupplier(ctx, orgID, supplier); err != nil {
+		t.Fatalf("creating supplier: %v", err)
+	}
+
+	entities := []entity{
+		{
+			name: "asset", id: asset.ID, ident: asset.Identifier,
+			get: s.handleGetAsset, update: s.handleUpdateAsset,
+			updBody: `{"notes":"%s"}`,
+			reread: func(id int64) (string, error) {
+				a, err := s.db.GetAsset(ctx, orgID, id)
+				if err != nil {
+					return "", err
+				}
+				return a.Notes, nil
+			},
+		},
+		{
+			name: "risk", id: risk.ID, ident: risk.Identifier,
+			get: s.handleGetRisk, update: s.handleUpdateRisk,
+			updBody: `{"description":"%s"}`,
+			reread: func(id int64) (string, error) {
+				r, err := s.db.GetRisk(ctx, orgID, id)
+				if err != nil {
+					return "", err
+				}
+				return r.Description, nil
+			},
+		},
+		{
+			name: "system", id: system.ID, ident: system.Identifier,
+			get: s.handleGetSystem, update: s.handleUpdateSystem,
+			updBody: `{"description":"%s"}`,
+			reread: func(id int64) (string, error) {
+				sys, err := s.db.GetSystem(ctx, orgID, id)
+				if err != nil {
+					return "", err
+				}
+				return sys.Description, nil
+			},
+		},
+		{
+			name: "supplier", id: supplier.ID, ident: supplier.Identifier,
+			get: s.handleGetSupplier, update: s.handleUpdateSupplier,
+			updBody: `{"notes":"%s"}`,
+			reread: func(id int64) (string, error) {
+				sup, err := s.db.GetSupplier(ctx, orgID, id)
+				if err != nil {
+					return "", err
+				}
+				return sup.Notes, nil
+			},
+		},
+	}
+
+	for _, ent := range entities {
+		t.Run(ent.name, func(t *testing.T) {
+			for _, form := range []struct{ kind, param string }{
+				{"numeric", fmt.Sprint(ent.id)},
+				{"identifier", ent.ident},
+			} {
+				c, rec := ctxFor(orgID, http.MethodGet, form.param, "")
+				if err := ent.get(c); err != nil {
+					t.Fatalf("GET by %s (%s): %v", form.kind, form.param, err)
+				}
+				var got struct {
+					ID int64 `json:"id"`
+				}
+				if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+					t.Fatalf("decoding GET by %s: %v", form.kind, err)
+				}
+				if got.ID != ent.id {
+					t.Errorf("GET by %s returned id %d, want %d", form.kind, got.ID, ent.id)
+				}
+
+				want := fmt.Sprintf("written by %s form", form.kind)
+				c, rec = ctxFor(orgID, http.MethodPut, form.param, fmt.Sprintf(ent.updBody, want))
+				if err := ent.update(c); err != nil {
+					t.Fatalf("PUT by %s (%s): %v", form.kind, form.param, err)
+				}
+				if rec.Code != http.StatusOK {
+					t.Fatalf("PUT by %s: status %d, body %s", form.kind, rec.Code, rec.Body.String())
+				}
+				after, err := ent.reread(ent.id)
+				if err != nil {
+					t.Fatalf("re-reading %s %d: %v", ent.name, ent.id, err)
+				}
+				if after != want {
+					t.Errorf("PUT by %s did not reach %s %d (%s): field = %q, want %q",
+						form.kind, ent.name, ent.id, ent.ident, after, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/isms/api/id_resolution_test.go
+++ b/internal/isms/api/id_resolution_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"go/ast"
 	"go/parser"
@@ -135,6 +136,40 @@ func TestEntityIDResolverKeysAreNameable(t *testing.T) {
 		if _, ok := common.EntityInline[entityType]; !ok {
 			t.Errorf("entityIDResolvers has %q but common.entity_inline has no key for it — "+
 				"the error message would render with a missing translation", entityType)
+		}
+	}
+}
+
+// TestEntityIDResolverHandlesAuditDisplayIDs: the MCP server passes display
+// identifiers to /changelog/:type/:id untouched (#201), so a type missing from
+// entityIDResolvers falls through to the numeric-only path and 400s on its own
+// display form. "audit" was absent, which broke get_entity_history("audit",
+// "AUDIT-3") — a call that worked before, when MCP stripped the prefix itself.
+// Neither audit resolver touches the Server or the database, so a nil receiver
+// is enough to drive them.
+func TestEntityIDResolverHandlesAuditDisplayIDs(t *testing.T) {
+	var s *Server
+	for _, tc := range []struct {
+		entityType, param string
+		want              int64
+		wantOK            bool
+	}{
+		{"audit", "AUDIT-3", 3, true},
+		{"audit", "3", 3, true},
+		{"audit_finding", "FIND-7", 7, true},
+		{"audit_finding", "7", 7, true},
+	} {
+		got, hasIdentifier, err := s.resolveEntityID(context.Background(), 1, tc.entityType, tc.param)
+		if err != nil {
+			t.Errorf("resolveEntityID(%q, %q): %v", tc.entityType, tc.param, err)
+			continue
+		}
+		if !hasIdentifier {
+			t.Errorf("resolveEntityID(%q, %q): hasIdentifier = false; the type must be in entityIDResolvers",
+				tc.entityType, tc.param)
+		}
+		if got != tc.want {
+			t.Errorf("resolveEntityID(%q, %q) = %d, want %d", tc.entityType, tc.param, got, tc.want)
 		}
 	}
 }

--- a/internal/isms/api/id_resolution_test.go
+++ b/internal/isms/api/id_resolution_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #201: one :id param used to have three resolution strategies. The arithmetic
+// strip (parseID) was the dangerous one — it turned "ASSET-3" into primary key 3
+// without checking that the identifier belonged to an asset, or to anything, so
+// a write could land on an unrelated row with a 200 and a changelog entry. These
+// tests guard the two halves of the fix that need no database: the shape check
+// that decides 400-vs-404, and the absence of any surviving strip.
+
+func TestHasIdentifierShape(t *testing.T) {
+	for _, tc := range []struct {
+		param string
+		want  bool
+		why   string
+	}{
+		{"ASSET-3", true, "the ordinary register identifier"},
+		{"LEGAL-1", true, "a prefix parseID never carried — used to 400"},
+		{"ISMS2026-3", true, "objective display ID: program key with digits"},
+		{"2026-3", true, "a program key may be all digits — only uppercased on create"},
+		{"A-1", true, "shortest real shape"},
+		{"ASSET-3-extra", true, "trailing segments are the lookup's problem, not the shape's"},
+		{"garbage", false, "no dash at all"},
+		{"", false, "empty param"},
+		{"-3", false, "empty prefix"},
+		{"ASSET-", false, "empty remainder"},
+	} {
+		if got := hasIdentifierShape(tc.param); got != tc.want {
+			t.Errorf("hasIdentifierShape(%q) = %v, want %v (%s)", tc.param, got, tc.want, tc.why)
+		}
+	}
+}
+
+// TestNoArithmeticIDStripSurvives is the drift guard. parseID was deleted, but
+// the failure mode is someone reintroducing the same shortcut under a new name:
+// strip an identifier prefix, treat the remainder as a primary key. It matches
+// both spellings that can do that here — strings.TrimPrefix and the package's own
+// stripPrefix, which this change made the sanctioned idiom at three sites.
+//
+// "FIND-" and "AUDIT-" are the only allowed literals: those display ids ARE the
+// primary key (db.SoftDeleteAuditFinding mints "FIND-<id>" from the row id) and
+// neither table has an identifier column, so there is nothing to look up.
+// Allow-listing the literals rather than the files means a new arithmetic strip
+// in api_audit.go or api_references.go is still caught — which is how the CR-
+// and TASK- strips in resolveEntityTitle were found.
+func TestNoArithmeticIDStripSurvives(t *testing.T) {
+	// The audit module is the exception: AUDIT- and FIND- are built from the row
+	// id, so there is no identifier column to look up.
+	auditPrefixes := map[string]bool{"FIND-": true, "AUDIT-": true}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			var name string
+			switch fn := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				if pkg, ok := fn.X.(*ast.Ident); ok && pkg.Name == "strings" {
+					name = "strings." + fn.Sel.Name
+				}
+			case *ast.Ident:
+				name = fn.Name
+			}
+			if name != "strings.TrimPrefix" && name != "stripPrefix" {
+				return true
+			}
+			for _, arg := range call.Args {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				v := strings.Trim(lit.Value, `"`)
+				if auditPrefixes[v] {
+					continue
+				}
+				// An identifier prefix is uppercase and ends in a dash.
+				if len(v) > 1 && strings.HasSuffix(v, "-") && v == strings.ToUpper(v) {
+					t.Errorf("%s: %s(..., %q) — identifier prefixes must be resolved by "+
+						"lookup (resolve*ID), not stripped to a primary key (#201)",
+						fset.Position(lit.Pos()), name, v)
+				}
+			}
+			return true
+		})
+	}
+}
+
+// TestEntityIDResolverKeysAreNameable: every type in entityIDResolvers is passed
+// to Entity() by handleEntityChangelog, and the client renders that by looking
+// it up in common.entity_inline.*. A type with no key there produces a broken
+// error message, which no other test would catch.
+func TestEntityIDResolverKeysAreNameable(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "web", "src", "locales", "en", "common.json"))
+	if err != nil {
+		t.Skipf("locale file unavailable: %v", err)
+	}
+	var common struct {
+		EntityInline map[string]string `json:"entity_inline"`
+	}
+	if err := json.Unmarshal(raw, &common); err != nil {
+		t.Fatalf("parsing common.json: %v", err)
+	}
+	for entityType := range entityIDResolvers {
+		if entityType == "change" {
+			continue // MCP alias for change_request; never rendered
+		}
+		if _, ok := common.EntityInline[entityType]; !ok {
+			t.Errorf("entityIDResolvers has %q but common.entity_inline has no key for it — "+
+				"the error message would render with a missing translation", entityType)
+		}
+	}
+}

--- a/internal/isms/api/openapi.yaml
+++ b/internal/isms/api/openapi.yaml
@@ -3197,7 +3197,16 @@ components:
       name: id
       in: path
       required: true
-      schema: { type: integer }
+      description: >-
+        The entity's numeric id, or its display identifier (ASSET-3, CR-1,
+        LEGAL-2, or an objective's program-scoped ISMS2026-3). The identifier is
+        resolved by lookup within the caller's organization, so it always names
+        the same row the UI shows; an identifier that does not exist returns 404,
+        and a value that is neither form returns 400.
+      schema:
+        oneOf:
+          - type: integer
+          - type: string
     docId:
       name: docId
       in: path
@@ -3353,7 +3362,7 @@ components:
       type: object
       properties:
         id: { type: integer }
-        identifier: { type: string, example: "AST-001" }
+        identifier: { type: string, example: "ASSET-1" }
         name: { type: string }
         description: { type: string }
         asset_type: { type: string, enum: [infrastructure, processing_devices, software, financial_info, personal_data, ipr, sales_marketing, processing_facility, products_services, supply_chain, system, network, service, other] }

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -3388,7 +3388,7 @@ func hasIdentifierShape(param string) bool {
 // entityIDResolvers maps the entity_type values written to entity_changelog —
 // which are also what the web UI's HistoryPanel and the MCP server send — to the
 // resolver for that type. Types absent from this map have no display identifier
-// (document carries a string document_id; checkin, access_review, audit and
+// (document carries a string document_id; checkin, access_review and
 // audit_programme are numeric only), so their :id can only be a primary key.
 //
 // Keep the keys in step with common.entity_inline.* in the web locales: the
@@ -3405,9 +3405,17 @@ var entityIDResolvers = map[string]func(*Server, context.Context, int, string) (
 	"change":            (*Server).resolveChangeID,
 	"change_request":    (*Server).resolveChangeID,
 	"objective":         (*Server).resolveObjectiveID,
+	// An audit's and a finding's display ids ARE their primary keys (db/audits.go),
+	// so there is nothing to look up — see the comment in api_audit.go. Both must
+	// still be listed here: the MCP server now passes the display form through
+	// untouched (#201), so an absent key would fall through to the numeric-only
+	// path in resolveEntityID and 400 on "AUDIT-3". The literals are spelled out
+	// at each site rather than hoisted into a helper so that
+	// TestNoArithmeticIDStripSurvives still sees them against its allow-list.
+	"audit": func(_ *Server, _ context.Context, _ int, param string) (int64, error) {
+		return strconv.ParseInt(stripPrefix(param, "AUDIT-"), 10, 64)
+	},
 	"audit_finding": func(_ *Server, _ context.Context, _ int, param string) (int64, error) {
-		// A finding's display id IS its primary key (db/audits.go), so there is
-		// nothing to look up — see the comment in api_audit.go.
 		return strconv.ParseInt(stripPrefix(param, "FIND-"), 10, 64)
 	},
 }

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -3385,6 +3385,47 @@ func hasIdentifierShape(param string) bool {
 // lookup (#177, #201). Numeric → the id; identifier-shaped → look it up, so a
 // per-org seq that differs from the id no longer silently resolves to the wrong
 // row; anything else → errInvalidID, which callers map to 400.
+// entityIDResolvers maps the entity_type values written to entity_changelog —
+// which are also what the web UI's HistoryPanel and the MCP server send — to the
+// resolver for that type. Types absent from this map have no display identifier
+// (document carries a string document_id; checkin, access_review, audit and
+// audit_programme are numeric only), so their :id can only be a primary key.
+//
+// Keep the keys in step with common.entity_inline.* in the web locales: the
+// handlers below pass the type to Entity(), which the client looks up there.
+var entityIDResolvers = map[string]func(*Server, context.Context, int, string) (int64, error){
+	"asset":             (*Server).resolveAssetID,
+	"risk":              (*Server).resolveRiskID,
+	"system":            (*Server).resolveSystemID,
+	"supplier":          (*Server).resolveSupplierID,
+	"task":              (*Server).resolveTaskID,
+	"incident":          (*Server).resolveIncidentID,
+	"corrective_action": (*Server).resolveCorrectiveActionID,
+	"legal_requirement": (*Server).resolveLegalID,
+	"change":            (*Server).resolveChangeID,
+	"change_request":    (*Server).resolveChangeID,
+	"objective":         (*Server).resolveObjectiveID,
+	"audit_finding": func(_ *Server, _ context.Context, _ int, param string) (int64, error) {
+		// A finding's display id IS its primary key (db/audits.go), so there is
+		// nothing to look up — see the comment in api_audit.go.
+		return strconv.ParseInt(stripPrefix(param, "FIND-"), 10, 64)
+	},
+}
+
+// resolveEntityID resolves a :id param for a route whose entity type is itself a
+// param (GET /changelog/:type/:id). The bool reports whether the type has a
+// display identifier at all; when false the param was parsed as a bare numeric
+// id, which is what every type did before #201.
+func (s *Server) resolveEntityID(ctx context.Context, orgID int, entityType, param string) (int64, bool, error) {
+	resolve, ok := entityIDResolvers[entityType]
+	if !ok {
+		n, err := strconv.ParseInt(param, 10, 64)
+		return n, false, err
+	}
+	n, err := resolve(s, ctx, orgID, param)
+	return n, true, err
+}
+
 func (s *Server) resolveChangeID(ctx context.Context, orgID int, param string) (int64, error) {
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil

--- a/internal/isms/api/server.go
+++ b/internal/isms/api/server.go
@@ -1970,9 +1970,11 @@ func (s *Server) handleDeleteAsset(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveAssetID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("asset")
+	} else if err != nil {
+		return errNotFound("asset")
 	}
 	old, _ := s.db.GetAsset(ctx, orgID, id)
 	if err := s.db.DeleteAsset(ctx, orgID, id); err != nil {
@@ -2314,9 +2316,11 @@ func (s *Server) handleRiskAdvisories(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
 
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveRiskID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("risk")
+	} else if err != nil {
+		return errNotFound("risk")
 	}
 
 	risk, err := s.db.GetRisk(ctx, orgID, id)
@@ -2413,9 +2417,11 @@ func (s *Server) handleDeleteRisk(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveRiskID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("risk")
+	} else if err != nil {
+		return errNotFound("risk")
 	}
 	old, _ := s.db.GetRisk(ctx, orgID, id)
 	if err := s.db.DeleteRisk(ctx, orgID, id); err != nil {
@@ -2545,9 +2551,11 @@ func (s *Server) handleUpdateAsset(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveAssetID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("asset")
+	} else if err != nil {
+		return errNotFound("asset")
 	}
 	old, err := s.db.GetAsset(ctx, orgID, id)
 	if err != nil {
@@ -2638,9 +2646,11 @@ func (s *Server) handleUpdateRisk(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveRiskID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("risk")
+	} else if err != nil {
+		return errNotFound("risk")
 	}
 	old, err := s.db.GetRisk(ctx, orgID, id)
 	if err != nil {
@@ -2805,9 +2815,11 @@ func (s *Server) handleUpdateSystem(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveSystemID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("system")
+	} else if err != nil {
+		return errNotFound("system")
 	}
 	old, err := s.db.GetSystem(ctx, orgID, id)
 	if err != nil {
@@ -2920,9 +2932,11 @@ func (s *Server) handleDeleteSystem(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveSystemID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("system")
+	} else if err != nil {
+		return errNotFound("system")
 	}
 	old, _ := s.db.GetSystem(ctx, orgID, id)
 	if err := s.db.DeleteSystem(ctx, orgID, id); err != nil {
@@ -2943,9 +2957,11 @@ func (s *Server) handleDeleteSystem(c echo.Context) error {
 func (s *Server) handleListAccessReviews(c echo.Context) error {
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	systemID, err := parseID(c.Param("id"))
-	if err != nil {
+	systemID, err := s.resolveSystemID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("system")
+	} else if err != nil {
+		return errNotFound("system")
 	}
 	reviews, err := s.db.ListAccessReviews(ctx, orgID, systemID)
 	if err != nil {
@@ -2963,9 +2979,11 @@ func (s *Server) handleCreateAccessReview(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	systemID, err := parseID(c.Param("id"))
-	if err != nil {
+	systemID, err := s.resolveSystemID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("system")
+	} else if err != nil {
+		return errNotFound("system")
 	}
 	var ar db.AccessReview
 	if err := c.Bind(&ar); err != nil {
@@ -3000,7 +3018,10 @@ func (s *Server) handleDeleteAccessReview(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
+	// The param here is the access review's own primary key (DELETE
+	// /access-reviews/:id), not a system reference — access reviews have no
+	// display identifier, so there is nothing to resolve.
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
 		return errInvalidEntityID("access_review")
 	}
@@ -3016,9 +3037,11 @@ func (s *Server) handleUpdateSupplier(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveSupplierID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("supplier")
+	} else if err != nil {
+		return errNotFound("supplier")
 	}
 	old, err := s.db.GetSupplier(ctx, orgID, id)
 	if err != nil {
@@ -3123,9 +3146,11 @@ func (s *Server) handleDeleteSupplier(c echo.Context) error {
 	}
 	orgID := getOrgID(c)
 	ctx := c.Request().Context()
-	id, err := parseID(c.Param("id"))
-	if err != nil {
+	id, err := s.resolveSupplierID(ctx, orgID, c.Param("id"))
+	if errors.Is(err, errInvalidID) {
 		return errInvalidEntityID("supplier")
+	} else if err != nil {
+		return errNotFound("supplier")
 	}
 	old, _ := s.db.GetSupplier(ctx, orgID, id)
 	if err := s.db.DeleteSupplier(ctx, orgID, id); err != nil {
@@ -3271,20 +3296,6 @@ func stripFrontmatter(s string) string {
 	return strings.TrimLeft(rest[idx+4:], "\n")
 }
 
-// parseID accepts a bare numeric id, or an identifier whose numeric SUFFIX is used
-// directly as the primary key: findings (FIND-<id>, built from the row id itself —
-// see SoftDeleteAuditFinding) and, so far incidentally rather than by design, the
-// pre-existing SUPPLIER-/ASSET-/RISK-/SYSTEM- handlers (same identifier_sequences
-// mechanism as TASK-/INC-/CA-/LEGAL-, just not yet observed to diverge). It does
-// NOT work for seq-based identifiers known to diverge from the id (TASK-/INC-/CA-/
-// LEGAL-) — those resolve via the resolve*ID lookups below (#174).
-func parseID(s string) (int64, error) {
-	for _, prefix := range []string{"RISK-", "ASSET-", "AST-", "SUPPLIER-", "SYSTEM-", "FIND-"} {
-		s = strings.TrimPrefix(s, prefix)
-	}
-	return strconv.ParseInt(s, 10, 64)
-}
-
 // errInvalidID marks a param that is neither numeric nor a well-formed identifier
 // for the entity. Callers map it to 400; a well-formed-but-missing identifier (a
 // real lookup miss) returns the lookup error instead, which callers map to 404 —
@@ -3351,17 +3362,35 @@ func (s *Server) resolveLegalID(ctx context.Context, orgID int, param string) (i
 	return lr.ID, nil
 }
 
-// resolveChangeID / resolveObjectiveID / resolveSystemID / resolveAssetID map a
-// suggestion's EntityID (numeric primary key OR the per-org identifier form) to
-// the numeric id via lookup (#177). Unlike resolveTaskID et al. these skip a
-// fixed-prefix check on purpose: asset identifiers exist as both ASSET- and AST-,
-// systems as SYSTEM-, and objective "identifiers" are program-key-scoped display
-// IDs (e.g. ISMS-1), so a hardcoded prefix would be wrong. Numeric → the id;
-// otherwise look it up — a per-org seq that differs from the id no longer silently
-// resolves to the wrong row.
+// hasIdentifierShape reports whether param could be a display identifier at all:
+// a non-empty prefix, a dash, and a non-empty remainder. It is deliberately
+// looser than the fixed-prefix checks in resolveTaskID et al. — asset
+// identifiers exist as both ASSET- and AST-, and objective display IDs are
+// program-key-scoped, so a hardcoded prefix would be wrong. It does not reject a
+// numeric prefix either: a program key is only uppercased on create
+// (api_objectives.go), never checked for digits, so "2026-3" is a legitimate
+// objective display ID.
+//
+// Its only job is to separate "malformed param" (400) from "well-formed
+// identifier that does not exist" (404). Deciding whether the identifier belongs
+// to THIS entity is the lookup's job, not this function's.
+func hasIdentifierShape(param string) bool {
+	prefix, rest, ok := strings.Cut(param, "-")
+	return ok && prefix != "" && rest != ""
+}
+
+// resolveChangeID / resolveObjectiveID / resolveSystemID / resolveAssetID / and
+// the risk and supplier variants map a URL param or a suggestion's EntityID
+// (numeric primary key OR the per-org identifier form) to the numeric id via
+// lookup (#177, #201). Numeric → the id; identifier-shaped → look it up, so a
+// per-org seq that differs from the id no longer silently resolves to the wrong
+// row; anything else → errInvalidID, which callers map to 400.
 func (s *Server) resolveChangeID(ctx context.Context, orgID int, param string) (int64, error) {
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
+	}
+	if !hasIdentifierShape(param) {
+		return 0, errInvalidID
 	}
 	cr, err := s.db.GetChangeRequestByIdentifier(ctx, orgID, param)
 	if err != nil {
@@ -3374,6 +3403,9 @@ func (s *Server) resolveObjectiveID(ctx context.Context, orgID int, param string
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
 	}
+	if !hasIdentifierShape(param) {
+		return 0, errInvalidID
+	}
 	o, err := s.db.GetObjectiveByDisplayID(ctx, orgID, param)
 	if err != nil {
 		return 0, err
@@ -3384,6 +3416,9 @@ func (s *Server) resolveObjectiveID(ctx context.Context, orgID int, param string
 func (s *Server) resolveSystemID(ctx context.Context, orgID int, param string) (int64, error) {
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
+	}
+	if !hasIdentifierShape(param) {
+		return 0, errInvalidID
 	}
 	sys, err := s.db.GetSystemByIdentifier(ctx, orgID, param)
 	if err != nil {
@@ -3396,6 +3431,9 @@ func (s *Server) resolveAssetID(ctx context.Context, orgID int, param string) (i
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
 	}
+	if !hasIdentifierShape(param) {
+		return 0, errInvalidID
+	}
 	a, err := s.db.GetAssetByIdentifier(ctx, orgID, param)
 	if err != nil {
 		return 0, err
@@ -3407,6 +3445,9 @@ func (s *Server) resolveRiskID(ctx context.Context, orgID int, param string) (in
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
 	}
+	if !hasIdentifierShape(param) {
+		return 0, errInvalidID
+	}
 	r, err := s.db.GetRiskByIdentifier(ctx, orgID, param)
 	if err != nil {
 		return 0, err
@@ -3417,6 +3458,9 @@ func (s *Server) resolveRiskID(ctx context.Context, orgID int, param string) (in
 func (s *Server) resolveSupplierID(ctx context.Context, orgID int, param string) (int64, error) {
 	if n, err := strconv.ParseInt(param, 10, 64); err == nil {
 		return n, nil
+	}
+	if !hasIdentifierShape(param) {
+		return 0, errInvalidID
 	}
 	sup, err := s.db.GetSupplierByIdentifier(ctx, orgID, param)
 	if err != nil {

--- a/internal/isms/mcp/server.go
+++ b/internal/isms/mcp/server.go
@@ -378,8 +378,10 @@ func (c *apiClient) toolGetEntity(args map[string]interface{}) (*mcpToolResult, 
 	if path == "" {
 		return errResult("unknown entity_type: " + entityType), nil
 	}
-	numID := stripPrefix(entityID)
-	data, err := c.get(path + "/" + url.PathEscape(numID))
+	// Pass the identifier through: every entity route resolves the display form
+	// by lookup (#201). Stripping the prefix here used to convert a correct
+	// identifier lookup into a primary-key hit on a possibly unrelated row.
+	data, err := c.get(path + "/" + url.PathEscape(entityID))
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -389,8 +391,8 @@ func (c *apiClient) toolGetEntity(args map[string]interface{}) (*mcpToolResult, 
 func (c *apiClient) toolGetEntityHistory(args map[string]interface{}) (*mcpToolResult, error) {
 	entityType := str(args, "entity_type")
 	entityID := str(args, "entity_id")
-	numID := stripPrefix(entityID)
-	data, err := c.get("/changelog/" + url.PathEscape(entityType) + "/" + url.PathEscape(numID))
+	// /changelog/:type/:id resolves the display form per entity type (#201).
+	data, err := c.get("/changelog/" + url.PathEscape(entityType) + "/" + url.PathEscape(entityID))
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -714,23 +716,6 @@ func entityTypeToAPIPath(t string) string {
 	default:
 		return ""
 	}
-}
-
-func stripPrefix(id string) string {
-	parts := strings.SplitN(id, "-", 2)
-	if len(parts) == 2 {
-		allLetters := true
-		for _, c := range parts[0] {
-			if c < 'A' || c > 'Z' {
-				allLetters = false
-				break
-			}
-		}
-		if allLetters {
-			return parts[1]
-		}
-	}
-	return id
 }
 
 func str(m map[string]interface{}, key string) string {


### PR DESCRIPTION
Closes #201.

## What was wrong

Every record in the registers has a short reference people actually use — `ASSET-3`, `CR-1`, `LEGAL-2`. Those references are how colleagues point each other at things in comments, in chat, and through the Copy link button.

The API had three different ways of turning one of those references into the right record, and which one a given operation used had nothing to do with which module it belonged to. Looking a record up usually worked. Changing or deleting one often did not, and some operations refused the reference outright.

The dangerous case was silent. For most editing operations the server took `ASSET-3`, threw away the `ASSET-` part, and used the leftover `3` as an internal row number. Those two numbers are not the same thing. Each organization counts its own records from 1, while the internal numbering runs across the whole install — so `ASSET-3` in your organization is almost never internal row 3. They line up only in the very first organization on a fresh install, which is exactly why this was never noticed in testing.

When they don't line up, one of two things happened:

- **"Not found" for a record that's on screen.** The leftover number belonged to another organization's record, which you can't see, so the edit failed with a confusing error.
- **The edit landed on the wrong record.** If that number happened to be a different record of your own organization, the change, deletion, or reading was applied to *that* one instead — and it succeeded, with a history entry recording you as the author.

The server also never checked that the reference matched the kind of record being changed. Editing an asset while quoting a *risk* reference edited the asset anyway.

## Are customers affected?

**Yes, but narrowly, and not through the web app.** The web interface happens to sidestep all of this: it looks a record up by its reference and then edits it by internal number, so it was never exposed. Anyone using the command-line tool or an AI agent could hit it, and the AI agent surface was the most exposed of all — it stripped references even more aggressively than the API did, converting the one operation that worked correctly into one that didn't.

One thing **is** visible in the web app, and it's worth naming because it looks like a design choice rather than a bug. Where a record links to a change request or a task, the link chip shows the linked item's title. Under the old code it could show the bare reference — `CR-1` — instead of the title, because the label lookup used the same faulty arithmetic. Checked in a browser before and after: the chip now reads the change request's actual title.

No data needs repair. Nothing about how references are stored or displayed has changed — only which record the server resolves them to.

## What this changes

References are now resolved by looking them up, everywhere, which is what a handful of operations were already doing correctly. Concretely:

- Editing, deleting and recording readings against assets, risks, systems, suppliers and legal requirements now reliably affect the record you named.
- Operations that used to reject a reference with a bare "invalid id" now accept it: all change-request edits, six objective operations, supplier and asset review entries, and legal-requirement readings, which had never worked by reference at all.
- Quoting the wrong kind of reference is now a clean "not found" rather than a successful edit of something else.
- The AI agent surface passes references through untouched instead of mangling them first.
- The command-line tool no longer needs the workarounds it carried for this — it used to download the entire list of objectives and search it locally just to translate a reference the server should have understood. Those workarounds are now redundant; removing them is separate work.

Audit findings are the one deliberate exception. Their reference genuinely *is* their internal number, so the old arithmetic is correct there and was left alone.

## Verification

Full test suite passes. The project's integration suite was run against a live server: 704 passed, 1 unrelated failure caused by a rate-limit setting in the local run, confirmed by re-running with that setting restored.

The two new database-backed tests were checked against the *old* code as well as the new, because a test that passes either way proves nothing here. Against the old code they fail exactly as reported in #201 — an edit by reference returning "not found" across organizations, and four mismatched-reference edits returning success and writing to the wrong record. A first draft of one test passed against the old code by luck and was rewritten until it didn't.

Also exercised by hand against a live server, in an organization where the numbering had genuinely drifted (`ASSET-1` was internal row 8, `LEGAL-1` was row 12, `CR-1` was row 22): the command-line tool editing by reference, every previously-rejected operation, and the link chip in a browser before and after.

A guard test now fails the build if this shortcut is reintroduced anywhere. It was checked by deliberately reintroducing it — and it immediately found three more places doing the same thing that the original report had not covered, which are fixed here too.

## Risk

Low. The numeric form still short-circuits before any lookup, so the web app's behaviour is unchanged and no extra database work is done on its path.

Two things a reviewer should weigh. Some operations that previously returned "invalid id" now return "not found", so anything branching on that distinction would see a different code — the only callers were the command-line workarounds this makes redundant. And the worst realistic outcome of a mistake here is an edit being refused with "not found" when it should have succeeded — visible and safe — rather than the current behaviour of an edit silently landing on the wrong record.

## What's left

A broader test sweep. The new tests drive read and write operations in both reference and numeric form for four record types; change requests, objectives, readings and deletions are not yet covered. Worth following up, not a blocker — the guard test catches the specific mistake this fixes.
